### PR TITLE
ci(actionlint): add reusable workflow and update README with usage ex…

### DIFF
--- a/.github/workflows/reusable/actionlint.yml
+++ b/.github/workflows/reusable/actionlint.yml
@@ -1,0 +1,35 @@
+name: Actionlint
+
+on:
+  workflow_call:
+    inputs:
+      fail_level:
+        type: string
+        required: false
+        default: error
+      reporter:
+        type: string
+        required: false
+        default: github-check
+      actionlint_version:
+        type: string
+        required: false
+        default: latest
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: ${{ inputs.fail_level }}
+          reporter: ${{ inputs.reporter }}
+          level: error
+          actionlint_version: ${{ inputs.actionlint_version }}

--- a/.github/workflows/reusable/actionlint.yml
+++ b/.github/workflows/reusable/actionlint.yml
@@ -11,10 +11,6 @@ on:
         type: string
         required: false
         default: github-check
-      actionlint_version:
-        type: string
-        required: false
-        default: latest
 
 jobs:
   actionlint:
@@ -23,8 +19,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
@@ -32,4 +26,3 @@ jobs:
           fail_level: ${{ inputs.fail_level }}
           reporter: ${{ inputs.reporter }}
           level: error
-          actionlint_version: ${{ inputs.actionlint_version }}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ jobs:
     uses: haspadar/piqule/.github/workflows/markdownlint.yml@v1
 ```
 
+### Actionlint only
+
+```
+jobs:
+  actionlint:
+    uses: haspadar/piqule/.github/workflows/reusable/actionlint.yml@v1
+```
+
 ## Contribute
 
 Fork, modify, and open a pull request.  


### PR DESCRIPTION
- Added reusable workflow `.github/workflows/reusable/actionlint.yml`
- Updated README with usage example for the reusable Actionlint workflow

Closes #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable CI workflow to run Actionlint checks with configurable fail level and reporter settings; can be invoked by other workflows.

* **Documentation**
  * Updated README with usage examples showing how to integrate and call the new Actionlint workflow from other CI workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->