### PR TITLE
Skipping-if-exists synchronization was added to support one-time initialization files

### DIFF
--- a/bin/piqule-init.php
+++ b/bin/piqule-init.php
@@ -10,7 +10,7 @@ use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Source\DiskSources;
 use Haspadar\Piqule\Target\Storage\DiskTargetStorage;
 use Haspadar\Piqule\Target\Storage\DryRunTargetStorage;
-use Haspadar\Piqule\Target\Sync\ReplaceSync;
+use Haspadar\Piqule\Target\Sync\SkippingIfExistsSync;
 use Haspadar\Piqule\Target\Sync\WithDryRunSync;
 
 // TODO(#193): CLI bootstrap logic is duplicated between init and sync entrypoints
@@ -48,7 +48,7 @@ try {
         $targetStorage = new DryRunTargetStorage($targetStorage);
     }
 
-    $sync = new ReplaceSync($sources, $targetStorage, $output);
+    $sync = new SkippingIfExistsSync($sources, $targetStorage, $output);
     $options->isDryRun()
         ? (new WithDryRunSync($sync, $output))->apply()
         : $sync->apply();

--- a/src/Target/Sync/SkippingIfExistsSync.php
+++ b/src/Target/Sync/SkippingIfExistsSync.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Target\Sync;
+
+use Haspadar\Piqule\Output\Color\Green;
+use Haspadar\Piqule\Output\Color\Grey;
+use Haspadar\Piqule\Output\Line\Text;
+use Haspadar\Piqule\Output\Output;
+use Haspadar\Piqule\Source\Sources;
+use Haspadar\Piqule\Target\DiskTarget;
+use Haspadar\Piqule\Target\Storage\TargetStorage;
+use Override;
+
+final readonly class SkippingIfExistsSync implements Sync
+{
+    public function __construct(
+        private Sources $sources,
+        private TargetStorage $targetDirectory,
+        private Output $output,
+    ) {}
+
+    #[Override]
+    public function apply(): void
+    {
+        foreach ($this->sources->files() as $source) {
+            $target = new DiskTarget($source, $this->targetDirectory);
+
+            if ($target->exists()) {
+                $this->output->write(
+                    new Text(
+                        sprintf('Skipped: %s', $target->id()),
+                        new Grey(),
+                    ),
+                );
+                continue;
+            }
+
+            $target->materialize();
+
+            $this->output->write(
+                new Text(
+                    sprintf('Created: %s', $target->id()),
+                    new Green(),
+                ),
+            );
+        }
+    }
+}

--- a/src/Target/Sync/SkippingIfExistsSync.php
+++ b/src/Target/Sync/SkippingIfExistsSync.php
@@ -17,7 +17,7 @@ final readonly class SkippingIfExistsSync implements Sync
 {
     public function __construct(
         private Sources $sources,
-        private TargetStorage $targetDirectory,
+        private TargetStorage $targetStorage,
         private Output $output,
     ) {}
 
@@ -25,7 +25,7 @@ final readonly class SkippingIfExistsSync implements Sync
     public function apply(): void
     {
         foreach ($this->sources->files() as $source) {
-            $target = new DiskTarget($source, $this->targetDirectory);
+            $target = new DiskTarget($source, $this->targetStorage);
 
             if ($target->exists()) {
                 $this->output->write(

--- a/tests/Unit/Target/Sync/SkippingIfExistsSyncTest.php
+++ b/tests/Unit/Target/Sync/SkippingIfExistsSyncTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Target\Sync;
+
+use Haspadar\Piqule\Source\Source;
+use Haspadar\Piqule\Target\Sync\SkippingIfExistsSync;
+use Haspadar\Piqule\Tests\Unit\Fake\File\FakeFile;
+use Haspadar\Piqule\Tests\Unit\Fake\Output\FakeOutput;
+use Haspadar\Piqule\Tests\Unit\Fake\Source\FakeSources;
+use Haspadar\Piqule\Tests\Unit\Fake\Target\Storage\FakeTargetStorage;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SkippingIfExistsSyncTest extends TestCase
+{
+    #[Test]
+    public function createsFileWhenTargetDoesNotExist(): void
+    {
+        $sources = new FakeSources([
+            new Source(
+                new FakeFile('hello'),
+                'example.txt',
+            ),
+        ]);
+        $storage = new FakeTargetStorage();
+
+        (new SkippingIfExistsSync($sources, $storage, new FakeOutput()))->apply();
+
+        self::assertArrayHasKey(
+            'example.txt',
+            $storage->all(),
+            'Target must be created when it does not exist',
+        );
+    }
+
+    #[Test]
+    public function skipsFileWhenTargetExists(): void
+    {
+        $sources = new FakeSources([
+            new Source(
+                new FakeFile('new'),
+                'example.txt',
+            ),
+        ]);
+        $storage = new FakeTargetStorage();
+        $storage->write('example.txt', new FakeFile('old'));
+
+        (new SkippingIfExistsSync($sources, $storage, new FakeOutput()))->apply();
+
+        self::assertSame(
+            'old',
+            $storage->all()['example.txt']->contents(),
+            'Target contents must remain unchanged when target already exists',
+        );
+    }
+
+    #[Test]
+    public function doesNotCompareContentsWhenTargetExists(): void
+    {
+        $sources = new FakeSources([
+            new Source(
+                new FakeFile('different'),
+                'example.txt',
+            ),
+        ]);
+        $storage = new FakeTargetStorage();
+        $storage->write('example.txt', new FakeFile('original'));
+
+        (new SkippingIfExistsSync($sources, $storage, new FakeOutput()))->apply();
+
+        self::assertSame(
+            'original',
+            $storage->all()['example.txt']->contents(),
+            'Existing target must never be replaced regardless of source contents',
+        );
+    }
+}

--- a/tests/Unit/Target/Sync/SkippingIfExistsSyncTest.php
+++ b/tests/Unit/Target/Sync/SkippingIfExistsSyncTest.php
@@ -55,25 +55,4 @@ final class SkippingIfExistsSyncTest extends TestCase
             'Target contents must remain unchanged when target already exists',
         );
     }
-
-    #[Test]
-    public function doesNotCompareContentsWhenTargetExists(): void
-    {
-        $sources = new FakeSources([
-            new Source(
-                new FakeFile('different'),
-                'example.txt',
-            ),
-        ]);
-        $storage = new FakeTargetStorage();
-        $storage->write('example.txt', new FakeFile('original'));
-
-        (new SkippingIfExistsSync($sources, $storage, new FakeOutput()))->apply();
-
-        self::assertSame(
-            'original',
-            $storage->all()['example.txt']->contents(),
-            'Existing target must never be replaced regardless of source contents',
-        );
-    }
 }


### PR DESCRIPTION
- Added SkippingIfExistsSync to support create-only synchronization behavior
- Updated init command to use the new strategy for one-time templates
- Covered skipping behavior with unit tests

Part of #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new sync mode that skips existing files instead of replacing them, preserving previously created content during initialization.

* **Tests**
  * Added comprehensive test coverage for the new sync behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->