### PR TITLE
Fix Markdownlint Version Handling In Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,7 +56,6 @@
   "registryAliases": {
     "NODE_VERSION": "nodejs/node",
     "ACTIONLINT_VERSION": "rhysd/actionlint",
-    "MARKDOWNLINT_VERSION": "markdownlint-cli2",
     "PHP_CS_FIXER_VERSION": "FriendsOfPHP/PHP-CS-Fixer",
     "TYPOS_VERSION": "crate-ci/typos",
     "HADOLINT_VERSION": "hadolint/hadolint"
@@ -71,6 +70,15 @@
       ],
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "description": "Update markdownlint-cli2 version (npm)",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "ARG MARKDOWNLINT_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "markdownlint-cli2",
+      "datasource": "npm"
     },
     {
       "description": "Update Docker base image",

--- a/renovate.json
+++ b/renovate.json
@@ -63,15 +63,6 @@
 
   "regexManagers": [
     {
-      "description": "Update Dockerfile ARG version variables",
-      "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": [
-        "ARG (?<depName>[A-Z_]+_VERSION)=(?<currentValue>[^\\s]+)"
-      ],
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v?(?<version>.*)$"
-    },
-    {
       "description": "Update markdownlint-cli2 version (npm)",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
@@ -79,6 +70,15 @@
       ],
       "depNameTemplate": "markdownlint-cli2",
       "datasource": "npm"
+    },
+    {
+      "description": "Update Dockerfile ARG version variables",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "ARG (?<depName>(?!MARKDOWNLINT_VERSION)[A-Z_]+_VERSION)=(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     },
     {
       "description": "Update Docker base image",


### PR DESCRIPTION
- Removed incorrect registry alias for MARKDOWNLINT_VERSION
- Added npm-based regex manager for markdownlint-cli2 updates
- Ensured Dockerfile ARG MARKDOWNLINT_VERSION is updated via npm datasource

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored dependency update configuration for markdownlint-cli2, switching from registry alias approach to direct npm registry management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->