### PR TITLE
Update Dockerfile Toolchain 

### DIFF
--- a/.github/workflows/_ast-metrics.yml
+++ b/.github/workflows/_ast-metrics.yml
@@ -1,4 +1,5 @@
 name: AST Metrics
+
 on:
   workflow_call:
     inputs:
@@ -6,28 +7,45 @@ on:
         description: Path to AST Metrics config file
         type: string
         required: true
+
 permissions:
   contents: read
+
 jobs:
   ast-metrics:
     name: AST Metrics lint
     runs-on: ubuntu-latest
+
+    env:
+      AST_METRICS_VERSION: "0.31.0"
+
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
-      # v6.0.1
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
       # ------------------------------------------------------------
-      # Install AST Metrics
+      # Install AST Metrics (official release binary)
       # ------------------------------------------------------------
       - name: Install AST Metrics
         run: |
-          # ast-metrics v0.31.0
-          AST_METRICS_URL="https://raw.githubusercontent.com/Halleck45/ast-metrics/d056054c4b05eac672a132f877de310ddc68bfed/scripts/download.sh"
-          curl -s "$AST_METRICS_URL" | bash
+          set -eux
+
+          ARCH="$(uname -m)"
+          case "$ARCH" in
+            x86_64)  BIN="ast-metrics_Linux_x86_64" ;;
+            aarch64) BIN="ast-metrics_Linux_arm64" ;;
+            *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+          esac
+
+          curl -sSfL \
+            "https://github.com/Halleck45/ast-metrics/releases/download/v${AST_METRICS_VERSION}/${BIN}" \
+            -o ast-metrics
+
           chmod +x ast-metrics
+
       # ------------------------------------------------------------
       # Run AST Metrics lint
       # ------------------------------------------------------------

--- a/.github/workflows/_markdownlint.yml
+++ b/.github/workflows/_markdownlint.yml
@@ -53,7 +53,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Install markdownlint-cli2
         if: steps.check.outputs.run == 'true'
-        run: npm install -g markdownlint-cli2
+        run: npm install -g markdownlint-cli2@0.20.0
       # ------------------------------------------------------------
       # Run markdownlint-cli2
       # ------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,32 +119,32 @@ RUN set -eux; \
       *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     \
-    # actionlint
+    # actionlint \
     curl -sSfL \
       "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin; \
     chmod +x /usr/local/bin/actionlint; \
     \
-    # markdownlint-cli2
+    # markdownlint-cli2 \
     npm install -g "markdownlint-cli2@${MARKDOWNLINT_VERSION}"; \
     npm cache clean --force; \
     \
     # yamllint (via pipx)
     pipx install "yamllint==${YAMLLINT_VERSION}"; \
     \
-    # hadolint
+    # hadolint \
     curl -sSfL \
       "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-linux-${HADOLINT_ARCH}" \
       -o /usr/local/bin/hadolint; \
     chmod +x /usr/local/bin/hadolint; \
     \
-    # typos
+    # typos \
     curl -sSfL \
       "https://github.com/crate-ci/typos/releases/download/v${TYPOS_VERSION}/typos-v${TYPOS_VERSION}-${TYPOS_ARCH}-unknown-linux-musl.tar.gz" \
       | tar -xz -C /usr/local/bin; \
     chmod +x /usr/local/bin/typos; \
     \
-    # AST Metrics
+    # AST Metrics \
     curl -sSfL \
       "https://github.com/Halleck45/ast-metrics/releases/download/v${AST_METRICS_VERSION}/ast-metrics_Linux_${AST_ARCH}" \
       -o /usr/local/bin/ast-metrics; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ RUN set -eux; \
     npm install -g "markdownlint-cli2@${MARKDOWNLINT_VERSION}"; \
     npm cache clean --force; \
     \
-    # yamllint (via pipx)
+    # yamllint (via pipx) \
     pipx install "yamllint==${YAMLLINT_VERSION}"; \
     \
     # hadolint \

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
         "test-coverage-html": "XDEBUG_MODE=coverage php -d memory_limit=512M ./vendor/bin/phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-html=.piqule/codecov/coverage-report",
         "infection": "XDEBUG_MODE=coverage php -d memory_limit=1G ./vendor/bin/infection --configuration=.piqule/infection/infection.json5 --threads=max",
         "phpstan": "phpstan analyse -c .piqule/phpstan/phpstan.neon",
