### PR TITLE
Introduce RunContext in CLI entrypoint

### DIFF
--- a/src/PiquleException.php
+++ b/src/PiquleException.php
@@ -6,4 +6,7 @@ namespace Haspadar\Piqule;
 
 use RuntimeException;
 
+/**
+ * The only exception type used by Piqule
+ */
 final class PiquleException extends RuntimeException {}

--- a/src/Project.php
+++ b/src/Project.php
@@ -1,9 +1,7 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Haspadar\Piqule;
 
-final readonly class Project
-{
-
-}
+final readonly class Project {}

--- a/src/Project.php
+++ b/src/Project.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Haspadar\Piqule;
+
+final readonly class Project
+{
+
+}

--- a/src/RunContext.php
+++ b/src/RunContext.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule;
+
+/**
+ * Represents the execution context of the Piqule process.
+ */
+final class RunContext
+{
+    /** @var array<int, string> */
+    private readonly array $argv;
+
+    /**
+     * @param array<int, string> $argv
+     */
+    public function __construct(array $argv)
+    {
+        $this->argv = $argv;
+    }
+
+    /**
+     * Returns the working directory of the invocation.
+     *
+     * @throws PiquleException If the working directory cannot be determined
+     */
+    public function root(): string
+    {
+        $root = getenv('COMPOSER_CWD') ?: getcwd();
+
+        if ($root === false) {
+            throw new PiquleException('Cannot determine working directory');
+        }
+
+        return $root;
+    }
+
+    /**
+     * Returns the CLI argument at the given index.
+     *
+     * @throws PiquleException If the argument is missing
+     */
+    public function argument(int $index): string
+    {
+        if (!array_key_exists($index, $this->argv)) {
+            throw new PiquleException(
+                sprintf('Missing argument #%d. Usage: piqule <init|update>', $index),
+            );
+        }
+
+        return $this->argv[$index];
+    }
+}


### PR DESCRIPTION
- Added RunContext to encapsulate CLI invocation concerns
- Added PiquleException as the single fatal error type
- Refactored bin/piqule.php to use centralized argument and root resolution
- Removed inline CLI branching and duplicated exit handling

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced CLI error handling with clearer error messages and improved command validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->