### PR TITLE
Extract tests job into reusable workflow

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -2,6 +2,10 @@ name: Tests
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+        description: 'Token for uploading coverage to Codecov'
 
 permissions:
   contents: read
@@ -12,17 +16,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
           php-version: '8.2'
           coverage: xdebug
           extensions: mbstring, dom, json
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Validate composer.json
         run: composer validate
@@ -31,8 +35,8 @@ jobs:
         run: composer test-coverage
 
       - name: Upload coverage to Codecov
-        if: hashFiles('tests/**') != ''
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        if: ${{ hashFiles('coverage-xml/*.xml') != '' }}
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage-xml/*.xml

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -1,0 +1,40 @@
+name: Tests
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+          extensions: mbstring, dom, json
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Validate composer.json
+        run: composer validate
+
+      - name: PHPUnit (with coverage)
+        run: composer test-coverage
+
+      - name: Upload coverage to Codecov
+        if: hashFiles('tests/**') != ''
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage-xml/*.xml
+          codecov_yml_path: .piqule/.codecov.yml
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,30 +44,7 @@ jobs:
       config: .piqule/.hadolint.yml
   tests:
     name: Tests with coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: mbstring, dom, json
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-      - name: Validate composer.json
-        run: composer validate
-      - name: PHPUnit (with coverage)
-        run: composer test-coverage
-      - name: Upload coverage to Codecov
-        if: hashFiles('tests/**') != ''
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage-xml/*.xml
-          codecov_yml_path: .piqule/.codecov.yml
-          fail_ci_if_error: true
+    uses: ./.github/workflows/_tests.yml
   pr_size_checker:
     name: PR Size Checker
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
   tests:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   pr_size_checker:
     name: PR Size Checker
     if: github.event_name == 'pull_request'

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
 
   "packageRules": [
     {
+      "description": "Pin GitHub Actions to commit SHA",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    },
+    {
       "description": "Auto-merge minor and patch dev dependencies",
       "matchDepTypes": ["require-dev"],
       "matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
- Refactored CI to move tests job into a reusable workflow
- Added dedicated tests workflow with PHP setup and coverage upload
- Simplified main CI workflow by delegating test execution
- Updated Renovate configuration to manage pinned GitHub Actions hashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved testing infrastructure with a reusable workflow for PHP tests and coverage reporting
  * Streamlined CI pipeline by consolidating test execution into a unified workflow
  * Enhanced dependency management for GitHub Actions through digest pinning

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->