### PR TITLE
Add Finder Support and Root Importer for PHP-CS-Fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2025 Konstantinas Mesnikas
+ * SPDX-License-Identifier: MIT
+ *
+ * Local test config that imports the Piqule rules
+ */
+
+$rules = require __DIR__ . '/php-cs-fixer/rules.php';
+$rules->setFinder(
+    PhpCsFixer\Finder::create()
+        ->in(__DIR__)
+        ->exclude('vendor')
+);
+
+return $rules;

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * Local test config that imports the Piqule rules
  */
 
+/** @var PhpCsFixer\Config $rules */
 $rules = require __DIR__ . '/php-cs-fixer/rules.php';
 $rules->setFinder(
     PhpCsFixer\Finder::create()

--- a/php-cs-fixer/rules.php
+++ b/php-cs-fixer/rules.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*
@@ -101,4 +102,8 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'ternary_operator_spaces' => true,
     ])
-    ->setUnsupportedPhpVersionAllowed(true);
+    ->setUnsupportedPhpVersionAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__ . '/..'),
+    );

--- a/php-cs-fixer/rules.php
+++ b/php-cs-fixer/rules.php
@@ -7,7 +7,19 @@ declare(strict_types=1);
  * SPDX-License-Identifier: MIT
  */
 
-$currentYear = (int) \date('Y');
+/**
+ * This ruleset is meant to be used in two ways:
+ * 1) Directly, via `php-cs-fixer fix --config=php-cs-fixer/rules.php`
+ *    In this mode a local Finder is required.
+ *
+ * 2) Imported from a project's root `.php-cs-fixer.php`
+ *    In that mode consumers are expected to override Finder themselves.
+ *
+ * Only the rule definitions here are shared across projects.
+ * Path configuration belongs to the consuming project.
+ */
+
+$currentYear = (int)\date('Y');
 $startYear = 2025;
 
 $header = $currentYear === $startYear


### PR DESCRIPTION
- Added Finder definition to rules.php for direct --config execution
- Added root .php-cs-fixer.php importing Piqule rules
- Updated root config to override Finder settings
- Validated both direct and importer execution modes
- 

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added and expanded PHP code-formatting and quality configuration to enforce consistent coding standards and automated fixes across the project, including rules and scanning setup to ignore vendor files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->