### PR TITLE
Persist Remembered Targets During Init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.idea/
 /*.log
 /.php-cs-fixer.cache
+/.piqule/lock.json

--- a/src/Project/Lock/JsonLock.php
+++ b/src/Project/Lock/JsonLock.php
@@ -84,7 +84,7 @@ final readonly class JsonLock implements Lock
 
         $json = json_encode(
             $this->hashes,
-            JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+            JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES,
         );
 
         if (file_put_contents($this->lockFile, $json) === false) {

--- a/src/Project/UninitializedProject.php
+++ b/src/Project/UninitializedProject.php
@@ -21,7 +21,7 @@ final readonly class UninitializedProject implements Project
     public function init(Materialization $materialization, Lock $lock): void
     {
         foreach ($this->sourceDirectory->files() as $sourceFile) {
-            $materialization->applyTo(
+            $lock = $materialization->applyTo(
                 new DiskTarget($sourceFile, $this->targetDirectory),
                 $lock,
             );

--- a/src/Target/Materialization/InitMaterialization.php
+++ b/src/Target/Materialization/InitMaterialization.php
@@ -26,6 +26,6 @@ final readonly class InitMaterialization implements Materialization
             ),
         );
 
-        return $lock;
+        return $lock->withRemembered($target);
     }
 }


### PR DESCRIPTION
- Fixed InitMaterialization to remember materialized targets in the lock
- Ensured UninitializedProject accumulates immutable lock snapshots
- Persisted populated lock after init instead of writing an empty file

Part of #90 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added lock configuration file to git ignore patterns

* **Refactor**
  * Improved lock file serialization and state management during project initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->