### PR TITLE
Extend Renovate Support For Docker And Node Upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,39 +4,35 @@
 FROM php:8.4-cli
 
 # ----------------------------------------
-# OCI labels (unchanged)
+# OCI labels
 # ----------------------------------------
 LABEL org.opencontainers.image.title="Piqule"
 LABEL org.opencontainers.image.description="Quality control for PHP projects"
 LABEL org.opencontainers.image.source="https://github.com/haspadar/piqule"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Ensure pipefail for all RUN commands (fixes DL4006)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # ----------------------------------------
-# System dependencies
+# Version arguments (updated by Renovate)
 # ----------------------------------------
-ARG NODE_MAJOR=20
+ARG NODE_MAJOR=24
 ARG ACTIONLINT_VERSION=1.7.9
 ARG MARKDOWNLINT_VERSION=0.19
 ARG PHP_CS_FIXER_VERSION=3.91.1
 ARG TYPOS_VERSION=1.24.6
 ARG HADOLINT_VERSION=2.12.0
 
+ENV RENOVATE_PLATFORM=local
+ENV RENOVATE_TOKEN=local
+
+# ----------------------------------------
+# System dependencies
+# ----------------------------------------
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        git \
-        unzip \
-        curl \
-        bash \
-        fish \
-        python3 \
-        python3-pip \
-        libicu-dev \
-        libzip-dev \
-        zlib1g-dev \
-        libonig-dev \
+        git unzip curl bash fish python3 python3-pip \
+        libicu-dev libzip-dev zlib1g-dev libonig-dev \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && docker-php-ext-install intl zip mbstring \
@@ -60,7 +56,7 @@ RUN mkdir -p /usr/local/composer \
 ENV PATH="/usr/local/composer/vendor/bin:${PATH}"
 
 # ----------------------------------------
-# PHP-CS-Fixer (only tool from PHP ecosystem)
+# PHP-CS-Fixer
 # ----------------------------------------
 RUN composer global require friendsofphp/php-cs-fixer:${PHP_CS_FIXER_VERSION} \
     && ln -s /usr/local/composer/vendor/bin/php-cs-fixer /usr/local/bin/php-cs-fixer \
@@ -70,42 +66,37 @@ RUN mkdir -p /usr/local/piqule
 COPY php-cs-fixer/rules.php /usr/local/piqule/php-cs-fixer.base.php
 
 # ----------------------------------------
-# actionlint
+# actionlint (x86_64 only)
 # ----------------------------------------
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
-    && curl -sSfL -o actionlint.tar.gz \
-       "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ARCH}.tar.gz" \
+RUN curl -sSfL -o actionlint.tar.gz \
+       "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
     && tar -xzf actionlint.tar.gz \
     && mv actionlint /usr/local/bin/actionlint \
     && chmod +x /usr/local/bin/actionlint \
-    && rm actionlint.tar.gz
+    && rm -f actionlint.tar.gz
 
 # ----------------------------------------
 # markdownlint-cli2 + yamllint
 # ----------------------------------------
-# NOTE: --break-system-packages is intentional:
-# we install CLI tools into the system Python environment inside the CI container
 RUN npm install -g markdownlint-cli2@${MARKDOWNLINT_VERSION} \
-    && pip3 install --no-cache-dir --break-system-packages \
-        yamllint \
-        reuse
+    && pip3 install --no-cache-dir --break-system-packages yamllint
 
 # ----------------------------------------
-# hadolint
+# hadolint (x86_64)
 # ----------------------------------------
 RUN curl -sSfL -o /usr/local/bin/hadolint \
        "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
     && chmod +x /usr/local/bin/hadolint
 
 # ----------------------------------------
-# typos
+# typos (x86_64)
 # ----------------------------------------
 RUN curl -sSfL -o typos.tar.gz \
        "https://github.com/crate-ci/typos/releases/download/v${TYPOS_VERSION}/typos-v${TYPOS_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
     && tar -xzf typos.tar.gz \
     && mv typos /usr/local/bin/typos \
     && chmod +x /usr/local/bin/typos \
-    && rm -rf typos.tar.gz
+    && rm -f typos.tar.gz
 
 # ----------------------------------------
 # Entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,14 @@ LABEL org.opencontainers.image.licenses="MIT"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # ----------------------------------------
-# Version arguments (updated by Renovate)
+# Version arguments
 # ----------------------------------------
-ARG NODE_MAJOR=24
+ARG NODE_VERSION=24.11.1
 ARG ACTIONLINT_VERSION=1.7.9
 ARG MARKDOWNLINT_VERSION=0.19
 ARG PHP_CS_FIXER_VERSION=3.91.1
 ARG TYPOS_VERSION=1.24.6
 ARG HADOLINT_VERSION=2.12.0
-
-ENV RENOVATE_PLATFORM=local
-ENV RENOVATE_TOKEN=local
 
 # ----------------------------------------
 # System dependencies
@@ -33,11 +30,16 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git unzip curl bash fish python3 python3-pip \
         libicu-dev libzip-dev zlib1g-dev libonig-dev \
-    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
     && docker-php-ext-install intl zip mbstring \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# ----------------------------------------
