### PR TITLE
Centralize PHP version management in CI

### DIFF
--- a/.github/workflows/_php-cs-fixer.yml
+++ b/.github/workflows/_php-cs-fixer.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   cs:
+    name: PHP-CS-Fixer (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -25,7 +26,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
@@ -51,7 +52,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282  # v2.36.0
+        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/.github/workflows/_php-cs-fixer.yml
+++ b/.github/workflows/_php-cs-fixer.yml
@@ -1,37 +1,32 @@
 name: PHP-CS-Fixer
+
 on:
   workflow_call:
     inputs:
-      php-version:
-        type: string
-        required: false
-        default: ""
       php-matrix:
+        description: JSON array of PHP versions to run against
         type: string
-        required: false
-        default: ""
+        required: true
+
 permissions:
   contents: read
+
 jobs:
   cs:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        php-version: >-
-          ${{ fromJson(
+        php-version: ${{ fromJson(inputs.php-matrix) }}
 
-
-            inputs.php-matrix != '' &&
-            inputs.php-matrix ||
-            format('["{0}"]', inputs.php-version)
-          ) }}
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
       # ------------------------------------------------------------
@@ -43,12 +38,14 @@ jobs:
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
+
       # ------------------------------------------------------------
       # Skip PHP-CS-Fixer when config is missing
       # ------------------------------------------------------------
       - name: Skip — no config found
         if: steps.check.outputs.run == 'false'
         run: echo "Skipping PHP-CS-Fixer — no .piqule/php-cs-fixer.project.php"
+
       # ------------------------------------------------------------
       # Setup PHP
       # ------------------------------------------------------------
@@ -58,12 +55,14 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
+
       # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         if: steps.check.outputs.run == 'true'
         run: composer install --prefer-dist --no-progress --no-interaction
+
       # ------------------------------------------------------------
       # Run PHP-CS-Fixer (dry-run)
       # ------------------------------------------------------------

--- a/.github/workflows/_php-cs-fixer.yml
+++ b/.github/workflows/_php-cs-fixer.yml
@@ -1,17 +1,17 @@
 name: PHP-CS-Fixer
-
 on:
   workflow_call:
     inputs:
       php-version:
         type: string
         required: false
-        default: "8.5"
+        default: ""
       php-matrix:
         type: string
         required: false
-        default: ""  # JSON: ["8.2","8.3","8.4","8.5"]
-
+        default: ""
+permissions:
+  contents: read
 jobs:
   cs:
     runs-on: ubuntu-latest
@@ -20,18 +20,18 @@ jobs:
       matrix:
         php-version: >-
           ${{ fromJson(
+
+
             inputs.php-matrix != '' &&
             inputs.php-matrix ||
             format('["{0}"]', inputs.php-version)
           ) }}
-
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
       # ------------------------------------------------------------
@@ -43,31 +43,27 @@ jobs:
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
-
       # ------------------------------------------------------------
       # Skip PHP-CS-Fixer when config is missing
       # ------------------------------------------------------------
       - name: Skip — no config found
         if: steps.check.outputs.run == 'false'
         run: echo "Skipping PHP-CS-Fixer — no .piqule/php-cs-fixer.project.php"
-
       # ------------------------------------------------------------
       # Setup PHP
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282  # v2.36.0
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
-
       # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         if: steps.check.outputs.run == 'true'
         run: composer install --prefer-dist --no-progress --no-interaction
-
       # ------------------------------------------------------------
       # Run PHP-CS-Fixer (dry-run)
       # ------------------------------------------------------------

--- a/.github/workflows/_phpmd.yml
+++ b/.github/workflows/_phpmd.yml
@@ -1,36 +1,47 @@
 name: PHPMD
+
 on:
   workflow_call:
     inputs:
+      php-version:
+        description: PHP version to use
+        type: string
+        required: true
       ruleset:
         description: Path to PHPMD ruleset XML
         type: string
         required: true
+
 permissions:
   contents: read
+
 jobs:
   phpmd:
     name: PHPMD (numeric metrics)
     runs-on: ubuntu-latest
+
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
       # ------------------------------------------------------------
       # Setup PHP
       # ------------------------------------------------------------
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs.php-version }}
           tools: composer
