### PR TITLE
Add Reusable Workflow for PHP-CS-Fixer

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Use php-matrix (JSON array) if provided, otherwise wrap php-version in array
         php-version: ${{ fromJson(inputs.php-matrix != '' && inputs.php-matrix || format('["{0}"]', inputs.php-version)) }}
 
     steps:

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 Konstantinas Mesnikas
+# SPDX-License-Identifier: MIT
+
+name: PHP-CS-Fixer
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        type: string
+        required: false
+        default: '8.5'
+
+      php-matrix:
+        type: string
+        required: false
+        default: '' # JSON: ["8.2","8.3","8.4","8.5"]
+
+jobs:
+  cs:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ${{ fromJson(inputs.php-matrix != '' && inputs.php-matrix || format('["{0}"]', inputs.php-version)) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run PHP-CS-Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,13 @@
+name: PHP Quality
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  cs:
+    uses: haspadar/piqule/.github/workflows/php-cs-fixer.yml@main
+    with:
+      php-matrix: '["8.2","8.3","8.4","8.5"]'


### PR DESCRIPTION
- Added reusable php-cs-fixer workflow for external repositories
- Added local php.yml to execute the workflow with a PHP version matrix
- Validated dry-run execution of PHP-CS-Fixer
- Ensured support for php-version and php-matrix inputs

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated PHP code style validation workflow using PHP-CS-Fixer to surface formatting issues.
  * Configured PHP quality checks to run across multiple PHP versions (8.2, 8.3, 8.4, 8.5) to ensure consistent behavior and style across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->