### PR TITLE
Add PHPMD numeric quality gate 

### DIFF
--- a/.github/workflows/_phpmd.yml
+++ b/.github/workflows/_phpmd.yml
@@ -26,11 +26,18 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
-      # ------------------------------------------------------------
+          # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
+      # ------------------------------------------------------------
+      # Install XML utilities
+      # ------------------------------------------------------------
+      - name: Install xmllint
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
       # ------------------------------------------------------------
       # Validate PHPMD ruleset XML
       # ------------------------------------------------------------

--- a/.github/workflows/_phpmd.yml
+++ b/.github/workflows/_phpmd.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
-          # ------------------------------------------------------------
+      # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
@@ -42,9 +42,13 @@ jobs:
       # Validate PHPMD ruleset XML
       # ------------------------------------------------------------
       - name: Validate PHPMD ruleset
-        run: xmllint --noout "${{ inputs.ruleset }}"
+        env:
+          PHPMD_RULESET: ${{ inputs.ruleset }}
+        run: xmllint --noout "$PHPMD_RULESET"
       # ------------------------------------------------------------
       # Run PHPMD
       # ------------------------------------------------------------
       - name: Run PHPMD
-        run: vendor/bin/phpmd src text "${{ inputs.ruleset }}"
+        env:
+          PHPMD_RULESET: ${{ inputs.ruleset }}
+        run: vendor/bin/phpmd src text "$PHPMD_RULESET"

--- a/.github/workflows/_phpmd.yml
+++ b/.github/workflows/_phpmd.yml
@@ -1,0 +1,43 @@
+name: PHPMD
+on:
+  workflow_call:
+    inputs:
+      ruleset:
+        description: Path to PHPMD ruleset XML
+        type: string
+        required: true
+permissions:
+  contents: read
+jobs:
+  phpmd:
+    name: PHPMD (numeric metrics)
+    runs-on: ubuntu-latest
+    steps:
+      # ------------------------------------------------------------
+      # Checkout repository
+      # ------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      # ------------------------------------------------------------
+      # Setup PHP
+      # ------------------------------------------------------------
+      - name: Setup PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        with:
+          php-version: '8.2'
+          tools: composer
+      # ------------------------------------------------------------
+      # Install dependencies
+      # ------------------------------------------------------------
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      # ------------------------------------------------------------
+      # Validate PHPMD ruleset XML
+      # ------------------------------------------------------------
+      - name: Validate PHPMD ruleset
+        run: xmllint --noout "${{ inputs.ruleset }}"
+      # ------------------------------------------------------------
+      # Run PHPMD
+      # ------------------------------------------------------------
+      - name: Run PHPMD
+        run: vendor/bin/phpmd src text "${{ inputs.ruleset }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,14 @@ jobs:
     with:
       config: .piqule/ast-metrics.yaml
   # ------------------------------------------------------------
+  # PHPMD (numeric metrics)
+  # ------------------------------------------------------------
+  phpmd:
+    name: PHPMD
+    uses: ./.github/workflows/_phpmd.yml
+    with:
+      ruleset: .piqule/phpmd.xml
+  # ------------------------------------------------------------
   # Dockerfile lint
   # ------------------------------------------------------------
   hadolint:

--- a/.piqule/phpmd.xml
+++ b/.piqule/phpmd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Piqule PHPMD Ruleset" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
     <description>
-        Numeric-only PHPMD ruleset aligned with Qulice.
+        Numeric-only PHPMD ruleset with intentionally strict thresholds
     </description>
     <!-- Cyclomatic complexity -->
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity">

--- a/.piqule/phpmd.xml
+++ b/.piqule/phpmd.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Piqule PHPMD Ruleset" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>
+        Numeric-only PHPMD ruleset aligned with Qulice.
+    </description>
+    <!-- Cyclomatic complexity -->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <property name="reportLevel" value="10"/>
+        </properties>
+    </rule>
+    <!-- NPath complexity -->
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="reportLevel" value="200"/>
+        </properties>
+    </rule>
+    <!-- Method length -->
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="50"/>
+        </properties>
+    </rule>
+    <!-- Class length -->
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
+        <properties>
+            <property name="minimum" value="200"/>
+        </properties>
+    </rule>
+    <!-- Number of methods -->
+    <rule ref="rulesets/codesize.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="10"/>
+        </properties>
+    </rule>
+    <!-- Number of parameters -->
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
+        <properties>
+            <property name="minimum" value="5"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ and helps avoid configuration drift across repositories.
 | Psalm           | Static analysis       | Complementary checks and early error detection          |
 | PHP-CS-Fixer    | Code style            | Deterministic formatting rules                          |
 | AST Metrics     | Code metrics          | Complexity, coupling, and maintainability quality gates |
