### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/_actionlint.yml
+++ b/.github/workflows/_actionlint.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1.69.1
+        uses: reviewdog/action-actionlint@83e4ed25b168066ad8f62f5afbb29ebd8641d982  # v1.69.1
         with:
           fail_level: ${{ inputs.fail_level }}
           reporter: ${{ inputs.reporter }}

--- a/.github/workflows/_hadolint.yml
+++ b/.github/workflows/_hadolint.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Run Hadolint
         if: ${{ hashFiles('Dockerfile') != '' }}
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: Dockerfile
           config: .piqule/.hadolint.yml

--- a/.github/workflows/_markdownlint.yml
+++ b/.github/workflows/_markdownlint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Check config exists
         id: check
         run: |

--- a/.github/workflows/_php-cs-fixer.yml
+++ b/.github/workflows/_php-cs-fixer.yml
@@ -23,7 +23,7 @@ jobs:
         php-version: ${{ fromJson(inputs.php-matrix != '' && inputs.php-matrix || format('["{0}"]', inputs.php-version)) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Check config exists
         id: check
         run: |
@@ -37,7 +37,7 @@ jobs:
         run: echo "Skipping PHP-CS-Fixer — config not found at ${{ inputs.config }}"
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@2.36.0
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # 2.36.0
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/.github/workflows/_pr-size-checker.yml
+++ b/.github/workflows/_pr-size-checker.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 0
       - name: Run PR Size Checker
-        uses: maidsafe/pr_size_checker@v3
+        uses: maidsafe/pr_size_checker@fa5820312a361f3f51aad2d3d9cb941d9e1d27db  # v3
         with:
           max_lines_changed: ${{ inputs.max_lines_changed }}

--- a/.github/workflows/_release-drafter.yml
+++ b/.github/workflows/_release-drafter.yml
@@ -9,7 +9,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Update draft release
-        uses: release-drafter/release-drafter@v6.1.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5  # v6.1.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/_typos.yml
+++ b/.github/workflows/_typos.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Check config exists
         id: check
         run: |
@@ -28,7 +28,7 @@ jobs:
         run: echo "Skipping Typos — config not found at ${{ inputs.config }}"
       - name: Run Typos
         if: steps.check.outputs.run == 'true'
-        uses: crate-ci/typos@v1.40.0
+        uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06  # v1.40.0
         with:
           files: .
           config: ${{ inputs.config }}

--- a/.github/workflows/_yamllint.yml
+++ b/.github/workflows/_yamllint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Check config exists
         id: check
         run: |
@@ -25,7 +25,7 @@ jobs:
         run: echo "Skipping Yamllint — config not found at ${{ inputs.config }}"
       - name: Run yamllint
         if: steps.check.outputs.run == 'true'
-        uses: ibiqlik/action-yamllint@v3.1.1
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
         with:
           config_file: ${{ inputs.config }}
           format: github

--- a/templates/renovate.json
+++ b/templates/renovate.json
@@ -14,6 +14,11 @@
 
   "packageRules": [
     {
+      "description": "Pin GitHub Actions to commit SHA",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    },
+    {
       "description": "Auto-merge minor and patch dev dependencies",
       "matchDepTypes": ["require-dev"],
       "matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
- Updated GitHub Actions to use pinned commit SHAs
- Added version comments for pinned actions
- Added integration test for DiskSources filesystem behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/workflow configurations across multiple checks to pin external actions to exact commit references (replacing tag-based references) for more deterministic runs.
  * Added a Renovate rule to automatically pin GitHub Actions to commit SHAs going forward.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->