### PR TITLE
Add Shared Markdownlint Configuration And Update Documentation

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,37 @@
+name: Markdownlint
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        type: string
+        default: '20'
+
+jobs:
+  markdownlint:
+    name: Markdownlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+
+      - name: Run markdownlint-cli2 using shared config
+        run: |
+          if [ -f "./vendor/haspadar/piqule/markdownlint/markdownlint-cli2.jsonc" ]; then
+            CONFIG_PATH="./vendor/haspadar/piqule/markdownlint/markdownlint-cli2.jsonc"
+          else
+            CONFIG_PATH="./markdownlint/markdownlint-cli2.jsonc"
+          fi
+
+          echo "Using config: $CONFIG_PATH"
+          markdownlint-cli2 --config "$CONFIG_PATH"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # Piqule
 
 Static analysis and linters for PHP projects.  
-It bundles PHPStan, Psalm, PHP-CS-Fixer, PhpMetrics, Markdownlint, Hadolint, Actionlint, and REUSE checks.  
-You don’t need to configure them individually anymore.
+Piqule bundles and standardizes configurations for:
+
+- PHPStan  
+- Psalm  
+- PHP-CS-Fixer  
+- PhpMetrics  
+- Markdownlint  
+- Hadolint  
+- Actionlint  
+
+You don’t need to configure these tools manually in every project — Piqule provides shared configs and reusable GitHub workflows.
 
 ## Usage
 
@@ -12,20 +21,23 @@ Add Piqule to your project:
 composer require --dev haspadar/piqule
 ```
 
-Include shared configs:
+### PHPStan
 
-**phpstan.neon**
+Create your `phpstan.neon`:
 
 ```
 includes:
-- vendor/piqule/piqule/config/phpstan.neon
-  ```
+  - vendor/haspadar/piqule/config/phpstan.neon
+```
 
-**php-cs-fixer.php**
+### PHP-CS-Fixer
+
+Create your `.php-cs-fixer.php`:
 
 ```
 /** @var PhpCsFixer\Config $rules */
 $rules = require __DIR__ . '/vendor/haspadar/piqule/php-cs-fixer/rules.php';
+
 $rules->setFinder(
     PhpCsFixer\Finder::create()
         ->in(__DIR__)
@@ -36,23 +48,40 @@ $rules->setFinder(
 return $rules;
 ```
 
-**psalm.xml**
+### Psalm
+
+Create or extend `psalm.xml`:
 
 ```
 <psalm>
-  <import name="vendor/piqule/piqule/config/psalm.xml" />
+  <import name="vendor/haspadar/piqule/config/psalm.xml" />
 </psalm>
 ```
 
-Optional helper:
+### Markdownlint
+
+Piqule includes a shared configuration for `markdownlint-cli2` and a reusable workflow that automatically selects the correct config depending on context.
+
+The workflow resolves configuration in this order:
+
+1. `vendor/haspadar/piqule/markdownlint/markdownlint-cli2.jsonc` (when Piqule is installed as a dependency)
+2. `markdownlint/markdownlint-cli2.jsonc` (when running inside the Piqule repository itself)
+
+Projects do not need to maintain their own `.markdownlint-cli2.jsonc` unless they want to override defaults.
+
+## Optional helper
 
 ```
 vendor/bin/piqule init
 ```
 
+This command can generate baseline config files for PHPStan, Psalm, and PHP-CS-Fixer.
+
 ## GitHub Actions
 
-Use preconfigured workflows:
+Piqule provides reusable CI modules.
+
+### PHPStan
 
 ```
 jobs:
@@ -60,16 +89,26 @@ jobs:
     uses: haspadar/piqule/.github/workflows/phpstan.yml@v1
 ```
 
+### Lint suite (CS + Markdownlint + Hadolint + Actionlint)
+
 ```
 jobs:
   lint:
     uses: haspadar/piqule/.github/workflows/lint.yml@v1
 ```
 
+### Markdownlint only
+
+```
+jobs:
+  markdownlint:
+    uses: haspadar/piqule/.github/workflows/markdownlint.yml@v1
+```
+
 ## Contribute
 
-Fork, modify, and submit a pull request.  
-Before sending it, run all Piqule checks locally.
+Fork, modify, and open a pull request.  
+Before submitting a PR, run all Piqule checks locally or via GitHub Actions.
 
 ## License
 

--- a/markdownlint/markdownlint-cli2.jsonc
+++ b/markdownlint/markdownlint-cli2.jsonc
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD033": false
+  },
+  "ignores": [
+    "**/vendor/**",
+    "**/node_modules/**",
+    "**/coverage/**",
+    "**/.git/**"
+  ]
+}


### PR DESCRIPTION
- Added shared markdownlint-cli2.jsonc configuration under markdownlint/
- Added README.md for markdownlint usage
- Updated root README.md to document Markdownlint integration and workflow usage

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdownlint to GitHub Actions CI workflow for automated markdown linting.

* **Documentation**
  * Restructured README with expanded per-tool setup guidance for PHPStan, PHP-CS-Fixer, Psalm, and Markdownlint.
  * Updated configuration paths and vendor namespace references.
  * Added dedicated CI workflow sections and configuration resolution guidance.

* **Chores**
  * Added Markdownlint shared configuration file with customized linting rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->