### PR TITLE
Fix project root resolution when running via vendor/bin

### DIFF
--- a/bin/piqule-sync.php
+++ b/bin/piqule-sync.php
@@ -23,9 +23,7 @@ foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php
 $output = new Console();
 
 try {
-    $projectRoot = Composer\InstalledVersions::getRootPackage()['install_path']
-        ?: throw new PiquleException('Cannot determine project root');
-
+    $projectRoot = getcwd();
     $libraryRoot = Composer\InstalledVersions::getInstallPath('haspadar/piqule')
         ?: throw new PiquleException('Cannot determine piqule install path');
 
@@ -37,7 +35,6 @@ try {
     }
 
     $command = new Synchronization($sources, $targetStorage, $output);
-
     $options->isDryRun()
         ? (new WithDryRunNotice($command, $output))->run()
         : $command->run();

--- a/bin/piqule-sync.php
+++ b/bin/piqule-sync.php
@@ -24,8 +24,12 @@ $output = new Console();
 
 try {
     $projectRoot = getcwd();
+    if ($projectRoot === false) {
+        throw new PiquleException('Cannot determine current working directory');
+    }
+
     $libraryRoot = Composer\InstalledVersions::getInstallPath('haspadar/piqule')
-        ?: throw new PiquleException('Cannot determine piqule install path');
+            ?: throw new PiquleException('Cannot determine piqule install path');
 
     $sources = new DiskSources($libraryRoot . '/templates');
     $targetStorage = new DiskTargetStorage($projectRoot);
@@ -36,8 +40,8 @@ try {
 
     $command = new Synchronization($sources, $targetStorage, $output);
     $options->isDryRun()
-        ? (new WithDryRunNotice($command, $output))->run()
-        : $command->run();
+            ? (new WithDryRunNotice($command, $output))->run()
+            : $command->run();
 } catch (PiquleException $e) {
     $output->write(new Error($e->getMessage()));
     exit(1);


### PR DESCRIPTION
- Fixed incorrect project root resolution when running via vendor/bin by separating project root from library root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project root detection so the synchronization tool more reliably locates and operates on your project in different environments, reducing startup failures.

* **Chores**
  * Minor formatting and indentation cleanup for clearer, consistent code structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->