### PR TITLE
Remove composer from Docker image 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-matrix: '["8.2","8.5"]'
+      php-matrix: '["8.3","8.5"]'
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -65,7 +65,7 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: '["8.2","8.5"]'
+      php-matrix: '["8.3","8.5"]'
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -74,7 +74,7 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: '["8.2","8.5"]'
+      php-matrix: '["8.3","8.5"]'
 
   # ------------------------------------------------------------
   # AST Metrics
@@ -92,7 +92,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
-      php-version: '8.2'
+      php-version: '8.3'
       ruleset: .piqule/phpmd/phpmd.xml
 
   # ------------------------------------------------------------
@@ -109,7 +109,7 @@ jobs:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: '8.2'
+      php-version: '8.3'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,15 @@ RUN set -eux; \
     esac; \
     \
     # -------------------------------------------------------- \
+    # Composer (verified installer) \
+    # -------------------------------------------------------- \
+    curl -sS https://getcomposer.org/installer | php -- \
+        --install-dir=/usr/local/bin \
+        --filename=composer; \
+    export COMPOSER_ALLOW_SUPERUSER=1; \
+    export COMPOSER_HOME=/usr/local/composer; \
+    \
+    # -------------------------------------------------------- \
     # actionlint \
     # -------------------------------------------------------- \
     curl -sSfL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,6 @@ ARG YAMLLINT_VERSION=1.37.1
 ARG TYPOS_VERSION=1.41.0
 
 # ============================================================
-# Composer tools
-# ============================================================
-ARG PHP_CS_FIXER_VERSION=3.92.3
-ARG PHPUNIT_VERSION=11.5.46
-ARG INFECTION_VERSION=0.32.0
-ARG PHPSTAN_VERSION=2.1.33
-ARG PSALM_VERSION=6.14.3
-ARG PHPMD_VERSION=2.15.0
-
-# ============================================================
 # AST Metrics
 # ============================================================
 ARG AST_METRICS_VERSION=0.31.0
@@ -55,14 +45,6 @@ ARG HADOLINT_VERSION
 ARG MARKDOWNLINT_VERSION
 ARG YAMLLINT_VERSION
 ARG TYPOS_VERSION
-
-ARG PHP_CS_FIXER_VERSION
-ARG PHPUNIT_VERSION
-ARG INFECTION_VERSION
-ARG PHPSTAN_VERSION
-ARG PSALM_VERSION
-ARG PHPMD_VERSION
-
 ARG AST_METRICS_VERSION
 
 # ------------------------------------------------------------
@@ -76,9 +58,9 @@ ENV PATH="/usr/local/bin:/usr/local/lib/node_modules/.bin:${PATH}"
 # ------------------------------------------------------------
 RUN set -eux; \
     \
