### PR TITLE
Normalize command-line arguments

### DIFF
--- a/src/CommandLine.php
+++ b/src/CommandLine.php
@@ -4,18 +4,35 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule;
 
-/**
- * Represents the execution context of the Piqule process.
- */
 final readonly class CommandLine
 {
     public function __construct(private array $argv) {}
 
+    /**
+     * Returns the normalized command string passed to the CLI.
+     *
+     * The command is built from argv arguments excluding the binary name.
+     * Each argument is trimmed, empty arguments are removed, and the result
+     * is joined with single spaces to ensure stable matching regardless of
+     * input whitespace.
+     *
+     * Examples:
+     *  - ['piqule', 'sync', '--dry-run']        => 'sync --dry-run'
+     *  - ['piqule', 'sync', '   --dry-run']    => 'sync --dry-run'
+     */
     public function command(): string
     {
         return implode(
             ' ',
-            array_slice($this->argv, 1),
+            array_values(
+                array_filter(
+                    array_map(
+                        static fn(string $arg): string => trim($arg),
+                        array_slice($this->argv, 1),
+                    ),
+                    static fn(string $arg): bool => $arg !== '',
+                ),
+            ),
         );
     }
 }

--- a/tests/CommandLineTest.php
+++ b/tests/CommandLineTest.php
@@ -19,4 +19,14 @@ final class CommandLineTest extends TestCase
             'Command must be extracted from argv',
         );
     }
+
+    #[Test]
+    public function normalizesWhitespaceInArguments(): void
+    {
+        self::assertSame(
+            'sync --dry-run',
+            (new CommandLine(['piqule', 'sync', '   --dry-run']))->command(),
+            'CommandLine must normalize whitespace in arguments',
+        );
+    }
 }

--- a/tests/Fake/Target/Storage/InMemoryTargetStorage.php
+++ b/tests/Fake/Target/Storage/InMemoryTargetStorage.php
@@ -35,4 +35,10 @@ final class InMemoryTargetStorage implements TargetStorage
 
         return $this->files[$relativePath];
     }
+
+    /** @return array<string, File> */
+    public function all(): array
+    {
+        return $this->files;
+    }
 }


### PR DESCRIPTION
- Updated CommandLine to trim and normalize CLI arguments
- Added unit tests for command normalization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public method to retrieve all stored items from in-memory storage

* **Bug Fixes**
  * Command-line argument processing now normalizes whitespace and trims arguments, ensuring consistent and reliable command parsing behavior regardless of input formatting

* **Tests**
  * Added test coverage for command-line argument whitespace normalization to verify correct handling of arguments with extra whitespace

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->