### PR TITLE
Remove Hadolint inputs and rely on conventions

### DIFF
--- a/.github/workflows/_hadolint.yml
+++ b/.github/workflows/_hadolint.yml
@@ -14,9 +14,7 @@ jobs:
       - uses: actions/checkout@v6.0.1
 
       - name: Run Hadolint
-        if: >-
-          ${{ hashFiles('Dockerfile') != '' &&
-              hashFiles('.piqule/.hadolint.yml') != '' }}
+        if: ${{ hashFiles('Dockerfile') != '' }}
         uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: Dockerfile

--- a/.github/workflows/_hadolint.yml
+++ b/.github/workflows/_hadolint.yml
@@ -1,40 +1,23 @@
 name: Hadolint
+
 on:
   workflow_call:
-    inputs:
-      dockerfile:
-        type: string
-        required: false
-        default: Dockerfile
-      config:
-        type: string
-        required: false
-        default: hadolint/.hadolint.yaml
+
 permissions:
   contents: read
+
 jobs:
   hadolint:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6.0.1
-      - name: Check required files exist
-        id: check
-        run: |
-          if [[ -f "${{ inputs.dockerfile }}" && -f "${{ inputs.config }}" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Skip — missing dockerfile or config
-        if: steps.check.outputs.run == 'false'
-        run: |
-          echo "Skipping Hadolint — dockerfile or config not found:"
-          echo "  dockerfile: ${{ inputs.dockerfile }}"
-          echo "  config:     ${{ inputs.config }}"
+      - uses: actions/checkout@v6.0.1
+
       - name: Run Hadolint
-        if: steps.check.outputs.run == 'true'
+        if: >-
+          ${{ hashFiles('Dockerfile') != '' &&
+              hashFiles('.piqule/.hadolint.yml') != '' }}
         uses: hadolint/hadolint-action@v3.3.0
         with:
-          dockerfile: ${{ inputs.dockerfile }}
-          config: ${{ inputs.config }}
+          dockerfile: Dockerfile
+          config: .piqule/.hadolint.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
   hadolint:
     name: Hadolint
     uses: ./.github/workflows/_hadolint.yml
-    with:
-      dockerfile: Dockerfile
-      config: .piqule/.hadolint.yml
   tests:
     name: Tests with coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Removed dockerfile and config inputs from Hadolint reusable workflow
- Updated Hadolint workflow to rely on fixed conventions
- Added hashFiles guard to skip Hadolint when Dockerfile is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI configuration for container linting: removed customizable inputs and consolidated checkout steps.
  * Linting now runs deterministically when a container manifest is present and uses default config paths, reducing workflow branching and improving consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->