-        "psalm": "psalm --config=.piqule/psalm/psalm.xml"
+        "psalm": "psalm --config=.piqule/psalm/psalm.xml",
+        "phpmd": "vendor/bin/phpmd src text .piqule/phpmd/phpmd.xml",
+        "ast-metrics": "ast-metrics lint --config .piqule/ast-metrics/ast-metrics.yaml"
     },
     "authors": [
         {

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+
+  "extends": [
+    "config:recommended"
+  ],
 
   "schedule": ["* 1-4 * * *"],
   "timezone": "UTC",
@@ -12,6 +15,20 @@
   "prConcurrentLimit": 3,
   "prHourlyLimit": 0,
 
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "composer": {
+    "enabled": true
+  },
+
+  "github-actions": {
+    "enabled": true
+  },
+  "dockerfile": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "description": "Pin GitHub Actions to commit SHA",
@@ -19,7 +36,7 @@
       "pinDigests": true
     },
     {
-      "description": "Auto-merge minor and patch dev dependencies",
+      "description": "Auto-merge patch and minor dev dependencies",
       "matchDepTypes": ["require-dev"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
@@ -39,39 +56,29 @@
     {
       "description": "Prioritize patch updates",
       "matchUpdateTypes": ["patch"],
-      "matchPackagePatterns": ["*"],
       "prPriority": 10
     },
     {
       "description": "Group CI toolchain updates",
       "groupName": "CI toolchain",
-      "matchManagers": ["custom.regex", "github-actions"]
+      "matchManagers": ["github-actions", "custom.regex"]
     }
   ],
-
-  "vulnerabilityAlerts": {
-    "labels": ["security"],
-    "enabled": true
-  },
-
-  "composer": { "enabled": true },
-  "github-actions": { "enabled": true },
-  "dockerfile": { "enabled": false },
-
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update Node.js version",
+      "description": "Update Node.js image version (Dockerfile)",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
-        "ARG NODE_VERSION=(?<currentValue>[^\\s]+)"
+        "ARG NODE_IMAGE=node:(?<currentValue>[^\\s]+)"
       ],
       "depNameTemplate": "node",
-      "datasourceTemplate": "node"
+      "datasourceTemplate": "docker"
     },
+
     {
       "customType": "regex",
-      "description": "Update actionlint version",
+      "description": "Update actionlint version (Dockerfile)",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
         "ARG ACTIONLINT_VERSION=(?<currentValue>[^\\s]+)"
@@ -79,9 +86,32 @@
       "depNameTemplate": "rhysd/actionlint",
       "datasourceTemplate": "github-releases"
     },
