### PR TITLE
Add names enumeration to Storage 

### DIFF
--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 
+use FilesystemIterator;
 use Haspadar\Piqule\PiquleException;
 use Override;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 
 final readonly class DiskStorage implements Storage
 {
@@ -78,6 +82,28 @@ final readonly class DiskStorage implements Storage
             throw new PiquleException(
                 sprintf('Failed to chmod file "%s"', $name),
             );
+        }
+    }
+
+    #[Override]
+    public function names(): iterable
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                $this->path->root(),
+                FilesystemIterator::SKIP_DOTS,
+            ),
+        );
+
+        $rootLength = strlen(rtrim($this->path->root(), '/')) + 1;
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            yield substr($file->getPathname(), $rootLength);
         }
     }
 }

--- a/src/Storage/DryRunStorage.php
+++ b/src/Storage/DryRunStorage.php
@@ -35,4 +35,10 @@ final readonly class DryRunStorage implements Storage
      */
     #[Override]
     public function writeExecutable(string $name, string $contents): void {}
+
+    #[Override]
+    public function names(): iterable
+    {
+        return $this->origin->names();
+    }
 }

--- a/src/Storage/InMemoryStorage.php
+++ b/src/Storage/InMemoryStorage.php
@@ -49,4 +49,13 @@ final class InMemoryStorage implements Storage
     {
         $this->write($name, $contents);
     }
+
+    /**
+     * @return iterable<string> logical file names
+     */
+    #[Override]
+    public function names(): iterable
+    {
+        return array_keys($this->files);
+    }
 }

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -29,4 +29,9 @@ interface Storage
      * Writes contents to a file and makes it executable
      */
     public function writeExecutable(string $name, string $contents): void;
+
+    /**
+     * @return iterable<string> logical file names
+     */
+    public function names(): iterable;
 }

--- a/tests/Integration/Storage/DiskStorageTest.php
+++ b/tests/Integration/Storage/DiskStorageTest.php
@@ -136,4 +136,22 @@ final class DiskStorageTest extends TestCase
         (new DiskStorage(new DiskPath($readonly)))
             ->writeExecutable('hook.sh', 'x');
     }
+
+    #[Test]
+    public function listsAllFilesRecursively(): void
+    {
+        $directory = (new DirectoryFixture('disk-storage'))
+            ->withFile('a.txt', 'a')
+            ->withFile('nested/b.txt', 'b');
+
+        $names = iterator_to_array(
+            (new DiskStorage(new DiskPath($directory->path())))->names(),
+        );
+
+        self::assertEquals(
+            ['a.txt', 'nested/b.txt'],
+            $names,
+            'Expected names() to return all file names relative to root',
+        );
+    }
 }

--- a/tests/Integration/Storage/DiskStorageTest.php
+++ b/tests/Integration/Storage/DiskStorageTest.php
@@ -148,7 +148,7 @@ final class DiskStorageTest extends TestCase
             (new DiskStorage(new DiskPath($directory->path())))->names(),
         );
 
-        self::assertEquals(
+        self::assertEqualsCanonicalizing(
             ['a.txt', 'nested/b.txt'],
             $names,
             'Expected names() to return all file names relative to root',

--- a/tests/Unit/Storage/DryRunStorageTest.php
+++ b/tests/Unit/Storage/DryRunStorageTest.php
@@ -63,4 +63,21 @@ final class DryRunStorageTest extends TestCase
             'Executable file was written in dry-run mode',
         );
     }
+
+    #[Test]
+    public function delegatesNamesToOriginalStorage(): void
+    {
+        self::assertEquals(
+            ['a.txt', 'nested/b.txt'],
+            iterator_to_array(
+                (new DryRunStorage(
+                    new InMemoryStorage([
+                        'a.txt' => 'a',
+                        'nested/b.txt' => 'b',
+                    ]),
+                ))->names(),
+            ),
+            'names() was not delegated to original storage',
+        );
+    }
 }

--- a/tests/Unit/Storage/InMemoryStorageTest.php
+++ b/tests/Unit/Storage/InMemoryStorageTest.php
@@ -86,4 +86,17 @@ final class InMemoryStorageTest extends TestCase
             'Expected writeExecutable() to behave like write()',
         );
     }
+
+    #[Test]
+    public function returnsAllStoredNames(): void
+    {
+        self::assertEquals(
+            ['a.txt', 'nested/b.txt'],
+            (new InMemoryStorage([
+                'a.txt' => 'a',
+                'nested/b.txt' => 'b',
+            ]))->names(),
+            'Expected names() to return all stored file names',
+        );
+    }
 }


### PR DESCRIPTION
- Added names() enumeration to Storage interface
- Implemented names() for DiskStorage, InMemoryStorage, and DryRunStorage
- Added unit and integration tests covering storage enumeration behavior


Part of #226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage now provides a method to list all stored file names. Users can retrieve a complete inventory of files across all storage implementations—disk storage (scanning nested directories), in-memory storage, and dry-run storage—with comprehensive test coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->