+# Node.js (official tar.xz)
+# ----------------------------------------
+RUN curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o node.tar.xz \
+    && tar -xf node.tar.xz -C /usr/local --strip-components=1 \
+    && rm node.tar.xz
 
 # ----------------------------------------
 # Composer

--- a/renovate/config.json
+++ b/renovate/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
 
-  "schedule": ["before 3am on Monday"],
+  "schedule": ["every hour"],
   "timezone": "UTC",
 
   "labels": ["dependencies"],

--- a/renovate/config.json
+++ b/renovate/config.json
@@ -53,6 +53,15 @@
   "github-actions": { "enabled": true },
   "dockerfile": { "enabled": true },
 
+  "registryAliases": {
+    "NODE_VERSION": "nodejs/node",
+    "ACTIONLINT_VERSION": "rhysd/actionlint",
+    "MARKDOWNLINT_VERSION": "igorshubovych/markdownlint-cli",
+    "PHP_CS_FIXER_VERSION": "FriendsOfPHP/PHP-CS-Fixer",
+    "TYPOS_VERSION": "crate-ci/typos",
+    "HADOLINT_VERSION": "hadolint/hadolint"
+  },
+
   "regexManagers": [
     {
       "description": "Update Dockerfile ARG version variables",

--- a/renovate/config.json
+++ b/renovate/config.json
@@ -1,77 +1,83 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "schedule": [
-    "before 3am on Monday"
-  ],
+  "extends": ["config:recommended"],
+
+  "schedule": ["before 3am on Monday"],
   "timezone": "UTC",
-  "labels": [
-    "dependencies"
-  ],
+
+  "labels": ["dependencies"],
   "assignees": [],
   "reviewers": [],
+
   "prConcurrentLimit": 3,
   "prHourlyLimit": 0,
+
   "packageRules": [
     {
-      "description": "Group all PHPStan packages together",
-      "groupName": "PHPStan packages",
-      "matchPackagePatterns": [
-        "^phpstan/"
-      ]
-    },
-    {
-      "description": "Auto-merge patch and minor updates for dev dependencies",
-      "matchDepTypes": [
-        "require-dev"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
+      "description": "Auto-merge minor and patch dev dependencies",
+      "matchDepTypes": ["require-dev"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
     },
     {
-      "description": "Separate dev dependencies from production",
-      "matchDepTypes": [
-        "require-dev"
-      ],
+      "description": "Group dev dependencies",
+      "matchDepTypes": ["require-dev"],
       "groupName": "dev dependencies"
     },
     {
       "description": "Group production dependencies",
-      "matchDepTypes": [
-        "require"
-      ],
-      "groupName": "production dependencies",
-      "excludePackagePatterns": [
-        "^phpstan/"
-      ]
+      "matchDepTypes": ["require"],
+      "groupName": "production dependencies"
     },
     {
-      "description": "Prioritize all patch updates",
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "enabled": true,
+      "description": "Prioritize patch updates",
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": ["*"],
       "prPriority": 10
+    },
+    {
+      "description": "Group CI toolchain updates",
+      "groupName": "CI toolchain",
+      "matchManagers": ["regex", "dockerfile", "github-actions"]
     }
   ],
+
   "vulnerabilityAlerts": {
-    "labels": [
-      "security"
-    ],
-    "assignees": [],
+    "labels": ["security"],
     "enabled": true
   },
-  "composer": {
-    "enabled": true
-  }
+
+  "composer": { "enabled": true },
+  "github-actions": { "enabled": true },
+  "dockerfile": { "enabled": true },
+
+  "regexManagers": [
+    {
+      "description": "Update Dockerfile ARG version variables",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "ARG (?<depName>[A-Z_]+_VERSION)=(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "description": "Update Docker base image",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "FROM (?<depName>[^:]+):(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Update pinned GitHub Actions versions in workflow files",
+      "fileMatch": [".github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "\\suses: (?<depName>[\\w\\-/]+)@(?<currentValue>v?[0-9][^\\s]*)"
+      ],
+      "datasourceTemplate": "github-tags"
+    }
+  ]
 }

--- a/renovate/config.json
+++ b/renovate/config.json
@@ -56,7 +56,7 @@
   "registryAliases": {
     "NODE_VERSION": "nodejs/node",
     "ACTIONLINT_VERSION": "rhysd/actionlint",
-    "MARKDOWNLINT_VERSION": "igorshubovych/markdownlint-cli",
+    "MARKDOWNLINT_VERSION": "DavidAnson/markdownlint",
     "PHP_CS_FIXER_VERSION": "FriendsOfPHP/PHP-CS-Fixer",
     "TYPOS_VERSION": "crate-ci/typos",
     "HADOLINT_VERSION": "hadolint/hadolint"


### PR DESCRIPTION
- Updated Renovate configuration to include Docker ARG version upgrades
- Updated Node version management in the CI Dockerfile
- Extended regex rules to cover additional CI toolchain components

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to v24 and switched to tarball-based installation; consolidated base image package setup.
  * Simplified container tooling installs, removed dynamic architecture detection (some tools now labeled x86_64).
  * Enhanced dependency automation: hourly schedule, refined grouping and auto-merge rules, CI toolchain group, registry aliases, and regex-driven manager checks.
  * Added public declarations for build-tooling and enabled vulnerability alerting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->