+
     {
       "customType": "regex",
-      "description": "Update markdownlint-cli2 (npm)",
+      "description": "Update hadolint version (Dockerfile)",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "ARG HADOLINT_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "hadolint/hadolint",
+      "datasourceTemplate": "github-releases"
+    },
+
+    {
+      "customType": "regex",
+      "description": "Update typos version (Dockerfile)",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "ARG TYPOS_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "crate-ci/typos",
+      "datasourceTemplate": "github-releases"
+    },
+
+    {
+      "customType": "regex",
+      "description": "Update markdownlint-cli2 version (Dockerfile)",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
         "ARG MARKDOWNLINT_VERSION=(?<currentValue>[^\\s]+)"
@@ -91,32 +121,24 @@
     },
     {
       "customType": "regex",
-      "description": "Update PHP-CS-Fixer version",
-      "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": [
-        "ARG PHP_CS_FIXER_VERSION=(?<currentValue>[^\\s]+)"
+      "description": "Update markdownlint-cli2 version in CI",
+      "fileMatch": [
+        "\\.github/workflows/.*\\.ya?ml$"
       ],
-      "depNameTemplate": "FriendsOfPHP/PHP-CS-Fixer",
-      "datasourceTemplate": "github-releases"
+      "matchStrings": [
+        "markdownlint-cli2@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "markdownlint-cli2",
+      "datasourceTemplate": "npm"
     },
     {
       "customType": "regex",
-      "description": "Update hadolint version",
+      "description": "Update AST Metrics version",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
-        "ARG HADOLINT_VERSION=(?<currentValue>[^\\s]+)"
+        "AST_METRICS_VERSION=(?<currentValue>[^\\s]+)"
       ],
-      "depNameTemplate": "hadolint/hadolint",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "description": "Update typos version",
-      "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": [
-        "ARG TYPOS_VERSION=(?<currentValue>[^\\s]+)"
-      ],
-      "depNameTemplate": "crate-ci/typos",
+      "depNameTemplate": "Halleck45/ast-metrics",
       "datasourceTemplate": "github-releases"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -136,7 +136,7 @@
       "description": "Update AST Metrics version",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
-        "AST_METRICS_VERSION=(?<currentValue>[^\\s]+)"
+        "ARG AST_METRICS_VERSION=(?<currentValue>[^\\s]+)"
       ],
       "depNameTemplate": "Halleck45/ast-metrics",
       "datasourceTemplate": "github-releases"

--- a/templates/.github/workflows/_ast-metrics.yml
+++ b/templates/.github/workflows/_ast-metrics.yml
@@ -1,4 +1,5 @@
 name: AST Metrics
+
 on:
   workflow_call:
     inputs:
@@ -6,28 +7,45 @@ on:
         description: Path to AST Metrics config file
         type: string
         required: true
+
 permissions:
   contents: read
+
 jobs:
   ast-metrics:
     name: AST Metrics lint
     runs-on: ubuntu-latest
+
+    env:
+      AST_METRICS_VERSION: "0.31.0"
+
     steps:
       # ------------------------------------------------------------
       # Checkout repository
       # ------------------------------------------------------------
-      # v6.0.1
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
       # ------------------------------------------------------------
-      # Install AST Metrics
+      # Install AST Metrics (official release binary)
       # ------------------------------------------------------------
       - name: Install AST Metrics
         run: |
-          # ast-metrics v0.31.0
-          AST_METRICS_URL="https://raw.githubusercontent.com/Halleck45/ast-metrics/d056054c4b05eac672a132f877de310ddc68bfed/scripts/download.sh"
-          curl -s "$AST_METRICS_URL" | bash
+          set -eux
+
+          ARCH="$(uname -m)"
+          case "$ARCH" in
+            x86_64)  BIN="ast-metrics_Linux_x86_64" ;;
+            aarch64) BIN="ast-metrics_Linux_arm64" ;;
+            *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+          esac
+
+          curl -sSfL \
+            "https://github.com/Halleck45/ast-metrics/releases/download/v${AST_METRICS_VERSION}/${BIN}" \
+            -o ast-metrics
+
           chmod +x ast-metrics
+
       # ------------------------------------------------------------
       # Run AST Metrics lint
       # ------------------------------------------------------------

--- a/templates/.github/workflows/_markdownlint.yml
+++ b/templates/.github/workflows/_markdownlint.yml
@@ -53,7 +53,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Install markdownlint-cli2
         if: steps.check.outputs.run == 'true'
-        run: npm install -g markdownlint-cli2
+        run: npm install -g markdownlint-cli2@0.20.0
       # ------------------------------------------------------------
       # Run markdownlint-cli2
       # ------------------------------------------------------------

--- a/templates/renovate.json
+++ b/templates/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+
+  "extends": [
+    "config:recommended"
+  ],
 
   "schedule": ["* 1-4 * * *"],
   "timezone": "UTC",
