### PR TITLE
Restrict PHPUnit to <12 for PHP 8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.91",
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": ">=11.5 <12.0"
     }
 }


### PR DESCRIPTION
- Updated PHPUnit version constraint to exclude 12.x
- Preserved compatibility with PHP 8.2 as declared in composer.json
