### PR TITLE
Use AST Metrics CI mode as a hard quality gate 

### DIFF
--- a/.github/workflows/_ast-metrics.yml
+++ b/.github/workflows/_ast-metrics.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      AST_METRICS_VERSION: "0.31.0"
+      AST_METRICS_VERSION: "0.31.1-haspadar.1"
 
     steps:
       # ------------------------------------------------------------
@@ -41,7 +41,7 @@ jobs:
           esac
 
           curl -sSfL \
-            "https://github.com/Halleck45/ast-metrics/releases/download/v${AST_METRICS_VERSION}/${BIN}" \
+            "https://github.com/haspadar/ast-metrics/releases/download/v${AST_METRICS_VERSION}/${BIN}" \
             -o ast-metrics
 
           chmod +x ast-metrics

--- a/.github/workflows/_ast-metrics.yml
+++ b/.github/workflows/_ast-metrics.yml
@@ -53,4 +53,4 @@ jobs:
         env:
           AST_METRICS_CONFIG: ${{ inputs.config }}
         run: |
-          ./ast-metrics lint --config "$AST_METRICS_CONFIG"
+          ./ast-metrics ci --config "$AST_METRICS_CONFIG"

--- a/.github/workflows/_ast-metrics.yml
+++ b/.github/workflows/_ast-metrics.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   ast-metrics:
-    name: AST Metrics lint
+    name: AST Metrics
     runs-on: ubuntu-latest
 
     env:
@@ -47,9 +47,9 @@ jobs:
           chmod +x ast-metrics
 
       # ------------------------------------------------------------
-      # Run AST Metrics lint
+      # Run AST Metrics
       # ------------------------------------------------------------