+
       # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
+
       # ------------------------------------------------------------
       # Install XML utilities
       # ------------------------------------------------------------
@@ -38,6 +49,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libxml2-utils
+
       # ------------------------------------------------------------
       # Validate PHPMD ruleset XML
       # ------------------------------------------------------------
@@ -45,6 +57,7 @@ jobs:
         env:
           PHPMD_RULESET: ${{ inputs.ruleset }}
         run: xmllint --noout "$PHPMD_RULESET"
+
       # ------------------------------------------------------------
       # Run PHPMD
       # ------------------------------------------------------------

--- a/.github/workflows/_phpmd.yml
+++ b/.github/workflows/_phpmd.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   phpmd:
-    name: PHPMD (numeric metrics)
+    name: PHPMD (PHP ${{ inputs.php-version }})
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/_phpstan.yml
+++ b/.github/workflows/_phpstan.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   phpstan:
+    name: PHPStan (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/_phpstan.yml
+++ b/.github/workflows/_phpstan.yml
@@ -6,11 +6,11 @@ on:
       php-version:
         type: string
         required: false
-        default: "8.5"
+        default: ""
       php-matrix:
         type: string
         required: false
-        default: ""  # JSON: ["8.2","8.3","8.4","8.5"]
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/_phpstan.yml
+++ b/.github/workflows/_phpstan.yml
@@ -3,14 +3,10 @@ name: PHPStan
 on:
   workflow_call:
     inputs:
-      php-version:
-        type: string
-        required: false
-        default: ""
       php-matrix:
+        description: JSON array of PHP versions to run against
         type: string
-        required: false
-        default: ""
+        required: true
 
 permissions:
   contents: read
@@ -22,12 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: >-
-          ${{ fromJson(
-            inputs.php-matrix != '' &&
-            inputs.php-matrix ||
-            format('["{0}"]', inputs.php-version)
-          ) }}
+        php-version: ${{ fromJson(inputs.php-matrix) }}
 
     steps:
       # ------------------------------------------------------------

--- a/.github/workflows/_psalm.yml
+++ b/.github/workflows/_psalm.yml
@@ -6,11 +6,11 @@ on:
       php-version:
         type: string
         required: false
-        default: "8.5"
+        default: ""
       php-matrix:
         type: string
         required: false
-        default: ""  # JSON: ["8.2","8.3","8.4","8.5"]
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/_psalm.yml
+++ b/.github/workflows/_psalm.yml
@@ -3,14 +3,10 @@ name: Psalm
 on:
   workflow_call:
     inputs:
-      php-version:
-        type: string
-        required: false
-        default: ""
       php-matrix:
+        description: JSON array of PHP versions to run against
         type: string
-        required: false
-        default: ""
+        required: true
 
 permissions:
   contents: read
@@ -22,12 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: >-
-          ${{ fromJson(
-            inputs.php-matrix != '' &&
-            inputs.php-matrix ||
-            format('["{0}"]', inputs.php-version)
-          ) }}
+        php-version: ${{ fromJson(inputs.php-matrix) }}
 
     steps:
       # ------------------------------------------------------------

--- a/.github/workflows/_psalm.yml
+++ b/.github/workflows/_psalm.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   psalm:
+    name: Psalm (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   tests:
+    name: Tests (PHP ${{ inputs.php-version }})
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -2,6 +2,11 @@ name: Tests
 
 on:
   workflow_call:
+    inputs:
+      php-version:
+        description: PHP version to use for tests
+        type: string
+        required: true
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -30,7 +35,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs.php-version }}
           coverage: xdebug
           extensions: mbstring, dom, json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  PHP_MIN_VERSION: '8.2'
-  PHP_MAX_VERSION: '8.5'
-
 jobs:
   # ------------------------------------------------------------
   # YAML lint
