### PR TITLE
Add PHPMetrics to CI pipeline

### DIFF
--- a/.github/workflows/_php-cs-fixer.yml
+++ b/.github/workflows/_php-cs-fixer.yml
@@ -26,7 +26,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
@@ -52,7 +52,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/.github/workflows/_phpmetrics.yml
+++ b/.github/workflows/_phpmetrics.yml
@@ -1,0 +1,74 @@
+name: PHPMetrics
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  phpmetrics:
+    name: PHPMetrics
+    runs-on: ubuntu-latest
+
+    steps:
+      # ------------------------------------------------------------
+      # Checkout repository
+      # ------------------------------------------------------------
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      # ------------------------------------------------------------
+      # Check phpmetrics config existence
+      # ------------------------------------------------------------
+      - name: Check config exists
+        id: check
+        run: |
+          if [[ -f ".piqule/phpmetrics/rules.php" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ------------------------------------------------------------
+      # Skip when config is missing
+      # ------------------------------------------------------------
+      - name: Skip — no phpmetrics config
+        if: steps.check.outputs.run == 'false'
+        run: echo "Skipping PHPMetrics — no rules.php"
+
+      # ------------------------------------------------------------
+      # Setup PHP
+      # ------------------------------------------------------------
+      - name: Setup PHP
+        if: steps.check.outputs.run == 'true'
+        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      # ------------------------------------------------------------
+      # Install dependencies
+      # ------------------------------------------------------------
+      - name: Install dependencies
+        if: steps.check.outputs.run == 'true'
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      # ------------------------------------------------------------
+      # Run PhpMetrics (generate JSON only)
+      # ------------------------------------------------------------
+      - name: Run PhpMetrics
+        if: steps.check.outputs.run == 'true'
+        run: |
+          php -d error_reporting='E_ALL & ~E_DEPRECATED' \
+            vendor/bin/phpmetrics src \
+            --exclude=vendor,tests,build,bin,var,node_modules \
+            --report-json=.piqule/phpmetrics/phpmetrics.json
+
+      # ------------------------------------------------------------
+      # Enforce metrics rules (hard gate)
+      # ------------------------------------------------------------
+      - name: Enforce PHPMetrics rules
+        if: steps.check.outputs.run == 'true'
+        run: |
+          php .piqule/phpmetrics/phpmetrics.php

--- a/.github/workflows/_phpmetrics.yml
+++ b/.github/workflows/_phpmetrics.yml
@@ -16,7 +16,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
       # Check phpmetrics config existence
@@ -42,7 +42,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
           php-version: '8.3'
           coverage: none

--- a/.github/workflows/_phpmetrics.yml
+++ b/.github/workflows/_phpmetrics.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Enforce PHPMetrics rules
         if: steps.check.outputs.run == 'true'
         run: |
-          php .piqule/phpmetrics/phpmetrics.php
+          php .piqule/phpmetrics/verify.php

--- a/.github/workflows/_pmd-cpd.yml
+++ b/.github/workflows/_pmd-cpd.yml
@@ -27,7 +27,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
       # Setup Java (PMD requirement)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
       config: .piqule/ast-metrics/ast-metrics.yaml
 
   # ------------------------------------------------------------
+  # PHPMetrics (hard gate)
+  # ------------------------------------------------------------
+  phpmetrics:
+    name: PHPMetrics
+    uses: ./.github/workflows/_phpmetrics.yml
+
+  # ------------------------------------------------------------
   # PHPMD (numeric metrics)
   # ------------------------------------------------------------
   phpmd:

--- a/.piqule/phpmetrics/verify.php
+++ b/.piqule/phpmetrics/verify.php
@@ -3,9 +3,9 @@
 
 declare(strict_types=1);
 
-$config = require __DIR__ . '/../.piqule/phpmetrics/rules.php';
+$config = require __DIR__ . '/../../.piqule/phpmetrics/rules.php';
 $report = json_decode(
-    file_get_contents(__DIR__ . '/../.piqule/phpmetrics/phpmetrics.json'),
+    file_get_contents(__DIR__ . '/../../.piqule/phpmetrics/phpmetrics.json'),
     true,
     flags: JSON_THROW_ON_ERROR,
 );

--- a/.piqule/phpmetrics/verify.php
+++ b/.piqule/phpmetrics/verify.php
@@ -3,9 +3,9 @@
 
 declare(strict_types=1);
 
-$config = require __DIR__ . '/../../.piqule/phpmetrics/rules.php';
+$config = require __DIR__ . '/rules.php';
 $report = json_decode(
-    file_get_contents(__DIR__ . '/../../.piqule/phpmetrics/phpmetrics.json'),
+    file_get_contents(__DIR__ . '/phpmetrics.json'),
     true,
     flags: JSON_THROW_ON_ERROR,
 );

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Piqule
+# Opinionated PHP Quality Policies
 
 [![CI](https://github.com/haspadar/piqule/actions/workflows/ci.yml/badge.svg)](https://github.com/haspadar/piqule/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/haspadar/piqule/branch/main/graph/badge.svg)](https://codecov.io/gh/haspadar/piqule)
@@ -9,16 +9,13 @@
 [![Hits-of-Code](https://hitsofcode.com/github/haspadar/piqule?branch=main)](https://hitsofcode.com/github/haspadar/piqule/view?branch=main)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/haspadar/piqule?labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
-## Piqule (PHP Quality Laws)
+**Piqule** provides a distribution of PHP quality policies.
 
-**Piqule** is a managed quality stack for PHP projects.
+It delivers predefined static analysis rules, CI workflows, and tooling
+configurations by copying them into project repositories.
 
-It provides a curated set of static analysis tools, linters, and CI workflows,
-together with a synchronization mechanism that installs and updates
-project-level configuration files in a predictable and repeatable way.
-
-Piqule acts as a **single source of truth** for PHP project quality tooling
-and helps avoid configuration drift across repositories.
+Piqule defines a single source of truth for quality policies;
+conflicts and deviations are resolved explicitly through Git.
 
 ---
 
@@ -45,109 +42,49 @@ and helps avoid configuration drift across repositories.
 
 ## Installation
 
-Add Piqule as a development dependency:
+Piqule defines quality policies and configuration files.
+Actual analysis tools are installed explicitly per project.
+
+### 1) Install Piqule
 
 ```bash
 composer require --dev haspadar/piqule
+```
+
+### 2) Install PHP analysis tools
+
+```bash
+composer require --dev \
+friendsofphp/php-cs-fixer \
+phpunit/phpunit \
+phpstan/phpstan \
+vimeo/psalm \
+phpmd/phpmd \
+phpmetrics/phpmetrics \
+infection/infection
 ```
 
 ---
 
 ## Configuration synchronization
 
-Piqule manages project configuration files via an explicit synchronization step:
+Copies predefined configuration files into the project, overwriting existing ones.
+No merging is performed; conflicts are resolved via Git.
 
 ```bash
 bin/piqule.php sync
-```
-
-During synchronization:
-
-- canonical configurations are installed into the project workspace
-- files are written to fixed locations:
-    - Renovate configuration is placed in the project root
-    - tool configurations are placed in `.piqule/`
-    - CI workflows are placed in `.github/workflows/`
-- **existing files are overwritten**
-
-Piqule does **not** merge configuration files automatically.
-If local changes are overwritten, merging must be done manually.
-
-### Dry run mode
-
-To preview changes without modifying files, run:
-
-```bash
 bin/piqule.php sync --dry-run
 ```
 
-This mode shows what files would be created, updated, or overwritten,
-allowing verification before applying changes.
+## Composer scripts (optional)
 
----
+Piqule provides configuration files for PHP tooling.
+Composer scripts are project-specific and not enforced.
 
-## PHP tooling (copy-paste)
+A reference setup used in this repository:
+https://github.com/haspadar/piqule/blob/main/composer.json
 
-Piqule synchronizes configuration files, but PHP developer tools are installed
-**per-project** via Composer.
-
-This keeps tool versions under project control and avoids hidden dependencies
-inside the Docker image.
-
-### 1) Install required Composer tools
-
-Copy and run:
-
-```bash
-composer require --dev \
-  friendsofphp/php-cs-fixer \
-  phpunit/phpunit \
-  phpstan/phpstan \
-  vimeo/psalm \
-  phpmd/phpmd \
-  infection/infection
-```
-
-### 2) Add Composer scripts
-
-Copy this section into your `composer.json`:
-
-```json
-{
-  "scripts": {
-    "format": "php-cs-fixer fix --config=.piqule/php-cs-fixer/php-cs-fixer.project.php --cache-file=.piqule/php-cs-fixer/.php-cs-fixer.cache",
-    "format-check": "php-cs-fixer fix --config=.piqule/php-cs-fixer/php-cs-fixer.project.php --cache-file=.piqule/php-cs-fixer/.php-cs-fixer.cache --dry-run --diff",
-
-    "phpstan": "phpstan analyse -c .piqule/phpstan/phpstan.neon",
-    "psalm": "psalm --config=.piqule/psalm/psalm.xml",
-    "phpmd": "phpmd src text .piqule/phpmd/phpmd.xml",
-    "ast-metrics": "ast-metrics lint --config .piqule/ast-metrics/ast-metrics.yaml",
-    "cpd": "pmd cpd --language php --minimum-tokens 100 --dir src",
-
-    "test": "phpunit -c .piqule/phpunit/phpunit.xml --order-by=random",
-    "test-coverage": "XDEBUG_MODE=coverage php -d memory_limit=512M phpunit -c .piqule/phpunit/phpunit.xml --path-coverage --coverage-clover=.piqule/codecov/coverage.xml",
-    "infection": "XDEBUG_MODE=coverage php -d memory_limit=1G infection --configuration=.piqule/infection/infection.json5 --threads=max",
-
-    "fix": [
-      "@format"
-    ],
-    "check": [
-      "@format-check",
-      "@phpstan",
-      "@psalm",
-      "@phpmd",
-      "@ast-metrics",
-      "@cpd"
-    ],
-    "ci": [
-      "@check",
-      "@test"
-    ]
-  }
-}
-```
-
-### 3) Docker image
+## Docker image
 
 Piqule includes a Dockerfile that builds a Docker image with
 infrastructure-level linters and AST Metrics.
@@ -164,7 +101,7 @@ The Docker image contains:
 
 The Docker image is provided as a **ready-to-use local environment**
 for running linters and AST Metrics without installing them on the host system.
-Usage of the Docker image is optional and independent of the CI workflows.
+The Docker image is optional and independent of CI workflows.
 
 Example local usage:
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ast-metrics": "ast-metrics lint --config .piqule/ast-metrics/ast-metrics.yaml",
 
         "phpmetrics:generate": "php -d error_reporting='E_ALL & ~E_DEPRECATED' vendor/bin/phpmetrics src --exclude=vendor,tests,build,bin,var,node_modules --report-json=.piqule/phpmetrics/phpmetrics.json --report-html=.piqule/phpmetrics/html",
-        "phpmetrics:verify": "php bin/phpmetrics.php",
+        "phpmetrics:verify": "php .piqule/phpmetrics/verify.php",
         "phpmetrics:check": [
             "@phpmetrics:generate",
             "@phpmetrics:verify"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,14 @@
         "psalm": "psalm --config=.piqule/psalm/psalm.xml",
         "phpmd": "phpmd src text .piqule/phpmd/phpmd.xml",
         "ast-metrics": "ast-metrics lint --config .piqule/ast-metrics/ast-metrics.yaml",
-        "phpmetrics": "php -d error_reporting='E_ALL & ~E_DEPRECATED' vendor/bin/phpmetrics src --exclude=vendor,tests,build,bin,var,node_modules --report-json=.piqule/phpmetrics/phpmetrics.json --report-html=.piqule/phpmetrics/html",
+
+        "phpmetrics:generate": "php -d error_reporting='E_ALL & ~E_DEPRECATED' vendor/bin/phpmetrics src --exclude=vendor,tests,build,bin,var,node_modules --report-json=.piqule/phpmetrics/phpmetrics.json --report-html=.piqule/phpmetrics/html",
+        "phpmetrics:verify": "php bin/phpmetrics.php",
+        "phpmetrics:check": [
+            "@phpmetrics:generate",
+            "@phpmetrics:verify"
+        ],
+
         "cpd": "pmd cpd --language php --minimum-tokens 100 --dir src",
 
         "test": "phpunit -c .piqule/phpunit/phpunit.xml --order-by=random",

--- a/templates/.github/workflows/_php-cs-fixer.yml
+++ b/templates/.github/workflows/_php-cs-fixer.yml
@@ -26,7 +26,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
       # Check PHP-CS-Fixer config existence
@@ -52,7 +52,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/templates/.github/workflows/_phpmetrics.yml
+++ b/templates/.github/workflows/_phpmetrics.yml
@@ -1,0 +1,74 @@
+name: PHPMetrics
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  phpmetrics:
+    name: PHPMetrics
+    runs-on: ubuntu-latest
+
+    steps:
+      # ------------------------------------------------------------
+      # Checkout repository
+      # ------------------------------------------------------------
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      # ------------------------------------------------------------
+      # Check phpmetrics config existence
+      # ------------------------------------------------------------
+      - name: Check config exists
+        id: check
+        run: |
+          if [[ -f ".piqule/phpmetrics/rules.php" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ------------------------------------------------------------
+      # Skip when config is missing
+      # ------------------------------------------------------------
+      - name: Skip — no phpmetrics config
+        if: steps.check.outputs.run == 'false'
+        run: echo "Skipping PHPMetrics — no rules.php"
+
+      # ------------------------------------------------------------
+      # Setup PHP
+      # ------------------------------------------------------------
+      - name: Setup PHP
+        if: steps.check.outputs.run == 'true'
+        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      # ------------------------------------------------------------
+      # Install dependencies
+      # ------------------------------------------------------------
+      - name: Install dependencies
+        if: steps.check.outputs.run == 'true'
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      # ------------------------------------------------------------
+      # Run PhpMetrics (generate JSON only)
+      # ------------------------------------------------------------
+      - name: Run PhpMetrics
+        if: steps.check.outputs.run == 'true'
+        run: |
+          php -d error_reporting='E_ALL & ~E_DEPRECATED' \
+            vendor/bin/phpmetrics src \
+            --exclude=vendor,tests,build,bin,var,node_modules \
+            --report-json=.piqule/phpmetrics/phpmetrics.json
+
+      # ------------------------------------------------------------
+      # Enforce metrics rules (hard gate)
+      # ------------------------------------------------------------
+      - name: Enforce PHPMetrics rules
+        if: steps.check.outputs.run == 'true'
+        run: |
+          php .piqule/phpmetrics/phpmetrics.php

--- a/templates/.github/workflows/_phpmetrics.yml
+++ b/templates/.github/workflows/_phpmetrics.yml
@@ -16,7 +16,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
       # Check phpmetrics config existence
@@ -42,7 +42,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Setup PHP
         if: steps.check.outputs.run == 'true'
-        uses: shivammathur/setup-php@5efa2a774eb6c55954af5652a1f947afbc8dd282
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
           php-version: '8.3'
           coverage: none

--- a/templates/.github/workflows/_phpmetrics.yml
+++ b/templates/.github/workflows/_phpmetrics.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Enforce PHPMetrics rules
         if: steps.check.outputs.run == 'true'
         run: |
-          php .piqule/phpmetrics/phpmetrics.php
+          php .piqule/phpmetrics/verify.php

--- a/templates/.github/workflows/_pmd-cpd.yml
+++ b/templates/.github/workflows/_pmd-cpd.yml
@@ -27,7 +27,7 @@ jobs:
       # Checkout repository
       # ------------------------------------------------------------
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
       # Setup Java (PMD requirement)

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
       config: .piqule/ast-metrics/ast-metrics.yaml
 
   # ------------------------------------------------------------
+  # PHPMetrics (hard gate)
+  # ------------------------------------------------------------
+  phpmetrics:
+    name: PHPMetrics
+    uses: ./.github/workflows/_phpmetrics.yml
+
+  # ------------------------------------------------------------
   # PHPMD (numeric metrics)
   # ------------------------------------------------------------
   phpmd:

--- a/templates/.piqule/phpmetrics/verify.php
+++ b/templates/.piqule/phpmetrics/verify.php
@@ -3,9 +3,9 @@
 
 declare(strict_types=1);
 
-$config = require __DIR__ . '/../../.piqule/phpmetrics/rules.php';
+$config = require __DIR__ . '/rules.php';
 $report = json_decode(
-    file_get_contents(__DIR__ . '/../../.piqule/phpmetrics/phpmetrics.json'),
+    file_get_contents(__DIR__ . '/phpmetrics.json'),
     true,
     flags: JSON_THROW_ON_ERROR,
 );

--- a/templates/.piqule/phpmetrics/verify.php
+++ b/templates/.piqule/phpmetrics/verify.php
@@ -1,0 +1,223 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$config = require __DIR__ . '/../../.piqule/phpmetrics/rules.php';
+$report = json_decode(
+    file_get_contents(__DIR__ . '/../../.piqule/phpmetrics/phpmetrics.json'),
+    true,
+    flags: JSON_THROW_ON_ERROR,
+);
+
+$violations = analyzeReport($report, $config);
+
+if ($violations !== []) {
+    renderViolationsGrouped($violations);
+    exit(1);
+}
+
+echo "✔ phpmetrics passed all thresholds\n";
+
+function analyzeReport(array $report, array $config): array
+{
+    $violations = [];
+
+    foreach ($report as $node) {
+        if (($node['_type'] ?? null) === 'Hal\\Metric\\ClassMetric') {
+            foreach (analyzeClass($node, $config) as $v) {
+                $violations[] = $v;
+            }
+        }
+
+        if (($node['_type'] ?? null) === 'Hal\\Metric\\ProjectMetric') {
+            foreach (analyzeProject($node, $config) as $v) {
+                $violations[] = $v;
+            }
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeClass(array $node, array $config): array
+{
+    $violations = [];
+    $class = $node['name'];
+
+    foreach (classRules() as $r) {
+        $limit = rule($config, $r['rule']);
+        if ($limit === null) {
+            continue;
+        }
+
+        $actual = $node[$r['metric']] ?? null;
+        if ($actual === null) {
+            continue;
+        }
+
+        $items = $r['type'] === 'min'
+            ? checkMin($class, $r['label'], $actual, $limit, path($r['rule']))
+            : checkMax($class, $r['label'], $actual, $limit, path($r['rule']));
+
+        foreach ($items as $v) {
+            $violations[] = $v;
+        }
+    }
+
+    foreach ($node['methods'] ?? [] as $method) {
+        foreach (analyzeMethod($class, $method, $config) as $v) {
+            $violations[] = $v;
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeMethod(string $class, array $method, array $config): array
+{
+    $violations = [];
+    $name = $method['name'];
+
+    foreach (methodRules() as $r) {
+        $limit = rule($config, $r['rule']);
+        if ($limit === null) {
+            continue;
+        }
+
+        foreach (
+            checkMax(
+                $class,
+                "Method {$name} {$r['label']}",
+                $method[$r['metric']] ?? 0,
+                $limit,
+                path($r['rule']),
+            ) as $v
+        ) {
+            $violations[] = $v;
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeProject(array $node, array $config): array
+{
+    if ($node['name'] !== 'tree') {
+        return [];
+    }
+
+    $maxDepth = rule($config, ['inheritance', 'max_depth']);
+    if ($maxDepth === null) {
+        return [];
+    }
+
+    if ($node['depthOfInheritanceTree'] > $maxDepth) {
+        return [[
+            'class'   => 'Project',
+            'message' => "Inheritance depth too high: got {$node['depthOfInheritanceTree']} (max: $maxDepth)",
+            'rule'    => 'inheritance.max_depth',
+        ]];
+    }
+
+    return [];
+}
+
+function classRules(): array
+{
+    return [
+        ['label' => 'Maintainability', 'metric' => 'mi', 'rule' => ['maintainability', 'min_index'], 'type' => 'min'],
+        ['label' => 'WMC', 'metric' => 'wmc', 'rule' => ['complexity', 'max_weighted_methods_per_class'], 'type' => 'max'],
+        ['label' => 'Cyclomatic complexity', 'metric' => 'ccnMethodMax', 'rule' => ['complexity', 'max_cyclomatic_per_method'], 'type' => 'max'],
+        ['label' => 'LOC', 'metric' => 'loc', 'rule' => ['size', 'max_loc_per_class'], 'type' => 'max'],
+        ['label' => 'LLOC', 'metric' => 'lloc', 'rule' => ['size', 'max_logical_loc_per_class'], 'type' => 'max'],
+        ['label' => 'Methods count', 'metric' => 'nbMethods', 'rule' => ['structure', 'max_methods_per_class'], 'type' => 'max'],
+        ['label' => 'Afferent coupling', 'metric' => 'afferentCoupling', 'rule' => ['coupling', 'max_afferent'], 'type' => 'max'],
+        ['label' => 'Efferent coupling', 'metric' => 'efferentCoupling', 'rule' => ['coupling', 'max_efferent'], 'type' => 'max'],
+        ['label' => 'Instability', 'metric' => 'instability', 'rule' => ['coupling', 'max_instability'], 'type' => 'max'],
+    ];
+}
+
+function methodRules(): array
+{
+    return [
+        ['label' => 'LLOC', 'metric' => 'lloc', 'rule' => ['size', 'max_logical_loc_per_method']],
+        ['label' => 'volume', 'metric' => 'volume', 'rule' => ['halstead', 'max_volume_per_method']],
+        ['label' => 'difficulty', 'metric' => 'difficulty', 'rule' => ['halstead', 'max_difficulty_per_method']],
+        ['label' => 'effort', 'metric' => 'effort', 'rule' => ['halstead', 'max_effort_per_method']],
+        ['label' => 'bugs', 'metric' => 'bugs', 'rule' => ['halstead', 'max_bugs_per_method']],
+    ];
+}
+
+function rule(array $config, array $path): mixed
+{
+    foreach ($path as $key) {
+        if (!array_key_exists($key, $config)) {
+            return null;
+        }
+        $config = $config[$key];
+    }
+
+    return $config;
+}
+
+function path(array $rule): string
+{
+    return implode('.', $rule);
+}
+
+function checkMax(
+    string $class,
+    string $label,
+    int|float $actual,
+    int|float|null $max,
+    string $rule,
+): array {
+    if ($max === null || $actual <= $max) {
+        return [];
+    }
+
+    return [[
+        'class'   => $class,
+        'message' => "$label too high: got $actual (max: $max)",
+        'rule'    => $rule,
+    ]];
+}
+
+function checkMin(
+    string $class,
+    string $label,
+    int|float|null $actual,
+    int|float|null $min,
+    string $rule,
+): array {
+    if ($actual === null || $min === null || $actual >= $min) {
+        return [];
+    }
+
+    return [[
+        'class'   => $class,
+        'message' => "$label too low: got $actual (min: $min)",
+        'rule'    => $rule,
+    ]];
+}
+
+function renderViolationsGrouped(array $violations): void
+{
+    $byClass = [];
+
+    foreach ($violations as $v) {
+        $byClass[$v['class']][] = $v;
+    }
+
+    ksort($byClass);
+
+    foreach ($byClass as $class => $items) {
+        fwrite(STDERR, "\nClass: $class\n");
+        foreach ($items as $v) {
+            fwrite(STDERR, " • {$v['message']} #{$v['rule']}\n");
+        }
+    }
+
+    fwrite(STDERR, "\n");
+}


### PR DESCRIPTION
- Added PHPMetrics hard gate to CI
- Added composer scripts to generate and verify phpmetrics report
- Enforced metric thresholds via custom verifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now includes a reusable PHPMetrics job to run PHP metrics as part of checks.
  * Composer scripts split into three commands: generate, verify, and check.

* **New Features — Tools**
  * Added a CLI verification tool that analyzes metrics reports and can fail CI on violations.

* **Documentation**
  * Project README updated with revised title, overview, tooling list, and installation guidance.

* **Chores**
  * Adjusted verification tool path handling to match repository layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->