-      - name: Run AST Metrics lint
+      - name: Run AST Metrics
         env:
           AST_METRICS_CONFIG: ${{ inputs.config }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 
 /.piqule/codecov/coverage-report/
 /.piqule/codecov/coverage.xml
-/.piqule/infection/infection.log
-/.piqule/infection/infection-summary.log
+/.piqule/infection/*.log
+/.piqule/ast-metrics/reports/
+/metrics.txt

--- a/.piqule/ast-metrics/ast-metrics.yaml
+++ b/.piqule/ast-metrics/ast-metrics.yaml
@@ -1,11 +1,11 @@
+# ============================================================
 # AST Metrics quality policy
+# ============================================================
 
 sources:
-  # Production code only
   - src
 
 exclude:
-  # Third-party and non-production code
   - /vendor/
   - /tests/
   - /build/
@@ -13,31 +13,31 @@ exclude:
   - /var/
   - /node_modules/
 
-# Reports are disabled by default (metrics are used as a quality gate)
-reports: {}
+reports:
+  html: .piqule/ast-metrics/reports/html
+  markdown: .piqule/ast-metrics/reports/report.md
+  sarif: .piqule/ast-metrics/reports/report.sarif
+  json: .piqule/ast-metrics/reports/report.json
 
 requirements:
   rules:
-    # Fail the build on any rule violation
-    fail_on_error: true
-
-    # Maximum cyclomatic complexity per method
-    cyclomatic_complexity:
-      max: 10
-      exclude: []
-
-    # Maximum number of lines per file
-    volume:
-      loc:
-        max: 100
-        exclude: []
-
-    # Maximum number of outgoing dependencies per component
     architecture:
-      coupling:
-        efferent:
-          max: 5
+      max_afferent_coupling: 10
+      max_efferent_coupling: 10
+      min_maintainability: 70
+      no_circular_dependencies: true
+      max_responsibilities: 1
+      no_god_class: true
 
-    # Minimum maintainability index per component
-    maintainability:
-      min: 70
+    volume:
+      max_loc: 1000
+      max_logical_loc: 600
+      max_loc_by_method: 30
+      max_logical_loc_by_method: 20
+      max_methods_per_class: 10
+      max_public_methods: 7
+      max_parameters_per_method: 5
+      max_nested_blocks: 4
+
+    complexity:
+      max_cyclomatic: 10

--- a/.piqule/phpmd/phpmd.xml
+++ b/.piqule/phpmd/phpmd.xml
@@ -61,10 +61,10 @@
     <!-- Boolean argument flag -->
     <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
 
-    <!-- Excessive class complexity -->
+    <!-- Excessive class complexity (WMC) -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
         <properties>
-            <property name="minimum" value="50"/>
+            <property name="maximum" value="50"/>
         </properties>
     </rule>
 

--- a/.piqule/phpmd/phpmd.xml
+++ b/.piqule/phpmd/phpmd.xml
@@ -1,42 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Piqule PHPMD Ruleset" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Piqule PHPMD Ruleset"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+                             https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
     <description>
         Numeric-only PHPMD ruleset with intentionally strict thresholds
     </description>
+
     <!-- Cyclomatic complexity -->
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
         <properties>
             <property name="reportLevel" value="10"/>
         </properties>
     </rule>
+
     <!-- NPath complexity -->
     <rule ref="rulesets/codesize.xml/NPathComplexity">
         <properties>
             <property name="reportLevel" value="200"/>
         </properties>
     </rule>
+
     <!-- Method length -->
     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
         <properties>
             <property name="minimum" value="50"/>
         </properties>
     </rule>
+
     <!-- Class length -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
         <properties>
             <property name="minimum" value="200"/>
         </properties>
     </rule>
+
     <!-- Number of methods -->
     <rule ref="rulesets/codesize.xml/TooManyMethods">
         <properties>
             <property name="maxmethods" value="10"/>
         </properties>
     </rule>
-    <!-- Number of parameters -->
+
+    <!-- Too many fields -->
+    <rule ref="rulesets/codesize.xml/TooManyFields">
+        <properties>
+            <property name="maxfields" value="10"/>
+        </properties>
+    </rule>
+
+    <!-- Excessive parameter list -->
     <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
         <properties>
             <property name="minimum" value="5"/>
         </properties>
     </rule>
+
+    <!-- Boolean argument flag -->
+    <rule ref="rulesets/cleanCode.xml/BooleanArgumentFlag"/>
+
+    <!-- Excessive class complexity -->
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
+        <properties>
+            <property name="minimum" value="50"/>
+        </properties>
+    </rule>
+
 </ruleset>

--- a/.piqule/phpmd/phpmd.xml
+++ b/.piqule/phpmd/phpmd.xml
@@ -59,7 +59,7 @@
     </rule>
 
     <!-- Boolean argument flag -->
-    <rule ref="rulesets/cleanCode.xml/BooleanArgumentFlag"/>
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
 
     <!-- Excessive class complexity -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG TYPOS_VERSION=1.41.0
 # ============================================================
 # AST Metrics
 # ============================================================
-ARG AST_METRICS_VERSION=0.31.0
+ARG AST_METRICS_VERSION=0.31.1-haspadar.1
 
 # ============================================================
 # Node.js stage (source of node + npm)
@@ -149,7 +149,7 @@ RUN set -eux; \
     # AST Metrics \
     # -------------------------------------------------------- \
     curl -sSfL \
-      "https://github.com/Halleck45/ast-metrics/releases/download/v${AST_METRICS_VERSION}/ast-metrics_Linux_${AST_ARCH}" \
+      "https://github.com/haspadar/ast-metrics/releases/download/v${AST_METRICS_VERSION}/ast-metrics_Linux_${AST_ARCH}" \
       -o /usr/local/bin/ast-metrics; \
     chmod +x /usr/local/bin/ast-metrics; \
     \

--- a/templates/.github/workflows/_ast-metrics.yml
+++ b/templates/.github/workflows/_ast-metrics.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      AST_METRICS_VERSION: "0.31.0"
+      AST_METRICS_VERSION: "0.31.1-haspadar.1"
 
     steps:
       # ------------------------------------------------------------
@@ -41,7 +41,7 @@ jobs:
           esac
 
           curl -sSfL \
-            "https://github.com/Halleck45/ast-metrics/releases/download/v${AST_METRICS_VERSION}/${BIN}" \
+            "https://github.com/haspadar/ast-metrics/releases/download/v${AST_METRICS_VERSION}/${BIN}" \
             -o ast-metrics
 
           chmod +x ast-metrics

--- a/templates/.github/workflows/_ast-metrics.yml
+++ b/templates/.github/workflows/_ast-metrics.yml
@@ -53,4 +53,4 @@ jobs:
         env:
           AST_METRICS_CONFIG: ${{ inputs.config }}
         run: |
-          ./ast-metrics lint --config "$AST_METRICS_CONFIG"
+          ./ast-metrics ci --config "$AST_METRICS_CONFIG"

--- a/templates/.github/workflows/_ast-metrics.yml
+++ b/templates/.github/workflows/_ast-metrics.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   ast-metrics:
-    name: AST Metrics lint
+    name: AST Metrics
     runs-on: ubuntu-latest
 
     env:
@@ -47,9 +47,9 @@ jobs:
           chmod +x ast-metrics
 
       # ------------------------------------------------------------
-      # Run AST Metrics lint
+      # Run AST Metrics
       # ------------------------------------------------------------
-      - name: Run AST Metrics lint
+      - name: Run AST Metrics
         env:
           AST_METRICS_CONFIG: ${{ inputs.config }}
         run: |

--- a/templates/.piqule/ast-metrics/ast-metrics.yaml
+++ b/templates/.piqule/ast-metrics/ast-metrics.yaml
@@ -1,11 +1,11 @@
+# ============================================================
 # AST Metrics quality policy
+# ============================================================
 
 sources:
-  # Production code only
   - src
 
 exclude:
-  # Third-party and non-production code
   - /vendor/
   - /tests/
   - /build/
@@ -13,31 +13,31 @@ exclude:
   - /var/
   - /node_modules/
 
-# Reports are disabled by default (metrics are used as a quality gate)
-reports: {}
+reports:
+  html: .piqule/ast-metrics/reports/html
+  markdown: .piqule/ast-metrics/reports/report.md
+  sarif: .piqule/ast-metrics/reports/report.sarif
+  json: .piqule/ast-metrics/reports/report.json
 
 requirements:
   rules:
-    # Fail the build on any rule violation
-    fail_on_error: true
-
-    # Maximum cyclomatic complexity per method
-    cyclomatic_complexity:
-      max: 10
-      exclude: []
-
-    # Maximum number of lines per file
-    volume:
-      loc:
-        max: 100
-        exclude: []
-
-    # Maximum number of outgoing dependencies per component
     architecture:
-      coupling:
-        efferent:
-          max: 5
+      max_afferent_coupling: 10
+      max_efferent_coupling: 10
+      min_maintainability: 70
+      no_circular_dependencies: true
+      max_responsibilities: 1
+      no_god_class: true
 
-    # Minimum maintainability index per component
-    maintainability:
-      min: 70
+    volume:
+      max_loc: 1000
+      max_logical_loc: 600
+      max_loc_by_method: 30
+      max_logical_loc_by_method: 20
+      max_methods_per_class: 10
+      max_public_methods: 7
+      max_parameters_per_method: 5
+      max_nested_blocks: 4
+
+    complexity:
+      max_cyclomatic: 10

--- a/templates/.piqule/phpmd/phpmd.xml
+++ b/templates/.piqule/phpmd/phpmd.xml
@@ -61,10 +61,10 @@
     <!-- Boolean argument flag -->
     <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
 
-    <!-- Excessive class complexity -->
+    <!-- Excessive class complexity (WMC) -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
         <properties>
-            <property name="minimum" value="50"/>
+            <property name="maximum" value="50"/>
         </properties>
     </rule>
 

--- a/templates/.piqule/phpmd/phpmd.xml
+++ b/templates/.piqule/phpmd/phpmd.xml
@@ -1,42 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Piqule PHPMD Ruleset" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Piqule PHPMD Ruleset"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+                             https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
     <description>
         Numeric-only PHPMD ruleset with intentionally strict thresholds
     </description>
+
     <!-- Cyclomatic complexity -->
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
         <properties>
             <property name="reportLevel" value="10"/>
         </properties>
     </rule>
+
     <!-- NPath complexity -->
     <rule ref="rulesets/codesize.xml/NPathComplexity">
         <properties>
             <property name="reportLevel" value="200"/>
         </properties>
     </rule>
+
     <!-- Method length -->
     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
         <properties>
             <property name="minimum" value="50"/>
         </properties>
     </rule>
+
     <!-- Class length -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
         <properties>
             <property name="minimum" value="200"/>
         </properties>
     </rule>
+
     <!-- Number of methods -->
     <rule ref="rulesets/codesize.xml/TooManyMethods">
         <properties>
             <property name="maxmethods" value="10"/>
         </properties>
     </rule>
-    <!-- Number of parameters -->
+
+    <!-- Too many fields -->
+    <rule ref="rulesets/codesize.xml/TooManyFields">
+        <properties>
+            <property name="maxfields" value="10"/>
+        </properties>
+    </rule>
+
+    <!-- Excessive parameter list -->
     <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
         <properties>
             <property name="minimum" value="5"/>
         </properties>
     </rule>
+
+    <!-- Boolean argument flag -->
+    <rule ref="rulesets/cleanCode.xml/BooleanArgumentFlag"/>
+
+    <!-- Excessive class complexity -->
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
+        <properties>
+            <property name="minimum" value="50"/>
+        </properties>
+    </rule>
+
 </ruleset>

--- a/templates/.piqule/phpmd/phpmd.xml
+++ b/templates/.piqule/phpmd/phpmd.xml
@@ -59,7 +59,7 @@
     </rule>
 
     <!-- Boolean argument flag -->
-    <rule ref="rulesets/cleanCode.xml/BooleanArgumentFlag"/>
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
 
     <!-- Excessive class complexity -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">


### PR DESCRIPTION
- Updated AST Metrics workflow to use the `ci` command instead of `lint`
- Ensured CI fails on any requirement violation regardless of severity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI code‑metrics tooling to a new release and switched its download host; CI now runs the tool using the recommended step.
  * Broadened ignored metrics/log patterns to exclude additional generated reports and logs.
  * No user-facing application code or public APIs changed.

* **Style**
  * Expanded static analysis and quality gates with additional maintainability, complexity, coupling and volume checks and added structured report outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->