### PR TITLE
XML lint validation via xmllint only

### DIFF
--- a/.github/workflows/_xmllint.yml
+++ b/.github/workflows/_xmllint.yml
@@ -18,16 +18,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
-      # Set up PHP (minimal, без matrix)
-      # ------------------------------------------------------------
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
-        with:
-          php-version: '8.3'
-          tools: composer
-
-      # ------------------------------------------------------------
-      # Install system dependencies
+      # Install xmllint
       # ------------------------------------------------------------
       - name: Install xmllint
         run: |
@@ -35,13 +26,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends libxml2-utils
 
       # ------------------------------------------------------------
-      # Install Composer dependencies
-      # ------------------------------------------------------------
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      # ------------------------------------------------------------
       # Run XML lint
       # ------------------------------------------------------------
       - name: XML lint
-        run: composer xml:check
+        run: xmllint --noout .piqule/*/*.xml

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "typos:check": "typos --config .piqule/typos/_typos.toml",
 
         "xml:check": "xmllint --noout .piqule/*/*.xml",
-        "xml:fix":   "xmllint --format --output .piqule/*/*.xml",
 
         "prettier:check": "prettier --check . --config .piqule/prettier/.prettierrc.yml --ignore-path .piqule/prettier/.prettierignore",
         "prettier:fix":   "prettier --write . --config .piqule/prettier/.prettierrc.yml --ignore-path .piqule/prettier/.prettierignore",

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,8 @@
         "yamllint:check": "yamllint -c .piqule/yamllint/.yamllint.yml .",
         "typos:check": "typos --config .piqule/typos/_typos.toml",
 
-        "xml:check": "find . -type f -name \"*.xml\" ! -path \"./vendor/*\" ! -path \"./.git/*\" -print0 | xargs -0 xmllint --noout",
-        "xml:fix": "find . -type f -name \"*.xml\" ! -path \"./vendor/*\" ! -path \"./.git/*\" -print0 | xargs -0 -I{} sh -c 'xmllint --format \"$1\" --output \"$1\"' _ {}",
+        "xml:check": "xmllint --noout .piqule/*/*.xml",
+        "xml:fix":   "xmllint --format --output .piqule/*/*.xml",
 
         "prettier:check": "prettier --check . --config .piqule/prettier/.prettierrc.yml --ignore-path .piqule/prettier/.prettierignore",
         "prettier:fix":   "prettier --write . --config .piqule/prettier/.prettierrc.yml --ignore-path .piqule/prettier/.prettierignore",
@@ -49,8 +49,7 @@
 
         "fix": [
             "@phpcs:fix",
-            "@php-cs-fixer:fix",
-            "@xml:fix"
+            "@php-cs-fixer:fix"
         ],
 
         "check": [

--- a/templates/always/.github/workflows/_xmllint.yml
+++ b/templates/always/.github/workflows/_xmllint.yml
@@ -18,16 +18,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # ------------------------------------------------------------
-      # Set up PHP (minimal, без matrix)
-      # ------------------------------------------------------------
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
-        with:
-          php-version: '8.3'
-          tools: composer
-
-      # ------------------------------------------------------------
-      # Install system dependencies
+      # Install xmllint
       # ------------------------------------------------------------
       - name: Install xmllint
         run: |
@@ -35,13 +26,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends libxml2-utils
 
       # ------------------------------------------------------------
-      # Install Composer dependencies
-      # ------------------------------------------------------------
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      # ------------------------------------------------------------
       # Run XML lint
       # ------------------------------------------------------------
       - name: XML lint
-        run: composer xml:check
+        run: xmllint --noout .piqule/*/*.xml


### PR DESCRIPTION
- Removed xml:fix script
- Simplified xml:check to xmllint validation only
- Simplified XML lint GitHub workflow to avoid composer invocation

Part of #209 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI XML validation by removing PHP and Composer setup steps.
  * Switched linting to direct xmllint invocation and removed composer-based XML checks/fixes.
  * Narrowed lint target to the .piqule directory and streamlined validation steps for faster, simpler CI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->