### PR TITLE
Centralize PHP-CS-Fixer cache configuration

### DIFF
--- a/.piqule/php-cs-fixer/php-cs-fixer.project.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.project.php
@@ -11,7 +11,7 @@ $rules->setFinder(
     Finder::create()
         ->in(__DIR__ . '/../..')
         ->exclude('vendor'),
-);
+)->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
 
 return $rules;
 


### PR DESCRIPTION
- Defined PHP-CS-Fixer cache file location in configuration

Part of #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled caching for PHP code formatting checks to improve performance during code style validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->