### PR TITLE
Introduce explicit sync chaining for init

### DIFF
--- a/src/Target/Sync/Chain.php
+++ b/src/Target/Sync/Chain.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Target\Sync;
 
 use Haspadar\Piqule\Target\Storage\TargetStorage;
+use Override;
 
 final readonly class Chain implements Sync
 {
@@ -13,6 +14,7 @@ final readonly class Chain implements Sync
         private array $syncs,
     ) {}
 
+    #[Override]
     public function apply(TargetStorage $targetStorage): void
     {
         foreach ($this->syncs as $sync) {

--- a/src/Target/Sync/Chain.php
+++ b/src/Target/Sync/Chain.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Target\Sync;
+
+use Haspadar\Piqule\Target\Storage\TargetStorage;
+
+final readonly class Chain implements Sync
+{
+    /** @param Sync[] $syncs */
+    public function __construct(
+        private array $syncs,
+    ) {}
+
+    public function apply(TargetStorage $targetStorage): void
+    {
+        foreach ($this->syncs as $sync) {
+            $sync->apply($targetStorage);
+        }
+    }
+}

--- a/src/Target/Sync/ReplaceSync.php
+++ b/src/Target/Sync/ReplaceSync.php
@@ -18,15 +18,14 @@ final readonly class ReplaceSync implements Sync
 {
     public function __construct(
         private Sources $sources,
-        private TargetStorage $targetDirectory,
         private Output $output,
     ) {}
 
     #[Override]
-    public function apply(): void
+    public function apply(TargetStorage $targetStorage): void
     {
         foreach ($this->sources->files() as $source) {
-            $target = new DiskTarget($source, $this->targetDirectory);
+            $target = new DiskTarget($source, $targetStorage);
 
             if (!$target->exists()) {
                 $target->materialize();

--- a/src/Target/Sync/SkippingIfExistsSync.php
+++ b/src/Target/Sync/SkippingIfExistsSync.php
@@ -17,15 +17,14 @@ final readonly class SkippingIfExistsSync implements Sync
 {
     public function __construct(
         private Sources $sources,
-        private TargetStorage $targetStorage,
         private Output $output,
     ) {}
 
     #[Override]
-    public function apply(): void
+    public function apply(TargetStorage $targetStorage): void
     {
         foreach ($this->sources->files() as $source) {
-            $target = new DiskTarget($source, $this->targetStorage);
+            $target = new DiskTarget($source, $targetStorage);
 
             if ($target->exists()) {
                 $this->output->write(

--- a/src/Target/Sync/Sync.php
+++ b/src/Target/Sync/Sync.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Target\Sync;
 
+use Haspadar\Piqule\Target\Storage\TargetStorage;
+
 interface Sync
 {
-    public function apply(): void;
+    public function apply(TargetStorage $targetStorage): void;
 }

--- a/src/Target/Sync/WithDryRunSync.php
+++ b/src/Target/Sync/WithDryRunSync.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Target\Sync;
 use Haspadar\Piqule\Output\Color\Yellow;
 use Haspadar\Piqule\Output\Line\Text;
 use Haspadar\Piqule\Output\Output;
+use Haspadar\Piqule\Target\Storage\TargetStorage;
 use Override;
 
 final readonly class WithDryRunSync implements Sync
@@ -17,7 +18,7 @@ final readonly class WithDryRunSync implements Sync
     ) {}
 
     #[Override]
-    public function apply(): void
+    public function apply(TargetStorage $targetStorage): void
     {
         $this->output->write(
             new Text(
@@ -26,7 +27,7 @@ final readonly class WithDryRunSync implements Sync
             ),
         );
 
-        $this->origin->apply();
+        $this->origin->apply($targetStorage);
 
         $this->output->write(
             new Text(

--- a/tests/Integration/SyncIntegrationTest.php
+++ b/tests/Integration/SyncIntegrationTest.php
@@ -24,9 +24,8 @@ final class SyncIntegrationTest extends TestCase
 
         (new ReplaceSync(
             new DiskSources($sources->path()),
-            new DiskTargetStorage($targets->path()),
             new FakeOutput(),
-        ))->apply();
+        ))->apply(new DiskTargetStorage($targets->path()));
 
         self::assertFileExists(
             $targets->path() . '/example.txt',

--- a/tests/Unit/Fake/Sync/FakeSync.php
+++ b/tests/Unit/Fake/Sync/FakeSync.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Tests\Unit\Fake\Sync;
 
+use Haspadar\Piqule\Target\Storage\TargetStorage;
 use Haspadar\Piqule\Target\Sync\Sync;
 
 final class FakeSync implements Sync
 {
     private bool $ran = false;
 
-    public function apply(): void
+    public function apply(TargetStorage $targetStorage): void
     {
         $this->ran = true;
     }

--- a/tests/Unit/Target/Sync/ReplaceSyncTest.php
+++ b/tests/Unit/Target/Sync/ReplaceSyncTest.php
@@ -25,7 +25,7 @@ final class ReplaceSyncTest extends TestCase
             ),
         ]);
         $storage = new FakeTargetStorage();
-        (new ReplaceSync($sources, $storage, new FakeOutput()))->apply();
+        (new ReplaceSync($sources, new FakeOutput()))->apply($storage);
 
         self::assertArrayHasKey(
             'example.txt',
@@ -46,7 +46,7 @@ final class ReplaceSyncTest extends TestCase
         $storage = new FakeTargetStorage();
         $storage->write('example.txt', new FakeFile('old'));
 
-        (new ReplaceSync($sources, $storage, new FakeOutput()))->apply();
+        (new ReplaceSync($sources, new FakeOutput()))->apply($storage);
 
         self::assertSame(
             'new',
@@ -67,7 +67,7 @@ final class ReplaceSyncTest extends TestCase
         $storage = new FakeTargetStorage();
         $storage->write('example.txt', new FakeFile('same'));
 
-        (new ReplaceSync($sources, $storage, new FakeOutput()))->apply();
+        (new ReplaceSync($sources, new FakeOutput()))->apply($storage);
 
         self::assertSame(
             'same',

--- a/tests/Unit/Target/Sync/SkippingIfExistsSyncTest.php
+++ b/tests/Unit/Target/Sync/SkippingIfExistsSyncTest.php
@@ -26,7 +26,7 @@ final class SkippingIfExistsSyncTest extends TestCase
         ]);
         $storage = new FakeTargetStorage();
 
-        (new SkippingIfExistsSync($sources, $storage, new FakeOutput()))->apply();
+        (new SkippingIfExistsSync($sources, new FakeOutput()))->apply($storage);
 
         self::assertArrayHasKey(
             'example.txt',
@@ -47,7 +47,7 @@ final class SkippingIfExistsSyncTest extends TestCase
         $storage = new FakeTargetStorage();
         $storage->write('example.txt', new FakeFile('old'));
 
-        (new SkippingIfExistsSync($sources, $storage, new FakeOutput()))->apply();
+        (new SkippingIfExistsSync($sources, new FakeOutput()))->apply($storage);
 
         self::assertSame(
             'old',

--- a/tests/Unit/Target/Sync/WithDryRunSyncTest.php
+++ b/tests/Unit/Target/Sync/WithDryRunSyncTest.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Tests\Unit\Target\Sync;
 use Haspadar\Piqule\Target\Sync\WithDryRunSync;
 use Haspadar\Piqule\Tests\Unit\Fake\Output\FakeOutput;
 use Haspadar\Piqule\Tests\Unit\Fake\Sync\FakeSync;
+use Haspadar\Piqule\Tests\Unit\Fake\Target\Storage\FakeTargetStorage;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ final class WithDryRunSyncTest extends TestCase
         $origin = new FakeSync();
         $output = new FakeOutput();
 
-        (new WithDryRunSync($origin, $output))->apply();
+        (new WithDryRunSync($origin, $output))->apply(new FakeTargetStorage());
 
         self::assertTrue(
             $origin->isRan(),
@@ -31,7 +32,7 @@ final class WithDryRunSyncTest extends TestCase
     {
         $output = new FakeOutput();
 
-        (new WithDryRunSync(new FakeSync(), $output))->apply();
+        (new WithDryRunSync(new FakeSync(), $output))->apply(new FakeTargetStorage());
 
         self::assertCount(
             2,


### PR DESCRIPTION
- Introduced Chain to represent sequential application of sync policies
- Applied explicit sync chaining in the init entrypoint
- Left sync entrypoint unchanged to limit refactoring scope

Part of #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the synchronization framework to use a sequential chain pattern for orchestrating multiple sync operations during initialization and file updates.
  * Enhanced dry-run functionality with improved integration into the core synchronization workflow architecture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->