### PR TITLE
Fix CLI bin autoload bootstrap 

### DIFF
--- a/bin/piqule-sync.php
+++ b/bin/piqule-sync.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 declare(strict_types=1);
@@ -12,7 +13,12 @@ use Haspadar\Piqule\Target\Command\WithDryRunNotice;
 use Haspadar\Piqule\Target\Storage\DiskTargetStorage;
 use Haspadar\Piqule\Target\Storage\DryRunTargetStorage;
 
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php'] as $file) {
+    if (file_exists($file)) {
+        require $file;
+        break;
+    }
+}
 
 $output = new Console();
 

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "description": "Static analysis and linters for PHP projects",
     "type": "library",
     "license": "MIT",
+    "bin": [
+        "bin/piqule-sync.php"
+    ],
     "autoload": {
         "psr-4": {
             "Haspadar\\Piqule\\": "src/"


### PR DESCRIPTION
- Fixed CLI bin autoload bootstrap to work both as root project and dependency
- Updated bin script to resolve Composer autoload deterministically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Registered `piqule-sync` as an executable CLI command.
  * Enhanced script initialization for improved installation compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->