### PR TITLE
Add piqule CLI entrypoint

### DIFF
--- a/bin/piqule.php
+++ b/bin/piqule.php
@@ -12,7 +12,7 @@ use Haspadar\Piqule\Structure\Root;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $output = new Console();
-if (!isset($argv[1])) {
+if (! isset($argv[1])) {
     $output->write(new Error('Usage: piqule <init|update>'));
     exit(1);
 }

--- a/bin/piqule.php
+++ b/bin/piqule.php
@@ -9,7 +9,7 @@ use Haspadar\Piqule\Output\Console;
 use Haspadar\Piqule\Output\Line\Error;
 use Haspadar\Piqule\Structure\Root;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 $output = new Console();
 if (!isset($argv[1])) {

--- a/bin/piqule.php
+++ b/bin/piqule.php
@@ -27,7 +27,7 @@ switch ($argument) {
 
     case 'update':
         (new Update($root, new DiskFileSystem(), new Console()))->run();
-        break;
+        exit(1);
 
     case '':
         (new Console())->write(new Error('Usage: piqule <init|update>'));

--- a/bin/piqule.php
+++ b/bin/piqule.php
@@ -12,7 +12,7 @@ use Haspadar\Piqule\Structure\Root;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $output = new Console();
-if (! isset($argv[1])) {
+if (!isset($argv[1])) {
     $output->write(new Error('Usage: piqule <init|update>'));
     exit(1);
 }

--- a/bin/piqule.php
+++ b/bin/piqule.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Haspadar\Piqule\Command\Init;
+use Haspadar\Piqule\Command\Update;
+use Haspadar\Piqule\FileSystem\DiskFileSystem;
+use Haspadar\Piqule\Output\Console;
+use Haspadar\Piqule\Output\Line\Error;
+use Haspadar\Piqule\Structure\Root;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$output = new Console();
+if (!isset($argv[1])) {
+    $output->write(new Error('Usage: piqule <init|update>'));
+    exit(1);
+}
+
+$argument = $argv[1];
+$root = new Root(getenv('COMPOSER_CWD') ?: getcwd());
+match ($argument) {
+    'init' => (new Init($root, new DiskFileSystem(), $output))->run(),
+    'update' => (new Update($root, new DiskFileSystem(), $output))->run(),
+    default => $output->write(new Error("Unknown command: $argument\n"))
+};

--- a/bin/piqule.php
+++ b/bin/piqule.php
@@ -11,16 +11,29 @@ use Haspadar\Piqule\Structure\Root;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-$output = new Console();
-if (!isset($argv[1])) {
-    $output->write(new Error('Usage: piqule <init|update>'));
+$argument = $argv[1] ?? '';
+$path = getenv('COMPOSER_CWD') ?: getcwd();
+if ($path === false) {
+    (new Console())->write(new Error('Cannot determine working directory'));
     exit(1);
 }
 
-$argument = $argv[1];
-$root = new Root(getenv('COMPOSER_CWD') ?: getcwd());
-match ($argument) {
-    'init' => (new Init($root, new DiskFileSystem(), $output))->run(),
-    'update' => (new Update($root, new DiskFileSystem(), $output))->run(),
-    default => $output->write(new Error("Unknown command: $argument\n"))
-};
+$root = new Root($path);
+
+switch ($argument) {
+    case 'init':
+        (new Init($root, new DiskFileSystem(), new Console()))->run();
+        break;
+
+    case 'update':
+        (new Update($root, new DiskFileSystem(), new Console()))->run();
+        break;
+
+    case '':
+        (new Console())->write(new Error('Usage: piqule <init|update>'));
+        exit(1);
+
+    default:
+        (new Console())->write(new Error("Unknown command: $argument"));
+        exit(1);
+}

--- a/src/Command/Update.php
+++ b/src/Command/Update.php
@@ -6,5 +6,8 @@ namespace Haspadar\Piqule\Command;
 
 final readonly class Update implements Command
 {
-    public function run(): void {}
+    public function run(): void
+    {
+        // TODO: Implement update command logic
+    }
 }

--- a/src/Command/Update.php
+++ b/src/Command/Update.php
@@ -4,10 +4,21 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Command;
 
+use Haspadar\Piqule\FileSystem\FileSystem;
+use Haspadar\Piqule\Output\Line\Error;
+use Haspadar\Piqule\Output\Output;
+use Haspadar\Piqule\Structure\Root;
+
 final readonly class Update implements Command
 {
+    public function __construct(
+        private Root $root,
+        private FileSystem $fileSystem,
+        private Output $output,
+    ) {}
+
     public function run(): void
     {
-        // TODO: Implement update command logic
+        $this->output->write(new Error('Update not implemented yet'));
     }
 }


### PR DESCRIPTION
- Added CLI entrypoint to dispatch init and update commands
- Wired command execution to process arguments

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line interface with `init` and `update` commands to initialize and update configurations.
  * CLI now shows usage and clear error messages for unknown or missing commands.

* **Chores**
  * The `update` command currently reports that update functionality is not yet implemented.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->