+| PHPMD           | Code metrics          | Numeric complexity and size quality gates               |
 | Infection       | Mutation testing      | Test quality validation                                 |
 | Markdownlint    | Markdown linting      | Consistent documentation style                          |
 | Hadolint        | Dockerfile linting    | Secure and reproducible Dockerfiles                     |

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "phpunit/phpunit": ">=11.5 <12.0",
         "infection/infection": "^0.32.0",
         "phpstan/phpstan": "^2.1",
-        "vimeo/psalm": "^6.14"
+        "vimeo/psalm": "^6.14",
+        "phpmd/phpmd": "^2.15"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e550c290af34901ec64eef478789e1b8",
+    "content-hash": "0593ff889df2c7ca0b98243ba4293857",
     "packages": [],
     "packages-dev": [
         {
@@ -2629,6 +2629,69 @@
             "time": "2024-03-12T13:22:30+00:00"
         },
         {
+            "name": "pdepend/pdepend",
+            "version": "2.16.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
+                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.7",
+                "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/polyfill-mbstring": "^1.19"
+            },
+            "require-dev": {
+                "easy-doc/easy-doc": "0.0.0|^1.2.3",
+                "gregwar/rst": "^1.0",
+                "squizlabs/php_codesniffer": "^2.0.0"
+            },
+            "bin": [
+                "src/bin/pdepend"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PDepend\\": "src/main/php/PDepend"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Official version of pdepend to be handled with Composer",
+            "keywords": [
+                "PHP Depend",
+                "PHP_Depend",
+                "dev",
+                "pdepend"
+            ],
+            "support": {
+                "issues": "https://github.com/pdepend/pdepend/issues",
+                "source": "https://github.com/pdepend/pdepend/tree/2.16.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/pdepend/pdepend",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-17T18:09:59+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.4",
             "source": {
@@ -2920,6 +2983,89 @@
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
             },
             "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
+            "name": "phpmd/phpmd",
+            "version": "2.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmd/phpmd.git",
+                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/74a1f56e33afad4128b886e334093e98e1b5e7c0",
+                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
+                "ext-xml": "*",
+                "pdepend/pdepend": "^2.16.1",
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "easy-doc/easy-doc": "0.0.0 || ^1.3.2",
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "gregwar/rst": "^1.0",
+                "mikey179/vfsstream": "^1.6.8",
+                "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2"
+            },
+            "bin": [
+                "src/bin/phpmd"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPMD\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Manuel Pichler",
+                    "email": "github@manuel-pichler.de",
+                    "homepage": "https://github.com/manuelpichler",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Marc Würth",
+                    "email": "ravage@bluewin.ch",
+                    "homepage": "https://github.com/ravage84",
+                    "role": "Project Maintainer"
+                },
+                {
+                    "name": "Other contributors",
+                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
+            "homepage": "https://phpmd.org/",
+            "keywords": [
+                "dev",
+                "mess detection",
+                "mess detector",
+                "pdepend",
+                "phpmd",
+                "pmd"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/phpmd",
+                "issues": "https://github.com/phpmd/phpmd/issues",
+                "source": "https://github.com/phpmd/phpmd/tree/2.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpmd/phpmd",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-11T08:22:20+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -5749,6 +5895,85 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/config",
+            "version": "v7.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "800ce889e358a53a9678b3212b0c8cecd8c6aace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/800ce889e358a53a9678b3212b0c8cecd8c6aace",
+                "reference": "800ce889e358a53a9678b3212b0c8cecd8c6aace",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.1|^8.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v7.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-23T14:24:27+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v7.4.1",
             "source": {
@@ -5845,6 +6070,90 @@
                 }
             ],
             "time": "2025-12-05T15:23:39+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v7.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "54122901b6d772e94f1e71a75e0533bc16563499"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/54122901b6d772e94f1e71a75e0533bc16563499",
+                "reference": "54122901b6d772e94f1e71a75e0533bc16563499",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^3.6",
+                "symfony/var-exporter": "^6.4.20|^7.2.5|^8.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.4",
+                "symfony/finder": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-28T10:55:46+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -7250,6 +7559,87 @@
                 }
             ],
             "time": "2025-11-27T13:27:24+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v7.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/03a60f169c79a28513a78c967316fbc8bf17816f",
+                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-11T10:15:23+00:00"
         },
         {
             "name": "thecodingmachine/safe",

--- a/templates/.github/workflows/_phpmd.yml
+++ b/templates/.github/workflows/_phpmd.yml
@@ -26,11 +26,18 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
-      # ------------------------------------------------------------
+          # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
+      # ------------------------------------------------------------
+      # Install XML utilities
+      # ------------------------------------------------------------
+      - name: Install xmllint
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
       # ------------------------------------------------------------
       # Validate PHPMD ruleset XML
       # ------------------------------------------------------------

--- a/templates/.github/workflows/_phpmd.yml
+++ b/templates/.github/workflows/_phpmd.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
-          # ------------------------------------------------------------
+      # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
@@ -42,9 +42,13 @@ jobs:
       # Validate PHPMD ruleset XML
       # ------------------------------------------------------------
       - name: Validate PHPMD ruleset
-        run: xmllint --noout "${{ inputs.ruleset }}"
+        env:
+          PHPMD_RULESET: ${{ inputs.ruleset }}
+        run: xmllint --noout "$PHPMD_RULESET"
       # ------------------------------------------------------------
       # Run PHPMD
       # ------------------------------------------------------------
       - name: Run PHPMD
-        run: vendor/bin/phpmd src text "${{ inputs.ruleset }}"
+        env:
+          PHPMD_RULESET: ${{ inputs.ruleset }}
+        run: vendor/bin/phpmd src text "$PHPMD_RULESET"

--- a/templates/.github/workflows/_phpmd.yml
+++ b/templates/.github/workflows/_phpmd.yml
@@ -1,0 +1,43 @@
+name: PHPMD
+on:
+  workflow_call:
+    inputs:
+      ruleset:
+        description: Path to PHPMD ruleset XML
+        type: string
+        required: true
+permissions:
+  contents: read
+jobs:
+  phpmd:
+    name: PHPMD (numeric metrics)
+    runs-on: ubuntu-latest
+    steps:
+      # ------------------------------------------------------------
+      # Checkout repository
+      # ------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      # ------------------------------------------------------------
+      # Setup PHP
+      # ------------------------------------------------------------
+      - name: Setup PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        with:
+          php-version: '8.2'
+          tools: composer
+      # ------------------------------------------------------------
+      # Install dependencies
+      # ------------------------------------------------------------
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      # ------------------------------------------------------------
+      # Validate PHPMD ruleset XML
+      # ------------------------------------------------------------
+      - name: Validate PHPMD ruleset
+        run: xmllint --noout "${{ inputs.ruleset }}"
+      # ------------------------------------------------------------
+      # Run PHPMD
+      # ------------------------------------------------------------
+      - name: Run PHPMD
+        run: vendor/bin/phpmd src text "${{ inputs.ruleset }}"

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -75,6 +75,14 @@ jobs:
     with:
       config: .piqule/ast-metrics.yaml
   # ------------------------------------------------------------
+  # PHPMD (numeric metrics)
+  # ------------------------------------------------------------
+  phpmd:
+    name: PHPMD
+    uses: ./.github/workflows/_phpmd.yml
+    with:
+      ruleset: .piqule/phpmd.xml
+  # ------------------------------------------------------------
   # Dockerfile lint
   # ------------------------------------------------------------
   hadolint:

--- a/templates/.piqule/phpmd.xml
+++ b/templates/.piqule/phpmd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Piqule PHPMD Ruleset" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
     <description>
-        Numeric-only PHPMD ruleset aligned with Qulice.
+        Numeric-only PHPMD ruleset with intentionally strict thresholds
     </description>
     <!-- Cyclomatic complexity -->
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity">

--- a/templates/.piqule/phpmd.xml
+++ b/templates/.piqule/phpmd.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Piqule PHPMD Ruleset" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>
+        Numeric-only PHPMD ruleset aligned with Qulice.
+    </description>
+    <!-- Cyclomatic complexity -->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <property name="reportLevel" value="10"/>
+        </properties>
+    </rule>
+    <!-- NPath complexity -->
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="reportLevel" value="200"/>
+        </properties>
+    </rule>
+    <!-- Method length -->
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="50"/>
+        </properties>
+    </rule>
+    <!-- Class length -->
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
+        <properties>
+            <property name="minimum" value="200"/>
+        </properties>
+    </rule>
+    <!-- Number of methods -->
+    <rule ref="rulesets/codesize.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="10"/>
+        </properties>
+    </rule>
+    <!-- Number of parameters -->
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
+        <properties>
+            <property name="minimum" value="5"/>
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
- Added PHPMD numeric-only ruleset aligned with Qulice
- Added reusable PHPMD workflow for CI enforcement
- Integrated PHPMD job into main CI pipeline

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated PHP Mess Detector (PHPMD) into CI to run automated code-quality and numeric complexity checks.
  * Added a reusable CI job to execute PHPMD as part of the existing pipeline.
  * Introduced a PHPMD ruleset defining thresholds for cyclomatic/NPath complexity, method/class length, parameter count, and max methods.
  * Added PHPMD as a development dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->