@@ -60,8 +56,8 @@ jobs:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-min-version: ${{ env.PHP_MIN_VERSION }}
-      php-max-version: ${{ env.PHP_MAX_VERSION }}
+      php-matrix: >-
+        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -70,8 +66,8 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-min-version: ${{ env.PHP_MIN_VERSION }}
-      php-max-version: ${{ env.PHP_MAX_VERSION }}
+      php-matrix: >-
+        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -80,8 +76,8 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-min-version: ${{ env.PHP_MIN_VERSION }}
-      php-max-version: ${{ env.PHP_MAX_VERSION }}
+      php-matrix: >-
+        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
 
   # ------------------------------------------------------------
   # AST Metrics
@@ -99,6 +95,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
+      php-version: ${{ vars.PHP_MIN_VERSION }}
       ruleset: .piqule/phpmd.xml
 
   # ------------------------------------------------------------
@@ -109,13 +106,13 @@ jobs:
     uses: ./.github/workflows/_hadolint.yml
 
   # ------------------------------------------------------------
-  # PHPUnit + Coverage + Infection (только min)
+  # PHPUnit + Coverage + Infection (min PHP version only)
   # ------------------------------------------------------------
   tests:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: ${{ env.PHP_MIN_VERSION }}
+      php-version: ${{ vars.PHP_MIN_VERSION }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-matrix: >-
-        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
+      php-matrix: '["8.2","8.5"]'
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -66,8 +65,7 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: >-
-        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
+      php-matrix: '["8.2","8.5"]'
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -76,8 +74,7 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: >-
-        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
+      php-matrix: '["8.2","8.5"]'
 
   # ------------------------------------------------------------
   # AST Metrics
@@ -95,7 +92,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
-      php-version: ${{ vars.PHP_MIN_VERSION }}
+      php-version: '8.2'
       ruleset: .piqule/phpmd.xml
 
   # ------------------------------------------------------------
@@ -112,7 +109,7 @@ jobs:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: ${{ vars.PHP_MIN_VERSION }}
+      php-version: '8.2'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,20 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
+
 permissions:
   contents: read
   pull-requests: read
+
+env:
+  PHP_MIN_VERSION: '8.2'
+  PHP_MAX_VERSION: '8.5'
+
 jobs:
   # ------------------------------------------------------------
   # YAML lint
@@ -17,6 +24,7 @@ jobs:
     uses: ./.github/workflows/_yamllint.yml
     with:
       config: .piqule/.yamllint.yml
+
   # ------------------------------------------------------------
   # GitHub Actions lint
   # ------------------------------------------------------------
@@ -26,6 +34,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-actionlint-${{ github.ref }}
       cancel-in-progress: true
+
   # ------------------------------------------------------------
   # Markdown lint
   # ------------------------------------------------------------
@@ -34,6 +43,7 @@ jobs:
     uses: ./.github/workflows/_markdownlint.yml
     with:
       config: .piqule/.markdownlint-cli2.jsonc
+
   # ------------------------------------------------------------
   # Typo checker
   # ------------------------------------------------------------
@@ -42,30 +52,37 @@ jobs:
     uses: ./.github/workflows/_typos.yml
     with:
       config: .piqule/_typos.toml
+
   # ------------------------------------------------------------
-  # PHP-CS-Fixer (matrix)
+  # PHP-CS-Fixer (min + max)
   # ------------------------------------------------------------
   php_cs_fixer:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-matrix: '["8.2","8.3","8.4","8.5"]'
+      php-min-version: ${{ env.PHP_MIN_VERSION }}
+      php-max-version: ${{ env.PHP_MAX_VERSION }}
+
   # ------------------------------------------------------------
-  # PHPStan (matrix)
+  # PHPStan (min + max)
   # ------------------------------------------------------------
   phpstan:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: '["8.2","8.3","8.4","8.5"]'
+      php-min-version: ${{ env.PHP_MIN_VERSION }}
+      php-max-version: ${{ env.PHP_MAX_VERSION }}
+
   # ------------------------------------------------------------
-  # Psalm (matrix)
+  # Psalm (min + max)
   # ------------------------------------------------------------
   psalm:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: '["8.2","8.3","8.4","8.5"]'
+      php-min-version: ${{ env.PHP_MIN_VERSION }}
+      php-max-version: ${{ env.PHP_MAX_VERSION }}
+
   # ------------------------------------------------------------
   # AST Metrics
   # ------------------------------------------------------------
@@ -74,6 +91,7 @@ jobs:
     uses: ./.github/workflows/_ast-metrics.yml
     with:
       config: .piqule/ast-metrics.yaml
+
   # ------------------------------------------------------------
   # PHPMD (numeric metrics)
   # ------------------------------------------------------------
@@ -82,21 +100,26 @@ jobs:
     uses: ./.github/workflows/_phpmd.yml
     with:
       ruleset: .piqule/phpmd.xml
+
   # ------------------------------------------------------------
   # Dockerfile lint
   # ------------------------------------------------------------
   hadolint:
     name: Hadolint
     uses: ./.github/workflows/_hadolint.yml
+
   # ------------------------------------------------------------
-  # PHPUnit + Coverage + Infection
+  # PHPUnit + Coverage + Infection (только min)
   # ------------------------------------------------------------
   tests:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
+    with:
+      php-version: ${{ env.PHP_MIN_VERSION }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+
   # ------------------------------------------------------------
   # PR size guard
   # ------------------------------------------------------------
@@ -106,8 +129,9 @@ jobs:
     uses: ./.github/workflows/_pr-size-checker.yml
     with:
       max_lines_changed: 250
+
   # ------------------------------------------------------------
-  # Release drafter (main only)
+  # Release drafter
   # ------------------------------------------------------------
   release_drafter:
     name: Release Drafter

--- a/templates/.github/workflows/_php-cs-fixer.yml
+++ b/templates/.github/workflows/_php-cs-fixer.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   cs:
+    name: PHP-CS-Fixer (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -25,7 +26,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
@@ -51,7 +52,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282  # v2.36.0
+        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/templates/.github/workflows/_php-cs-fixer.yml
+++ b/templates/.github/workflows/_php-cs-fixer.yml
@@ -1,37 +1,32 @@
 name: PHP-CS-Fixer
+
 on:
   workflow_call:
     inputs:
-      php-version:
-        type: string
-        required: false
-        default: ""
       php-matrix:
+        description: JSON array of PHP versions to run against
         type: string
-        required: false
-        default: ""
+        required: true
+
 permissions:
   contents: read
+
 jobs:
   cs:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        php-version: >-
-          ${{ fromJson(
+        php-version: ${{ fromJson(inputs.php-matrix) }}
 
-
-            inputs.php-matrix != '' &&
-            inputs.php-matrix ||
-            format('["{0}"]', inputs.php-version)
-          ) }}
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
       # ------------------------------------------------------------
@@ -43,12 +38,14 @@ jobs:
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
+
       # ------------------------------------------------------------
       # Skip PHP-CS-Fixer when config is missing
       # ------------------------------------------------------------
       - name: Skip — no config found
         if: steps.check.outputs.run == 'false'
         run: echo "Skipping PHP-CS-Fixer — no .piqule/php-cs-fixer.project.php"
+
       # ------------------------------------------------------------
       # Setup PHP
       # ------------------------------------------------------------
@@ -58,12 +55,14 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
+
       # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         if: steps.check.outputs.run == 'true'
         run: composer install --prefer-dist --no-progress --no-interaction
+
       # ------------------------------------------------------------
       # Run PHP-CS-Fixer (dry-run)
       # ------------------------------------------------------------

--- a/templates/.github/workflows/_php-cs-fixer.yml
+++ b/templates/.github/workflows/_php-cs-fixer.yml
@@ -1,17 +1,17 @@
 name: PHP-CS-Fixer
-
 on:
   workflow_call:
     inputs:
       php-version:
         type: string
         required: false
-        default: "8.5"
+        default: ""
       php-matrix:
         type: string
         required: false
-        default: ""  # JSON: ["8.2","8.3","8.4","8.5"]
-
+        default: ""
+permissions:
+  contents: read
 jobs:
   cs:
     runs-on: ubuntu-latest
@@ -20,18 +20,18 @@ jobs:
       matrix:
         php-version: >-
           ${{ fromJson(
+
+
             inputs.php-matrix != '' &&
             inputs.php-matrix ||
             format('["{0}"]', inputs.php-version)
           ) }}
-
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
       # ------------------------------------------------------------
@@ -43,31 +43,27 @@ jobs:
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
-
       # ------------------------------------------------------------
       # Skip PHP-CS-Fixer when config is missing
       # ------------------------------------------------------------
       - name: Skip — no config found
         if: steps.check.outputs.run == 'false'
         run: echo "Skipping PHP-CS-Fixer — no .piqule/php-cs-fixer.project.php"
-
       # ------------------------------------------------------------
       # Setup PHP
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282  # v2.36.0
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
-
       # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         if: steps.check.outputs.run == 'true'
         run: composer install --prefer-dist --no-progress --no-interaction
-
       # ------------------------------------------------------------
       # Run PHP-CS-Fixer (dry-run)
       # ------------------------------------------------------------

--- a/templates/.github/workflows/_phpmd.yml
+++ b/templates/.github/workflows/_phpmd.yml
@@ -1,36 +1,47 @@
 name: PHPMD
+
 on:
   workflow_call:
     inputs:
+      php-version:
+        description: PHP version to use
+        type: string
+        required: true
       ruleset:
         description: Path to PHPMD ruleset XML
         type: string
         required: true
+
 permissions:
   contents: read
+
 jobs:
   phpmd:
     name: PHPMD (numeric metrics)
     runs-on: ubuntu-latest
+
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
       # ------------------------------------------------------------
       # Setup PHP
       # ------------------------------------------------------------
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs.php-version }}
           tools: composer
+
       # ------------------------------------------------------------
       # Install dependencies
       # ------------------------------------------------------------
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
+
       # ------------------------------------------------------------
       # Install XML utilities
       # ------------------------------------------------------------
@@ -38,6 +49,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libxml2-utils
+
       # ------------------------------------------------------------
       # Validate PHPMD ruleset XML
       # ------------------------------------------------------------
@@ -45,6 +57,7 @@ jobs:
         env:
           PHPMD_RULESET: ${{ inputs.ruleset }}
         run: xmllint --noout "$PHPMD_RULESET"
+
       # ------------------------------------------------------------
       # Run PHPMD
       # ------------------------------------------------------------

--- a/templates/.github/workflows/_phpmd.yml
+++ b/templates/.github/workflows/_phpmd.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   phpmd:
-    name: PHPMD (numeric metrics)
+    name: PHPMD (PHP ${{ inputs.php-version }})
     runs-on: ubuntu-latest
 
     steps:

--- a/templates/.github/workflows/_phpstan.yml
+++ b/templates/.github/workflows/_phpstan.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   phpstan:
+    name: PHPStan (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/templates/.github/workflows/_phpstan.yml
+++ b/templates/.github/workflows/_phpstan.yml
@@ -6,11 +6,11 @@ on:
       php-version:
         type: string
         required: false
-        default: "8.5"
+        default: ""
       php-matrix:
         type: string
         required: false
-        default: ""  # JSON: ["8.2","8.3","8.4","8.5"]
+        default: ""
 
 permissions:
   contents: read

--- a/templates/.github/workflows/_phpstan.yml
+++ b/templates/.github/workflows/_phpstan.yml
@@ -3,14 +3,10 @@ name: PHPStan
 on:
   workflow_call:
     inputs:
-      php-version:
-        type: string
-        required: false
-        default: ""
       php-matrix:
+        description: JSON array of PHP versions to run against
         type: string
-        required: false
-        default: ""
+        required: true
 
 permissions:
   contents: read
@@ -22,12 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: >-
-          ${{ fromJson(
-            inputs.php-matrix != '' &&
-            inputs.php-matrix ||
-            format('["{0}"]', inputs.php-version)
-          ) }}
+        php-version: ${{ fromJson(inputs.php-matrix) }}
 
     steps:
       # ------------------------------------------------------------

--- a/templates/.github/workflows/_psalm.yml
+++ b/templates/.github/workflows/_psalm.yml
@@ -6,11 +6,11 @@ on:
       php-version:
         type: string
         required: false
-        default: "8.5"
+        default: ""
       php-matrix:
         type: string
         required: false
-        default: ""  # JSON: ["8.2","8.3","8.4","8.5"]
+        default: ""
 
 permissions:
   contents: read

--- a/templates/.github/workflows/_psalm.yml
+++ b/templates/.github/workflows/_psalm.yml
@@ -3,14 +3,10 @@ name: Psalm
 on:
   workflow_call:
     inputs:
-      php-version:
-        type: string
-        required: false
-        default: ""
       php-matrix:
+        description: JSON array of PHP versions to run against
         type: string
-        required: false
-        default: ""
+        required: true
 
 permissions:
   contents: read
@@ -22,12 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: >-
-          ${{ fromJson(
-            inputs.php-matrix != '' &&
-            inputs.php-matrix ||
-            format('["{0}"]', inputs.php-version)
-          ) }}
+        php-version: ${{ fromJson(inputs.php-matrix) }}
 
     steps:
       # ------------------------------------------------------------

--- a/templates/.github/workflows/_psalm.yml
+++ b/templates/.github/workflows/_psalm.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   psalm:
+    name: Psalm (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/templates/.github/workflows/_tests.yml
+++ b/templates/.github/workflows/_tests.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   tests:
+    name: Tests (PHP ${{ inputs.php-version }})
     runs-on: ubuntu-latest
 
     steps:

--- a/templates/.github/workflows/_tests.yml
+++ b/templates/.github/workflows/_tests.yml
@@ -2,6 +2,11 @@ name: Tests
 
 on:
   workflow_call:
+    inputs:
+      php-version:
+        description: PHP version to use for tests
+        type: string
+        required: true
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -30,7 +35,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs.php-version }}
           coverage: xdebug
           extensions: mbstring, dom, json
 

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  PHP_MIN_VERSION: '8.2'
-  PHP_MAX_VERSION: '8.5'
-
 jobs:
   # ------------------------------------------------------------
   # YAML lint
@@ -60,8 +56,8 @@ jobs:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-min-version: ${{ env.PHP_MIN_VERSION }}
-      php-max-version: ${{ env.PHP_MAX_VERSION }}
+      php-matrix: >-
+        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -70,8 +66,8 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-min-version: ${{ env.PHP_MIN_VERSION }}
-      php-max-version: ${{ env.PHP_MAX_VERSION }}
+      php-matrix: >-
+        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -80,8 +76,8 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-min-version: ${{ env.PHP_MIN_VERSION }}
-      php-max-version: ${{ env.PHP_MAX_VERSION }}
+      php-matrix: >-
+        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
 
   # ------------------------------------------------------------
   # AST Metrics
@@ -99,6 +95,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
+      php-version: ${{ vars.PHP_MIN_VERSION }}
       ruleset: .piqule/phpmd.xml
 
   # ------------------------------------------------------------
@@ -109,13 +106,13 @@ jobs:
     uses: ./.github/workflows/_hadolint.yml
 
   # ------------------------------------------------------------
-  # PHPUnit + Coverage + Infection (только min)
+  # PHPUnit + Coverage + Infection (min PHP version only)
   # ------------------------------------------------------------
   tests:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: ${{ env.PHP_MIN_VERSION }}
+      php-version: ${{ vars.PHP_MIN_VERSION }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-matrix: >-
-        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
+      php-matrix: '["8.2","8.5"]'
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -66,8 +65,7 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: >-
-        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
+      php-matrix: '["8.2","8.5"]'
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -76,8 +74,7 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: >-
-        ["${{ vars.PHP_MIN_VERSION }}","${{ vars.PHP_MAX_VERSION }}"]
+      php-matrix: '["8.2","8.5"]'
 
   # ------------------------------------------------------------
   # AST Metrics
@@ -95,7 +92,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
-      php-version: ${{ vars.PHP_MIN_VERSION }}
+      php-version: '8.2'
       ruleset: .piqule/phpmd.xml
 
   # ------------------------------------------------------------
@@ -112,7 +109,7 @@ jobs:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: ${{ vars.PHP_MIN_VERSION }}
+      php-version: '8.2'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -1,13 +1,20 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
+
 permissions:
   contents: read
   pull-requests: read
+
+env:
+  PHP_MIN_VERSION: '8.2'
+  PHP_MAX_VERSION: '8.5'
+
 jobs:
   # ------------------------------------------------------------
   # YAML lint
@@ -17,6 +24,7 @@ jobs:
     uses: ./.github/workflows/_yamllint.yml
     with:
       config: .piqule/.yamllint.yml
+
   # ------------------------------------------------------------
   # GitHub Actions lint
   # ------------------------------------------------------------
@@ -26,6 +34,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-actionlint-${{ github.ref }}
       cancel-in-progress: true
+
   # ------------------------------------------------------------
   # Markdown lint
   # ------------------------------------------------------------
@@ -34,6 +43,7 @@ jobs:
     uses: ./.github/workflows/_markdownlint.yml
     with:
       config: .piqule/.markdownlint-cli2.jsonc
+
   # ------------------------------------------------------------
   # Typo checker
   # ------------------------------------------------------------
@@ -42,30 +52,37 @@ jobs:
     uses: ./.github/workflows/_typos.yml
     with:
       config: .piqule/_typos.toml
+
   # ------------------------------------------------------------
-  # PHP-CS-Fixer (matrix)
+  # PHP-CS-Fixer (min + max)
   # ------------------------------------------------------------
   php_cs_fixer:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-matrix: '["8.2","8.3","8.4","8.5"]'
+      php-min-version: ${{ env.PHP_MIN_VERSION }}
+      php-max-version: ${{ env.PHP_MAX_VERSION }}
+
   # ------------------------------------------------------------
-  # PHPStan (matrix)
+  # PHPStan (min + max)
   # ------------------------------------------------------------
   phpstan:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: '["8.2","8.3","8.4","8.5"]'
+      php-min-version: ${{ env.PHP_MIN_VERSION }}
+      php-max-version: ${{ env.PHP_MAX_VERSION }}
+
   # ------------------------------------------------------------
-  # Psalm (matrix)
+  # Psalm (min + max)
   # ------------------------------------------------------------
   psalm:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: '["8.2","8.3","8.4","8.5"]'
+      php-min-version: ${{ env.PHP_MIN_VERSION }}
+      php-max-version: ${{ env.PHP_MAX_VERSION }}
+
   # ------------------------------------------------------------
   # AST Metrics
   # ------------------------------------------------------------
@@ -74,6 +91,7 @@ jobs:
     uses: ./.github/workflows/_ast-metrics.yml
     with:
       config: .piqule/ast-metrics.yaml
+
   # ------------------------------------------------------------
   # PHPMD (numeric metrics)
   # ------------------------------------------------------------
@@ -82,21 +100,26 @@ jobs:
     uses: ./.github/workflows/_phpmd.yml
     with:
       ruleset: .piqule/phpmd.xml
+
   # ------------------------------------------------------------
   # Dockerfile lint
   # ------------------------------------------------------------
   hadolint:
     name: Hadolint
     uses: ./.github/workflows/_hadolint.yml
+
   # ------------------------------------------------------------
-  # PHPUnit + Coverage + Infection
+  # PHPUnit + Coverage + Infection (только min)
   # ------------------------------------------------------------
   tests:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
+    with:
+      php-version: ${{ env.PHP_MIN_VERSION }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+
   # ------------------------------------------------------------
   # PR size guard
   # ------------------------------------------------------------
@@ -106,8 +129,9 @@ jobs:
     uses: ./.github/workflows/_pr-size-checker.yml
     with:
       max_lines_changed: 250
+
   # ------------------------------------------------------------
-  # Release drafter (main only)
+  # Release drafter
   # ------------------------------------------------------------
   release_drafter:
     name: Release Drafter


### PR DESCRIPTION
- Centralized PHP version configuration in main CI workflow
- Switched reusable workflows to consume versions via inputs
- Reduced PHP matrices to min/max strategy for faster CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized PHP version bounds and switched PHP jobs to configurable min/max or JSON matrix.
  * Workflows updated to require explicit PHP inputs and use dynamic job names.
  * Added top-level workflow permissions and minor naming/permission tweaks.
* **New Features**
  * Added PHPMD execution and ruleset validation.
  * Added additional lint jobs (YAML/action/markdown/typos) and Hadolint.
  * Added PR size checker and adjusted release drafter behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->