@@ -12,6 +15,20 @@
   "prConcurrentLimit": 3,
   "prHourlyLimit": 0,
 
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "composer": {
+    "enabled": true
+  },
+
+  "github-actions": {
+    "enabled": true
+  },
+  "dockerfile": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "description": "Pin GitHub Actions to commit SHA",
@@ -19,7 +36,7 @@
       "pinDigests": true
     },
     {
-      "description": "Auto-merge minor and patch dev dependencies",
+      "description": "Auto-merge patch and minor dev dependencies",
       "matchDepTypes": ["require-dev"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
@@ -39,39 +56,29 @@
     {
       "description": "Prioritize patch updates",
       "matchUpdateTypes": ["patch"],
-      "matchPackagePatterns": ["*"],
       "prPriority": 10
     },
     {
       "description": "Group CI toolchain updates",
       "groupName": "CI toolchain",
-      "matchManagers": ["custom.regex", "github-actions"]
+      "matchManagers": ["github-actions", "custom.regex"]
     }
   ],
-
-  "vulnerabilityAlerts": {
-    "labels": ["security"],
-    "enabled": true
-  },
-
-  "composer": { "enabled": true },
-  "github-actions": { "enabled": true },
-  "dockerfile": { "enabled": false },
-
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update Node.js version",
+      "description": "Update Node.js image version (Dockerfile)",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
-        "ARG NODE_VERSION=(?<currentValue>[^\\s]+)"
+        "ARG NODE_IMAGE=node:(?<currentValue>[^\\s]+)"
       ],
       "depNameTemplate": "node",
-      "datasourceTemplate": "node"
+      "datasourceTemplate": "docker"
     },
+
     {
       "customType": "regex",
-      "description": "Update actionlint version",
+      "description": "Update actionlint version (Dockerfile)",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
         "ARG ACTIONLINT_VERSION=(?<currentValue>[^\\s]+)"
@@ -79,9 +86,32 @@
       "depNameTemplate": "rhysd/actionlint",
       "datasourceTemplate": "github-releases"
     },
+
     {
       "customType": "regex",
-      "description": "Update markdownlint-cli2 (npm)",
+      "description": "Update hadolint version (Dockerfile)",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "ARG HADOLINT_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "hadolint/hadolint",
+      "datasourceTemplate": "github-releases"
+    },
+
+    {
+      "customType": "regex",
+      "description": "Update typos version (Dockerfile)",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "ARG TYPOS_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "crate-ci/typos",
+      "datasourceTemplate": "github-releases"
+    },
+
+    {
+      "customType": "regex",
+      "description": "Update markdownlint-cli2 version (Dockerfile)",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
         "ARG MARKDOWNLINT_VERSION=(?<currentValue>[^\\s]+)"
@@ -91,32 +121,24 @@
     },
     {
       "customType": "regex",
-      "description": "Update PHP-CS-Fixer version",
-      "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": [
-        "ARG PHP_CS_FIXER_VERSION=(?<currentValue>[^\\s]+)"
+      "description": "Update markdownlint-cli2 version in CI",
+      "fileMatch": [
+        "\\.github/workflows/.*\\.ya?ml$"
       ],
-      "depNameTemplate": "FriendsOfPHP/PHP-CS-Fixer",
-      "datasourceTemplate": "github-releases"
+      "matchStrings": [
+        "markdownlint-cli2@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "markdownlint-cli2",
+      "datasourceTemplate": "npm"
     },
     {
       "customType": "regex",
-      "description": "Update hadolint version",
+      "description": "Update AST Metrics version",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
-        "ARG HADOLINT_VERSION=(?<currentValue>[^\\s]+)"
+        "ARG AST_METRICS_VERSION=(?<currentValue>[^\\s]+)"
       ],
-      "depNameTemplate": "hadolint/hadolint",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "description": "Update typos version",
-      "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": [
-        "ARG TYPOS_VERSION=(?<currentValue>[^\\s]+)"
-      ],
-      "depNameTemplate": "crate-ci/typos",
+      "depNameTemplate": "Halleck45/ast-metrics",
       "datasourceTemplate": "github-releases"
     }
   ]


### PR DESCRIPTION
- Updated Dockerfile with refreshed linters and composer tools
- Updated AST Metrics installation to use release binaries
- Aligned markdownlint and yamllint handling
- Adjusted renovate rules for Dockerfile-managed versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Architecture-aware tooling installs and a configurable AST Metrics lint step.
  * Composer scripts added to run PHPMD and AST Metrics.

* **Chores**
  * Pin markdownlint-cli2 to a specific version for deterministic checks.
  * Convert to a parameterized multi-stage container build with centralized tooling and a non-root runtime.
  * Expand Renovate automation to cover CI workflows, Dockerfile tooling and version updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->