### PR TITLE
Refactor File abstraction to expose source identifier 

### DIFF
--- a/src/File/DiskFile.php
+++ b/src/File/DiskFile.php
@@ -9,18 +9,24 @@ use Override;
 
 final readonly class DiskFile implements File
 {
-    /**
-     * Absolute or relative filesystem path
-     */
     public function __construct(
         private string $path,
     ) {}
 
-    /**
-     * Reads and returns the file contents
-     *
-     * @throws PiquleException If the file cannot be read
-     */
+    #[Override]
+    public function id(): string
+    {
+        $realPath = realpath($this->path);
+
+        if ($realPath === false) {
+            throw new PiquleException(
+                sprintf('Failed to resolve file path: "%s"', $this->path),
+            );
+        }
+
+        return $realPath;
+    }
+
     #[Override]
     public function contents(): string
     {

--- a/src/File/File.php
+++ b/src/File/File.php
@@ -9,7 +9,15 @@ use Haspadar\Piqule\PiquleException;
 interface File
 {
     /**
-     * Returns the full contents of the file.
+     * Returns a stable identifier of the file source
+     *
+     * The identifier must uniquely represent the origin of the file
+     * within the current execution context
+     */
+    public function id(): string;
+
+    /**
+     * Returns the full contents of the file
      *
      * @throws PiquleException If the contents cannot be read
      */

--- a/tests/Integration/File/DiskFileTest.php
+++ b/tests/Integration/File/DiskFileTest.php
@@ -23,4 +23,30 @@ final class DiskFileTest extends TestCase
 
         $file->contents();
     }
+
+    #[Test]
+    public function returnsCanonicalAbsolutePathAsId(): void
+    {
+        $directory = new DirectoryFixture('disk-file');
+        $path = $directory->path() . '/file.txt';
+
+        file_put_contents($path, 'test');
+
+        $file = new DiskFile($path);
+
+        $this->assertSame(
+            realpath($path),
+            $file->id(),
+        );
+    }
+
+    #[Test]
+    public function throwsExceptionWhenIdCannotBeResolved(): void
+    {
+        $file = new DiskFile('/missing/file.txt');
+
+        $this->expectException(PiquleException::class);
+
+        $file->id();
+    }
 }

--- a/tests/Integration/Fixtures/FileFixture.php
+++ b/tests/Integration/Fixtures/FileFixture.php
@@ -10,7 +10,13 @@ final readonly class FileFixture implements File
 {
     public function __construct(
         private string $contents,
+        private string $id = 'fake:file',
     ) {}
+
+    public function id(): string
+    {
+        return $this->id;
+    }
 
     public function contents(): string
     {

--- a/tests/Unit/Fake/File/FakeFile.php
+++ b/tests/Unit/Fake/File/FakeFile.php
@@ -10,7 +10,13 @@ final readonly class FakeFile implements File
 {
     public function __construct(
         private string $contents,
+        private string $id = 'fake:file',
     ) {}
+
+    public function id(): string
+    {
+        return $this->id;
+    }
 
     public function contents(): string
     {


### PR DESCRIPTION
- Added id() method to File interface
- Updated file implementations to expose stable identifiers

Part of #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Files now expose a public id() method that returns a canonical, absolute identifier for a file; calling it for non-resolvable paths will raise an error.
* **Tests**
  * Added unit and integration tests validating id() behavior and existing file contents handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->