### PR TITLE
Add PhpMetrics quality gate entrypoint

### DIFF
--- a/.piqule/phpmetrics/rules.php
+++ b/.piqule/phpmetrics/rules.php
@@ -1,36 +1,29 @@
 <?php
 
 return [
-        'maintainability' => [
-                'min_index' => 70,
-        ],
-        'complexity' => [
-                'max_cyclomatic_per_method' => 10,
-                'max_weighted_methods_per_class' => 20,
-        ],
-        'size' => [
-                'max_loc_per_class' => 1000,
-                'max_logical_loc_per_class' => 600,
-                'max_logical_loc_per_method' => 20,
-        ],
-        'halstead' => [
-                'max_volume_per_method' => 1000,
-                'max_difficulty_per_method' => 15,
-                'max_effort_per_method' => 15000,
-                'max_bugs_per_method' => 0.5,
-        ],
-        'cohesion' => [
-                'max_lcom' => 1,
-        ],
-        'inheritance' => [
-                'max_depth' => 3,
-        ],
-        'structure' => [
-                'max_methods_per_class' => 10,
-        ],
-        'coupling' => [
-                'max_afferent' => 10,
-                'max_efferent' => 10,
-                'max_instability' => 0.8,
-        ],
+    'complexity' => [
+        'max_cyclomatic_per_method' => 10,
+        'max_weighted_methods_per_class' => 20,
+    ],
+    'size' => [
+        'max_loc_per_class' => 1000,
+        'max_logical_loc_per_class' => 600,
+        'max_logical_loc_per_method' => 20,
+    ],
+    'halstead' => [
+        'max_volume_per_method' => 1000,
+        'max_difficulty_per_method' => 15,
+        'max_effort_per_method' => 15000,
+        'max_bugs_per_method' => 0.5,
+    ],
+    'inheritance' => [
+        'max_depth' => 3,
+    ],
+    'structure' => [
+        'max_methods_per_class' => 10,
+    ],
+    'coupling' => [
+        'max_afferent' => 10,
+        'max_efferent' => 10,
+    ],
 ];

