### PR TITLE
Add FileSkipped domain event 

### DIFF
--- a/src/File/Event/FileSkipped.php
+++ b/src/File/Event/FileSkipped.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\File\Event;
+
+use Haspadar\Piqule\File\Target\FileTarget;
+use Override;
+
+final readonly class FileSkipped implements FileEvent
+{
+    public function __construct(private string $name) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param FileTarget $target
+     */
+    #[Override]
+    public function passTo(FileTarget $target): void
+    {
+        $target->skipped($this);
+    }
+}

--- a/src/File/Target/FileTarget.php
+++ b/src/File/Target/FileTarget.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\File\Target;
 
 use Haspadar\Piqule\File\Event\FileCreated;
+use Haspadar\Piqule\File\Event\FileSkipped;
 use Haspadar\Piqule\File\Event\FileUpdated;
 
 interface FileTarget
@@ -12,4 +13,6 @@ interface FileTarget
     public function created(FileCreated $event): void;
 
     public function updated(FileUpdated $event): void;
+
+    public function skipped(FileSkipped $event): void;
 }

--- a/tests/Unit/Fake/File/Target/FakeTarget.php
+++ b/tests/Unit/Fake/File/Target/FakeTarget.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Unit\Fake\File\Target;
 
 use Haspadar\Piqule\File\Event\FileCreated;
+use Haspadar\Piqule\File\Event\FileSkipped;
 use Haspadar\Piqule\File\Event\FileUpdated;
 use Haspadar\Piqule\File\Target\FileTarget;
 
@@ -19,6 +20,11 @@ final class FakeTarget implements FileTarget
     }
 
     public function updated(FileUpdated $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    public function skipped(FileSkipped $event): void
     {
         $this->events[] = $event;
     }

--- a/tests/Unit/File/Event/FileSkippedTest.php
+++ b/tests/Unit/File/Event/FileSkippedTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\File\Event;
+
+use Haspadar\Piqule\File\Event\FileSkipped;
+use Haspadar\Piqule\Tests\Unit\Fake\File\Target\FakeTarget;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FileSkippedTest extends TestCase
+{
+    #[Test]
+    public function passesSkippedEventToTarget(): void
+    {
+        $target = new FakeTarget();
+
+        (new FileSkipped('config/logging.php'))->passTo($target);
+
+        self::assertCount(
+            1,
+            $target->events(),
+            'Skipped event must be passed to target',
+        );
+    }
+
+    #[Test]
+    public function exposesFileName(): void
+    {
+        self::assertSame(
+            'config/session.php',
+            (new FileSkipped('config/session.php'))->name(),
+            'FileSkipped must expose the file name it was created with',
+        );
+    }
+}


### PR DESCRIPTION
- Added FileSkipped domain event to represent skipped file handling
- Extended FileTarget contract and test doubles accordingly
- Added unit tests to lock FileSkipped behavior

Part of #226