### PR TITLE
Simplify Piqule installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,20 +60,19 @@
     ],
     "minimum-stability": "stable",
     "require": {
-      "php": ">=8.3"
-    },
-    "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.91",
-        "phpunit/phpunit": ">=11.5 <12.0",
-        "infection/infection": "^0.32.0",
-        "phpstan/phpstan": "^2.1",
-        "vimeo/psalm": "^6.14",
-        "phpmd/phpmd": "^2.15",
-        "phpmetrics/phpmetrics": "^2.9"
+      "php": ">=8.3",
+      "friendsofphp/php-cs-fixer": "^3.91",
+      "phpunit/phpunit": ">=11.5 <12.0",
+      "infection/infection": "^0.32.0",
+      "phpstan/phpstan": "^2.1",
+      "vimeo/psalm": "^6.14",
+      "phpmd/phpmd": "^2.15",
+      "phpmetrics/phpmetrics": "^2.9"
     },
     "config": {
         "allow-plugins": {
-            "infection/extension-installer": true
+            "infection/extension-installer": true,
+            "phpro/grumphp": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -71,8 +71,7 @@
     },
     "config": {
         "allow-plugins": {
-            "infection/extension-installer": true,
-            "phpro/grumphp": true
+            "infection/extension-installer": true
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "402fac10f7b39e100cd325c12256707c",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "dfd1e76510cd6306a4d207eaa855b655",
+    "packages": [
         {
             "name": "amphp/amp",
             "version": "v3.1.1",
@@ -4803,16 +4802,16 @@
         },
         {
             "name": "sanmai/pipeline",
-            "version": "7.6",
+            "version": "7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/pipeline.git",
-                "reference": "f7aeb6e1c9572f366c6035c79d715a2a73eeb1c9"
+                "reference": "9341ac243258ff16259b0edc6654af5583fa8743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/f7aeb6e1c9572f366c6035c79d715a2a73eeb1c9",
-                "reference": "f7aeb6e1c9572f366c6035c79d715a2a73eeb1c9",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/9341ac243258ff16259b0edc6654af5583fa8743",
+                "reference": "9341ac243258ff16259b0edc6654af5583fa8743",
                 "shasum": ""
             },
             "require": {
@@ -4835,7 +4834,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "v6.x-dev"
+                    "dev-main": "7.x-dev"
                 }
             },
             "autoload": {
@@ -4859,7 +4858,7 @@
             "description": "General-purpose collections pipeline",
             "support": {
                 "issues": "https://github.com/sanmai/pipeline/issues",
-                "source": "https://github.com/sanmai/pipeline/tree/7.6"
+                "source": "https://github.com/sanmai/pipeline/tree/7.7"
             },
             "funding": [
                 {
@@ -4867,7 +4866,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-20T07:22:08+00:00"
+            "time": "2026-01-09T10:16:17+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -8031,16 +8030,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.0.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "1b34b004e35a164bc5bb6ebd33c844b2d8069a54"
+                "reference": "bdbabc199a7ba9965484e4725d66170e5711323b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/1b34b004e35a164bc5bb6ebd33c844b2d8069a54",
-                "reference": "1b34b004e35a164bc5bb6ebd33c844b2d8069a54",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bdbabc199a7ba9965484e4725d66170e5711323b",
+                "reference": "bdbabc199a7ba9965484e4725d66170e5711323b",
                 "shasum": ""
             },
             "require": {
@@ -8087,11 +8086,12 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.0.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.1.1"
             },
-            "time": "2025-12-16T21:36:00+00:00"
+            "time": "2026-01-08T11:28:40+00:00"
         }
     ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},


### PR DESCRIPTION
- Updated Piqule to own toolchain dependencies
- Reduced installation to a single composer require command

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated dependencies by moving development and code-quality tools into the project's main requirements.
  * Removed the separate development-only dependency section.
  * Raised the minimum supported PHP version to 8.3, reflecting the updated runtime requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->