### PR TITLE
Clean Up Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
 
-  "schedule": ["* * * * *"],
+  "schedule": ["* 4-21 * * *"],
   "timezone": "UTC",
 
   "labels": ["dependencies"],
@@ -49,14 +49,6 @@
   "composer": { "enabled": true },
   "github-actions": { "enabled": true },
   "dockerfile": { "enabled": false },
-
-  "registryAliases": {
-    "NODE_VERSION": "nodejs/node",
-    "ACTIONLINT_VERSION": "rhysd/actionlint",
-    "PHP_CS_FIXER_VERSION": "FriendsOfPHP/PHP-CS-Fixer",
-    "TYPOS_VERSION": "crate-ci/typos",
-    "HADOLINT_VERSION": "hadolint/hadolint"
-  },
 
   "customManagers": [
     {


### PR DESCRIPTION
- Updated schedule to limit Renovate activity to daytime hours
- Removed unused registry aliases to eliminate package lookup warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update schedule to run during restricted hours (4 PM - 9 PM UTC) instead of continuously.
  * Removed predefined version mapping configuration, streamlining version resolution setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->