### PR TITLE
Introduce init-only templates category

### DIFF
--- a/templates/once/README.md
+++ b/templates/once/README.md
@@ -1,0 +1,37 @@
+# PROJECT
+
+Short description of the project purpose.
+
+[![CI](https://github.com/haspadar/PROJECT/actions/workflows/ci.yml/badge.svg)](https://github.com/haspadar/PROJECT/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/haspadar/PROJECT/branch/main/graph/badge.svg)](https://codecov.io/gh/haspadar/PROJECT)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fhaspadar%2FPROJECT%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/haspadar/PROJECT/main)
+[![PHPStan Level](https://img.shields.io/badge/PHPStan-Level%209-brightgreen)](https://phpstan.org/)
+[![Psalm](https://img.shields.io/badge/psalm-level%201-brightgreen)](https://psalm.dev)
+
+[![Hits-of-Code](https://hitsofcode.com/github/haspadar/PROJECT?branch=main)](https://hitsofcode.com/github/haspadar/PROJECT/view?branch=main)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/haspadar/PROJECT?labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+
+---
+
+## About
+
+The project is under active development
+---
+
+## Installation
+
+```bash
+composer require --dev haspadar/PROJECT
+```
+
+---
+
+## Contributing
+
+Fork the repository, apply changes, and open a pull request.
+
+---
+
+## License
+
+MIT


### PR DESCRIPTION
- Added init-only templates category
- Added README template intended for one-time project initialization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project README with badges for CI, coverage, and code quality metrics, alongside installation instructions, contribution guidelines, and license information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->