-    # --------------------------------------------------------
-    # System packages
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # System packages \
+    # -------------------------------------------------------- \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -96,14 +78,14 @@ RUN set -eux; \
         libonig-dev; \
     rm -rf /var/lib/apt/lists/*; \
     \
-    # --------------------------------------------------------
-    # PHP extensions
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # PHP extensions \
+    # -------------------------------------------------------- \
     docker-php-ext-install intl zip mbstring; \
     \
-    # --------------------------------------------------------
-    # Architecture detection
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # Architecture detection \
+    # -------------------------------------------------------- \
     ARCH="$(uname -m)"; \
     case "$ARCH" in \
       x86_64) \
@@ -119,74 +101,52 @@ RUN set -eux; \
       *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     \
-    # --------------------------------------------------------
-    # Composer (verified installer)
-    # --------------------------------------------------------
-    curl -sS https://getcomposer.org/installer | php -- \
-        --install-dir=/usr/local/bin \
-        --filename=composer; \
-    export COMPOSER_ALLOW_SUPERUSER=1; \
-    export COMPOSER_HOME=/usr/local/composer; \
-    \
-    # --------------------------------------------------------
-    # actionlint
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # actionlint \
+    # -------------------------------------------------------- \
     curl -sSfL \
       "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin; \
     chmod +x /usr/local/bin/actionlint; \
     \
-    # --------------------------------------------------------
-    # markdownlint-cli2
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # markdownlint-cli2 \
+    # -------------------------------------------------------- \
     npm install -g "markdownlint-cli2@${MARKDOWNLINT_VERSION}"; \
     npm cache clean --force; \
     \
-    # --------------------------------------------------------
-    # yamllint (pipx)
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # yamllint (pipx) \
+    # -------------------------------------------------------- \
     pipx install "yamllint==${YAMLLINT_VERSION}"; \
     \
-    # --------------------------------------------------------
-    # hadolint
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # hadolint \
+    # -------------------------------------------------------- \
     curl -sSfL \
       "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-linux-${HADOLINT_ARCH}" \
       -o /usr/local/bin/hadolint; \
     chmod +x /usr/local/bin/hadolint; \
     \
-    # --------------------------------------------------------
-    # typos
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # typos \
+    # -------------------------------------------------------- \
     curl -sSfL \
       "https://github.com/crate-ci/typos/releases/download/v${TYPOS_VERSION}/typos-v${TYPOS_VERSION}-${TYPOS_ARCH}-unknown-linux-musl.tar.gz" \
       | tar -xz -C /usr/local/bin; \
     chmod +x /usr/local/bin/typos; \
     \
-    # --------------------------------------------------------
-    # AST Metrics
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # AST Metrics \
+    # -------------------------------------------------------- \
     curl -sSfL \
       "https://github.com/Halleck45/ast-metrics/releases/download/v${AST_METRICS_VERSION}/ast-metrics_Linux_${AST_ARCH}" \
       -o /usr/local/bin/ast-metrics; \
     chmod +x /usr/local/bin/ast-metrics; \
     \
-    # --------------------------------------------------------
-    # Composer global tools
-    # --------------------------------------------------------
-    composer global config --no-plugins allow-plugins.infection/extension-installer true; \
-    composer global require --no-interaction --no-progress --prefer-dist \
-        friendsofphp/php-cs-fixer:${PHP_CS_FIXER_VERSION} \
-        phpunit/phpunit:${PHPUNIT_VERSION} \
-        phpstan/phpstan:${PHPSTAN_VERSION} \
-        vimeo/psalm:${PSALM_VERSION} \
-        phpmd/phpmd:${PHPMD_VERSION} \
-        infection/infection:${INFECTION_VERSION}; \
-    composer clear-cache; \
-    \
-    # --------------------------------------------------------
-    # Runtime user
-    # --------------------------------------------------------
+    # -------------------------------------------------------- \
+    # Runtime user \
+    # -------------------------------------------------------- \
     useradd --uid 1000 --create-home --shell /bin/bash appuser
 
 # ============================================================

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ and helps avoid configuration drift across repositories.
 
 Add Piqule as a development dependency:
 
-```
+```bash
 composer require --dev haspadar/piqule
 ```
 
@@ -54,9 +54,9 @@ composer require --dev haspadar/piqule
 
 ## Configuration synchronization
 
-Piqule manages project configuration files via an explicit synchronization step.
+Piqule manages project configuration files via an explicit synchronization step:
 
-```
+```bash
 bin/piqule.php sync
 ```
 
@@ -72,13 +72,11 @@ During synchronization:
 Piqule does **not** merge configuration files automatically.
 If local changes are overwritten, merging must be done manually.
 
----
-
 ### Dry run mode
 
 To preview changes without modifying files, run:
 
-```
+```bash
 bin/piqule.php sync --dry-run
 ```
 
@@ -87,13 +85,68 @@ allowing verification before applying changes.
 
 ---
 
-## Design principles
+## PHP tooling (copy-paste)
 
-- **Template-driven** — configuration is generated from canonical sources
-- **Managed, not merged** — files are overwritten deterministically
-- **Explicit ownership** — local modifications are intentional and manual
-- **Repeatable setup** — the same command produces the same layout everywhere
-- **Low noise** — tooling is curated to avoid redundant checks
+Piqule synchronizes configuration files, but PHP developer tools are installed
+**per-project** via Composer.
+
+This keeps tool versions under project control and avoids hidden dependencies
+inside the Docker image.
+
+### 1) Install required Composer tools
+
+Copy and run:
+
+```bash
+composer require --dev \
+  friendsofphp/php-cs-fixer \
+  phpunit/phpunit \
+  phpstan/phpstan \
+  vimeo/psalm \
+  phpmd/phpmd \
+  infection/infection
+```
+
+### 2) Add Composer scripts
+
+Copy this section into your `composer.json`:
+
+```json
+{
+  "scripts": {
+    "format": "php-cs-fixer fix --config=.piqule/php-cs-fixer/php-cs-fixer.project.php --cache-file=.piqule/php-cs-fixer/.php-cs-fixer.cache",
+    "format-check": "php-cs-fixer fix --config=.piqule/php-cs-fixer/php-cs-fixer.project.php --cache-file=.piqule/php-cs-fixer/.php-cs-fixer.cache --dry-run --diff",
+    "test": "phpunit -c .piqule/phpunit/phpunit.xml --order-by=random --random-order-seed=$(date +%s)",
+    "test-coverage": "XDEBUG_MODE=coverage php -d memory_limit=512M ./vendor/bin/phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-text --coverage-clover=.piqule/codecov/coverage.xml",
+    "test-coverage-html": "XDEBUG_MODE=coverage php -d memory_limit=512M ./vendor/bin/phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-html=.piqule/codecov/coverage-report",
+    "infection": "XDEBUG_MODE=coverage php -d memory_limit=1G ./vendor/bin/infection --configuration=.piqule/infection/infection.json5 --threads=max",
+    "phpstan": "phpstan analyse -c .piqule/phpstan/phpstan.neon",
+    "psalm": "psalm --config=.piqule/psalm/psalm.xml",
+    "phpmd": "vendor/bin/phpmd src text .piqule/phpmd/phpmd.xml",
+    "ast-metrics": "ast-metrics lint --config .piqule/ast-metrics/ast-metrics.yaml"
+  }
+}
+```
+
+## 3) Docker image
+
+Piqule includes a Dockerfile that builds a Docker image with
+infrastructure-level linters and AST Metrics.
+
+The Docker image contains:
+
+- actionlint
+- hadolint
+- markdownlint-cli2
+- yamllint
+- typos
+- ast-metrics
+
+The Docker image is provided as a **ready-to-use local environment**
+for running linters and AST Metrics without installing them on the host system.
+
+Usage of the Docker image is optional and independent of the CI workflows.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -116,19 +116,22 @@ Copy this section into your `composer.json`:
   "scripts": {
     "format": "php-cs-fixer fix --config=.piqule/php-cs-fixer/php-cs-fixer.project.php --cache-file=.piqule/php-cs-fixer/.php-cs-fixer.cache",
     "format-check": "php-cs-fixer fix --config=.piqule/php-cs-fixer/php-cs-fixer.project.php --cache-file=.piqule/php-cs-fixer/.php-cs-fixer.cache --dry-run --diff",
-    "test": "phpunit -c .piqule/phpunit/phpunit.xml --order-by=random --random-order-seed=$(date +%s)",
-    "test-coverage": "XDEBUG_MODE=coverage php -d memory_limit=512M ./vendor/bin/phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-text --coverage-clover=.piqule/codecov/coverage.xml",
-    "test-coverage-html": "XDEBUG_MODE=coverage php -d memory_limit=512M ./vendor/bin/phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-html=.piqule/codecov/coverage-report",
-    "infection": "XDEBUG_MODE=coverage php -d memory_limit=1G ./vendor/bin/infection --configuration=.piqule/infection/infection.json5 --threads=max",
+    "test": "phpunit -c .piqule/phpunit/phpunit.xml --order-by=random",
+    "test-coverage": "XDEBUG_MODE=coverage php -d memory_limit=512M phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-text --coverage-clover=.piqule/codecov/coverage.xml",
+    "test-coverage-html": "XDEBUG_MODE=coverage php -d memory_limit=512M phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-html=.piqule/codecov/coverage-report",
+    "infection": "XDEBUG_MODE=coverage php -d memory_limit=1G infection --configuration=.piqule/infection/infection.json5 --threads=max",
     "phpstan": "phpstan analyse -c .piqule/phpstan/phpstan.neon",
     "psalm": "psalm --config=.piqule/psalm/psalm.xml",
-    "phpmd": "vendor/bin/phpmd src text .piqule/phpmd/phpmd.xml",
+    "phpmd": "phpmd src text .piqule/phpmd/phpmd.xml",
     "ast-metrics": "ast-metrics lint --config .piqule/ast-metrics/ast-metrics.yaml"
   }
 }
 ```
 
-## 3) Docker image
+> Notes:
+> - `ast-metrics` is provided by the Piqule Docker image and is not installed locally.
+
+### 3) Docker image
 
 Piqule includes a Dockerfile that builds a Docker image with
 infrastructure-level linters and AST Metrics.
@@ -144,9 +147,14 @@ The Docker image contains:
 
 The Docker image is provided as a **ready-to-use local environment**
 for running linters and AST Metrics without installing them on the host system.
-
 Usage of the Docker image is optional and independent of the CI workflows.
 
+Example local usage:
+
+```bash
+docker build -t piqule .
+docker run --rm -v "$PWD:/app" -w /app piqule markdownlint-cli2 "**/*.md"
+```
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-      "php": ">=8.2"
+      "php": ">=8.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.91",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0593ff889df2c7ca0b98243ba4293857",
+    "content-hash": "aa12876caef31071ee3b23b6ae8ff712",
     "packages": [],
     "packages-dev": [
         {
@@ -1536,16 +1536,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.92.3",
+            "version": "v3.92.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "2ba8f5a60f6f42fb65758cfb3768434fa2d1c7e8"
+                "reference": "9e7488b19403423e02e8403cc1eb596baf4673b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/2ba8f5a60f6f42fb65758cfb3768434fa2d1c7e8",
-                "reference": "2ba8f5a60f6f42fb65758cfb3768434fa2d1c7e8",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/9e7488b19403423e02e8403cc1eb596baf4673b0",
+                "reference": "9e7488b19403423e02e8403cc1eb596baf4673b0",
                 "shasum": ""
             },
             "require": {
@@ -1577,17 +1577,17 @@
             },
             "require-dev": {
                 "facile-it/paraunit": "^1.3.1 || ^2.7",
-                "infection/infection": "^0.31.0",
-                "justinrainbow/json-schema": "^6.5",
-                "keradus/cli-executor": "^2.2",
+                "infection/infection": "^0.31",
+                "justinrainbow/json-schema": "^6.6",
+                "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
-                "phpunit/phpunit": "^9.6.25 || ^10.5.53 || ^11.5.34",
+                "phpunit/phpunit": "^9.6.31 || ^10.5.60 || ^11.5.46",
                 "symfony/polyfill-php85": "^1.33",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.24 || ^7.3.2 || ^8.0",
-                "symfony/yaml": "^5.4.45 || ^6.4.24 || ^7.3.2 || ^8.0"
+                "symfony/var-dumper": "^5.4.48 || ^6.4.26 || ^7.4.0 || ^8.0",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -1628,7 +1628,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.92.3"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.92.4"
             },
             "funding": [
                 {
@@ -1636,7 +1636,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-18T10:45:02+00:00"
+            "time": "2026-01-04T00:38:52+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -1995,16 +1995,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.6.3",
+            "version": "6.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "134e98916fa2f663afa623970af345cd788e8967"
+                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/134e98916fa2f663afa623970af345cd788e8967",
-                "reference": "134e98916fa2f663afa623970af345cd788e8967",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2eeb75d21cf73211335888e7f5e6fd7440723ec7",
+                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7",
                 "shasum": ""
             },
             "require": {
@@ -2064,9 +2064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.3"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.4"
             },
-            "time": "2025-12-02T10:21:33+00:00"
+            "time": "2025-12-19T15:01:32+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -4520,16 +4520,16 @@
         },
         {
             "name": "sanmai/di-container",
-            "version": "0.1.5",
+            "version": "0.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/di-container.git",
-                "reference": "355534ad7970fc7dab4211ecaf2da5c546855ee8"
+                "reference": "f7ea6a00692608f785fc0eabb1c54f5349d973e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/di-container/zipball/355534ad7970fc7dab4211ecaf2da5c546855ee8",
-                "reference": "355534ad7970fc7dab4211ecaf2da5c546855ee8",
+                "url": "https://api.github.com/repos/sanmai/di-container/zipball/f7ea6a00692608f785fc0eabb1c54f5349d973e9",
+                "reference": "f7ea6a00692608f785fc0eabb1c54f5349d973e9",
                 "shasum": ""
             },
             "require": {
@@ -4583,7 +4583,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sanmai/di-container/issues",
-                "source": "https://github.com/sanmai/di-container/tree/0.1.5"
+                "source": "https://github.com/sanmai/di-container/tree/0.1.8"
             },
             "funding": [
                 {
@@ -4591,7 +4591,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-04T09:43:58+00:00"
+            "time": "2026-01-03T14:10:40+00:00"
         },
         {
             "name": "sanmai/duoclock",
@@ -5975,16 +5975,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.1",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e"
+                "reference": "732a9ca6cd9dfd940c639062d5edbde2f6727fb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/732a9ca6cd9dfd940c639062d5edbde2f6727fb6",
+                "reference": "732a9ca6cd9dfd940c639062d5edbde2f6727fb6",
                 "shasum": ""
             },
             "require": {
@@ -6049,7 +6049,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.1"
+                "source": "https://github.com/symfony/console/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -6069,7 +6069,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T15:23:39+00:00"
+            "time": "2025-12-23T14:50:43+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -6455,16 +6455,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.0",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd"
+                "reference": "fffe05569336549b20a1be64250b40516d6e8d06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/340b9ed7320570f319028a2cbec46d40535e94bd",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/fffe05569336549b20a1be64250b40516d6e8d06",
+                "reference": "fffe05569336549b20a1be64250b40516d6e8d06",
                 "shasum": ""
             },
             "require": {
@@ -6499,7 +6499,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.0"
+                "source": "https://github.com/symfony/finder/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -6519,7 +6519,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T05:42:40+00:00"
+            "time": "2025-12-23T14:50:43+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -7253,16 +7253,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.0",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8"
+                "reference": "2f8e1a6cdf590ca63715da4d3a7a3327404a523f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
-                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/2f8e1a6cdf590ca63715da4d3a7a3327404a523f",
+                "reference": "2f8e1a6cdf590ca63715da4d3a7a3327404a523f",
                 "shasum": ""
             },
             "require": {
@@ -7294,7 +7294,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.0"
+                "source": "https://github.com/symfony/process/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -7314,7 +7314,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-16T11:21:06+00:00"
+            "time": "2025-12-19T10:00:43+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -8017,7 +8017,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2"
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     name: PHP-CS-Fixer
     uses: ./.github/workflows/_php-cs-fixer.yml
     with:
-      php-matrix: '["8.2","8.5"]'
+      php-matrix: '["8.3","8.5"]'
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -65,7 +65,7 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: '["8.2","8.5"]'
+      php-matrix: '["8.3","8.5"]'
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -74,7 +74,7 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: '["8.2","8.5"]'
+      php-matrix: '["8.3","8.5"]'
 
   # ------------------------------------------------------------
   # AST Metrics
@@ -92,7 +92,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
-      php-version: '8.2'
+      php-version: '8.3'
       ruleset: .piqule/phpmd/phpmd.xml
 
   # ------------------------------------------------------------
@@ -109,7 +109,7 @@ jobs:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: '8.2'
+      php-version: '8.3'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}


### PR DESCRIPTION
- Removed Composer and PHP developer tools from Docker image
- Clarified Docker image responsibility and PHP tooling setup in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed bundled Composer-based dev tools from the Docker image.
  * Bumped minimum PHP requirement to >=8.3 and updated CI matrices/workflows accordingly.

* **Documentation**
  * Improved code block formatting and added a detailed PHP tooling guide with per-project Composer examples, composer.json scripts, Docker image notes, and a dry-run synchronization example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->