--- a/bin/phpmetrics.php
+++ b/bin/phpmetrics.php
@@ -1,0 +1,223 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$config = require __DIR__ . '/../.piqule/phpmetrics/rules.php';
+$report = json_decode(
+    file_get_contents(__DIR__ . '/../.piqule/phpmetrics/phpmetrics.json'),
+    true,
+    flags: JSON_THROW_ON_ERROR,
+);
+
+$violations = analyzeReport($report, $config);
+
+if ($violations !== []) {
+    renderViolationsGrouped($violations);
+    exit(1);
+}
+
+echo "✔ phpmetrics passed all thresholds\n";
+
+function analyzeReport(array $report, array $config): array
+{
+    $violations = [];
+
+    foreach ($report as $node) {
+        if (($node['_type'] ?? null) === 'Hal\\Metric\\ClassMetric') {
+            foreach (analyzeClass($node, $config) as $v) {
+                $violations[] = $v;
+            }
+        }
+
+        if (($node['_type'] ?? null) === 'Hal\\Metric\\ProjectMetric') {
+            foreach (analyzeProject($node, $config) as $v) {
+                $violations[] = $v;
+            }
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeClass(array $node, array $config): array
+{
+    $violations = [];
+    $class = $node['name'];
+
+    foreach (classRules() as $r) {
+        $limit = rule($config, $r['rule']);
+        if ($limit === null) {
+            continue;
+        }
+
+        $actual = $node[$r['metric']] ?? null;
+        if ($actual === null) {
+            continue;
+        }
+
+        $items = $r['type'] === 'min'
+            ? checkMin($class, $r['label'], $actual, $limit, path($r['rule']))
+            : checkMax($class, $r['label'], $actual, $limit, path($r['rule']));
+
+        foreach ($items as $v) {
+            $violations[] = $v;
+        }
+    }
+
+    foreach ($node['methods'] ?? [] as $method) {
+        foreach (analyzeMethod($class, $method, $config) as $v) {
+            $violations[] = $v;
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeMethod(string $class, array $method, array $config): array
+{
+    $violations = [];
+    $name = $method['name'];
+
+    foreach (methodRules() as $r) {
+        $limit = rule($config, $r['rule']);
+        if ($limit === null) {
+            continue;
+        }
+
+        foreach (
+            checkMax(
+                $class,
+                "Method {$name} {$r['label']}",
+                $method[$r['metric']] ?? 0,
+                $limit,
+                path($r['rule']),
+            ) as $v
+        ) {
+            $violations[] = $v;
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeProject(array $node, array $config): array
+{
+    if ($node['name'] !== 'tree') {
+        return [];
+    }
+
+    $maxDepth = rule($config, ['inheritance', 'max_depth']);
+    if ($maxDepth === null) {
+        return [];
+    }
+
+    if ($node['depthOfInheritanceTree'] > $maxDepth) {
+        return [[
+            'class'   => 'Project',
+            'message' => "Inheritance depth too high: got {$node['depthOfInheritanceTree']} (max: $maxDepth)",
+            'rule'    => 'inheritance.max_depth',
+        ]];
+    }
+
+    return [];
+}
+
+function classRules(): array
+{
+    return [
+        ['label' => 'Maintainability', 'metric' => 'mi', 'rule' => ['maintainability', 'min_index'], 'type' => 'min'],
+        ['label' => 'WMC', 'metric' => 'wmc', 'rule' => ['complexity', 'max_weighted_methods_per_class'], 'type' => 'max'],
+        ['label' => 'Cyclomatic complexity', 'metric' => 'ccnMethodMax', 'rule' => ['complexity', 'max_cyclomatic_per_method'], 'type' => 'max'],
+        ['label' => 'LOC', 'metric' => 'loc', 'rule' => ['size', 'max_loc_per_class'], 'type' => 'max'],
+        ['label' => 'LLOC', 'metric' => 'lloc', 'rule' => ['size', 'max_logical_loc_per_class'], 'type' => 'max'],
+        ['label' => 'Methods count', 'metric' => 'nbMethods', 'rule' => ['structure', 'max_methods_per_class'], 'type' => 'max'],
+        ['label' => 'Afferent coupling', 'metric' => 'afferentCoupling', 'rule' => ['coupling', 'max_afferent'], 'type' => 'max'],
+        ['label' => 'Efferent coupling', 'metric' => 'efferentCoupling', 'rule' => ['coupling', 'max_efferent'], 'type' => 'max'],
+        ['label' => 'Instability', 'metric' => 'instability', 'rule' => ['coupling', 'max_instability'], 'type' => 'max'],
+    ];
+}
+
+function methodRules(): array
+{
+    return [
+        ['label' => 'LLOC', 'metric' => 'lloc', 'rule' => ['size', 'max_logical_loc_per_method']],
+        ['label' => 'volume', 'metric' => 'volume', 'rule' => ['halstead', 'max_volume_per_method']],
+        ['label' => 'difficulty', 'metric' => 'difficulty', 'rule' => ['halstead', 'max_difficulty_per_method']],
+        ['label' => 'effort', 'metric' => 'effort', 'rule' => ['halstead', 'max_effort_per_method']],
+        ['label' => 'bugs', 'metric' => 'bugs', 'rule' => ['halstead', 'max_bugs_per_method']],
+    ];
+}
+
+function rule(array $config, array $path): mixed
+{
+    foreach ($path as $key) {
+        if (!array_key_exists($key, $config)) {
+            return null;
+        }
+        $config = $config[$key];
+    }
+
+    return $config;
+}
+
+function path(array $rule): string
+{
+    return implode('.', $rule);
+}
+
+function checkMax(
+    string $class,
+    string $label,
+    int|float $actual,
+    int|float|null $max,
+    string $rule,
+): array {
+    if ($max === null || $actual <= $max) {
+        return [];
+    }
+
+    return [[
+        'class'   => $class,
+        'message' => "$label too high: got $actual (max: $max)",
+        'rule'    => $rule,
+    ]];
+}
+
+function checkMin(
+    string $class,
+    string $label,
+    int|float|null $actual,
+    int|float|null $min,
+    string $rule,
+): array {
+    if ($actual === null || $min === null || $actual >= $min) {
+        return [];
+    }
+
+    return [[
+        'class'   => $class,
+        'message' => "$label too low: got $actual (min: $min)",
+        'rule'    => $rule,
+    ]];
+}
+
+function renderViolationsGrouped(array $violations): void
+{
+    $byClass = [];
+
+    foreach ($violations as $v) {
+        $byClass[$v['class']][] = $v;
+    }
+
+    ksort($byClass);
+
+    foreach ($byClass as $class => $items) {
+        fwrite(STDERR, "\nClass: $class\n");
+        foreach ($items as $v) {
+            fwrite(STDERR, " • {$v['message']} #{$v['rule']}\n");
+        }
+    }
+
+    fwrite(STDERR, "\n");
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1817,16 +1817,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.32.0",
+            "version": "0.32.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/infection/infection",
-                "reference": "71d4a12cbe62d79c06dce628b8a5fe234636424c"
+                "url": "https://github.com/infection/infection.git",
+                "reference": "b5c2dc7dd7615c90edf56924df09d39170c2817d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/71d4a12cbe62d79c06dce628b8a5fe234636424c",
-                "reference": "71d4a12cbe62d79c06dce628b8a5fe234636424c",
+                "url": "https://api.github.com/repos/infection/infection/zipball/b5c2dc7dd7615c90edf56924df09d39170c2817d",
+                "reference": "b5c2dc7dd7615c90edf56924df09d39170c2817d",
                 "shasum": ""
             },
             "require": {
@@ -1936,9 +1936,20 @@
                 "unit testing"
             ],
             "support": {
-                "issues": "https://github.com/infection/infection/issues"
+                "issues": "https://github.com/infection/infection/issues",
+                "source": "https://github.com/infection/infection/tree/0.32.1"
             },
-            "time": "2025-12-24T13:55:03+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-01-05T18:10:44+00:00"
         },
         {
             "name": "infection/mutator",

--- a/templates/.piqule/phpmetrics/rules.php
+++ b/templates/.piqule/phpmetrics/rules.php
@@ -1,36 +1,29 @@
 <?php
 
 return [
-        'maintainability' => [
-                'min_index' => 70,
-        ],
-        'complexity' => [
-                'max_cyclomatic_per_method' => 10,
-                'max_weighted_methods_per_class' => 20,
-        ],
-        'size' => [
-                'max_loc_per_class' => 1000,
-                'max_logical_loc_per_class' => 600,
-                'max_logical_loc_per_method' => 20,
-        ],
-        'halstead' => [
-                'max_volume_per_method' => 1000,
-                'max_difficulty_per_method' => 15,
-                'max_effort_per_method' => 15000,
-                'max_bugs_per_method' => 0.5,
-        ],
-        'cohesion' => [
-                'max_lcom' => 1,
-        ],
-        'inheritance' => [
-                'max_depth' => 3,
-        ],
-        'structure' => [
-                'max_methods_per_class' => 10,
-        ],
-        'coupling' => [
-                'max_afferent' => 10,
-                'max_efferent' => 10,
-                'max_instability' => 0.8,
-        ],
+    'complexity' => [
+        'max_cyclomatic_per_method' => 10,
+        'max_weighted_methods_per_class' => 20,
+    ],
+    'size' => [
+        'max_loc_per_class' => 1000,
+        'max_logical_loc_per_class' => 600,
+        'max_logical_loc_per_method' => 20,
+    ],
+    'halstead' => [
+        'max_volume_per_method' => 1000,
+        'max_difficulty_per_method' => 15,
+        'max_effort_per_method' => 15000,
+        'max_bugs_per_method' => 0.5,
+    ],
+    'inheritance' => [
+        'max_depth' => 3,
+    ],
+    'structure' => [
+        'max_methods_per_class' => 10,
+    ],
+    'coupling' => [
+        'max_afferent' => 10,
+        'max_efferent' => 10,
+    ],
 ];


### PR DESCRIPTION
- Added PhpMetrics verification entrypoint in bin/phpmetrics.php
- Removed LCOM from PhpMetrics quality gate evaluation
- Refactored PhpMetrics checks to avoid array_merge in loops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to validate PHP metrics reports, producing grouped violation output and non-zero exit status when issues are found.

* **Chores**
  * Relaxed several quality thresholds by removing specific maintainability, cohesion, and coupling limits from the metrics configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->