### PR TITLE
Disable not_operator_with_successor_space rule

### DIFF
--- a/.piqule/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer.php
@@ -88,7 +88,7 @@ return (new PhpCsFixer\Config())
         'binary_operator_spaces' => ['default' => 'single_space'],
         'concat_space' => ['spacing' => 'one'],
         'unary_operator_spaces' => true,
-        'not_operator_with_successor_space' => true,
+        'not_operator_with_successor_space' => false,
 
         // Misc
         'encoding' => true,


### PR DESCRIPTION
- Updated PHP-CS-Fixer configuration to disable not_operator_with_successor_space

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting standards to refine spacing conventions in the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->