### PR TITLE
Add DirectoryPath value object 

### DIFF
--- a/src/File/DirectoryPath.php
+++ b/src/File/DirectoryPath.php
@@ -12,22 +12,6 @@ final readonly class DirectoryPath
 
     public function value(): string
     {
-        return $this->normalized();
-    }
-
-    private function normalized(): string
-    {
-        if ($this->isRoot()) {
-            return $this->value;
-        }
-
-        return rtrim($this->value, '\\/');
-    }
-
-    private function isRoot(): bool
-    {
-        return $this->value === '/'
-            || $this->value === '\\'
-            || preg_match('/^[A-Za-z]:[\\\\\/]$/', $this->value) === 1;
+        return $this->value;
     }
 }

--- a/src/File/DirectoryPath.php
+++ b/src/File/DirectoryPath.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\File;
+
+use Haspadar\Piqule\PiquleException;
+
+final readonly class DirectoryPath
+{
+    public function __construct(
+        private string $value,
+    ) {}
+
+    public function value(): string
+    {
+        if ($this->isEmpty()) {
+            throw new PiquleException('Directory path cannot be empty');
+        }
+
+        if (!$this->isAbsolute()) {
+            throw new PiquleException('Directory path must be absolute');
+        }
+
+        return $this->normalized();
+    }
+
+    private function isEmpty(): bool
+    {
+        return $this->value === '';
+    }
+
+    private function isAbsolute(): bool
+    {
+        return $this->isPosixAbsolute()
+            || $this->isWindowsDriveAbsolute()
+            || $this->isWindowsUncAbsolute();
+    }
+
+    private function isPosixAbsolute(): bool
+    {
+        return str_starts_with($this->value, '/');
+    }
+
+    private function isWindowsDriveAbsolute(): bool
+    {
+        return preg_match('/^[A-Za-z]:[\\\\\\/]/', $this->value) === 1;
+    }
+
+    private function isWindowsUncAbsolute(): bool
+    {
+        return str_starts_with($this->value, '\\');
+    }
+
+    private function normalized(): string
+    {
+        return rtrim($this->value, '\\/');
+    }
+}

--- a/src/File/DirectoryPath.php
+++ b/src/File/DirectoryPath.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\File;
 
-use Haspadar\Piqule\PiquleException;
-
 final readonly class DirectoryPath
 {
     public function __construct(
@@ -14,46 +12,22 @@ final readonly class DirectoryPath
 
     public function value(): string
     {
-        if ($this->isEmpty()) {
-            throw new PiquleException('Directory path cannot be empty');
-        }
-
-        if (!$this->isAbsolute()) {
-            throw new PiquleException('Directory path must be absolute');
-        }
-
         return $this->normalized();
-    }
-
-    private function isEmpty(): bool
-    {
-        return $this->value === '';
-    }
-
-    private function isAbsolute(): bool
-    {
-        return $this->isPosixAbsolute()
-            || $this->isWindowsDriveAbsolute()
-            || $this->isWindowsUncAbsolute();
-    }
-
-    private function isPosixAbsolute(): bool
-    {
-        return str_starts_with($this->value, '/');
-    }
-
-    private function isWindowsDriveAbsolute(): bool
-    {
-        return preg_match('/^[A-Za-z]:[\\\\\\/]/', $this->value) === 1;
-    }
-
-    private function isWindowsUncAbsolute(): bool
-    {
-        return str_starts_with($this->value, '\\');
     }
 
     private function normalized(): string
     {
+        if ($this->isRoot()) {
+            return $this->value;
+        }
+
         return rtrim($this->value, '\\/');
+    }
+
+    private function isRoot(): bool
+    {
+        return $this->value === '/'
+            || $this->value === '\\'
+            || preg_match('/^[A-Za-z]:[\\\\\/]$/', $this->value) === 1;
     }
 }

--- a/src/File/NormalizedDirectoryPath.php
+++ b/src/File/NormalizedDirectoryPath.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\File;
+
+final readonly class NormalizedDirectoryPath
+{
+    public function __construct(
+        private DirectoryPath $origin,
+    ) {}
+
+    public function value(): string
+    {
+        $value = $this->origin->value();
+
+        if ($this->isRoot($value)) {
+            return $value;
+        }
+
+        return rtrim($value, '\\/');
+    }
+
+    private function isRoot(string $value): bool
+    {
+        return $value === '/'
+            || $value === '\\'
+            || preg_match('/^[A-Za-z]:[\\\\\/]$/', $value) === 1;
+    }
+}

--- a/src/File/ValidatedDirectoryPath.php
+++ b/src/File/ValidatedDirectoryPath.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\File;
+
+use Haspadar\Piqule\Path\Path;
+use Haspadar\Piqule\PiquleException;
+use Override;
+
+final readonly class ValidatedDirectoryPath implements Path
+{
+    public function __construct(
+        private DirectoryPath $origin,
+    ) {}
+
+    #[Override]
+    public function value(): string
+    {
+        $value = $this->origin->value();
+
+        if ($value === '') {
+            throw new PiquleException('Directory path cannot be empty');
+        }
+
+        if (!$this->isAbsolute($value)) {
+            throw new PiquleException('Directory path must be absolute');
+        }
+
+        return $value;
+    }
+
+    private function isAbsolute(string $value): bool
+    {
+        return str_starts_with($value, '/')
+            || str_starts_with($value, '\\')
+            || preg_match('/^[A-Za-z]:[\\\\\\/]/', $value) === 1;
+    }
+}

--- a/src/File/ValidatedDirectoryPath.php
+++ b/src/File/ValidatedDirectoryPath.php
@@ -4,17 +4,14 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\File;
 
-use Haspadar\Piqule\Path\Path;
 use Haspadar\Piqule\PiquleException;
-use Override;
 
-final readonly class ValidatedDirectoryPath implements Path
+final readonly class ValidatedDirectoryPath
 {
     public function __construct(
         private DirectoryPath $origin,
     ) {}
 
-    #[Override]
     public function value(): string
     {
         $value = $this->origin->value();

--- a/tests/Unit/File/DirectoryPathTest.php
+++ b/tests/Unit/File/DirectoryPathTest.php
@@ -5,55 +5,18 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Unit\File;
 
 use Haspadar\Piqule\File\DirectoryPath;
-use Haspadar\Piqule\PiquleException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class DirectoryPathTest extends TestCase
 {
     #[Test]
-    public function throwsWhenEmpty(): void
-    {
-        $this->expectException(PiquleException::class);
-
-        (new DirectoryPath(''))->value();
-    }
-
-    #[Test]
-    public function throwsWhenRelative(): void
-    {
-        $this->expectException(PiquleException::class);
-
-        (new DirectoryPath('relative/path'))->value();
-    }
-
-    #[Test]
-    public function returnsPosixAbsolute(): void
+    public function returnsRawValue(): void
     {
         self::assertSame(
-            '/var/www',
-            (new DirectoryPath('/var/www/'))->value(),
-            'Accepts POSIX absolute directory paths',
-        );
-    }
-
-    #[Test]
-    public function returnsWindowsDriveAbsolute(): void
-    {
-        self::assertSame(
-            'C:\Windows',
-            (new DirectoryPath('C:\Windows\\'))->value(),
-            'Accepts Windows drive absolute directory paths',
-        );
-    }
-
-    #[Test]
-    public function returnsWindowsUncAbsolute(): void
-    {
-        self::assertSame(
-            '\Windows\System32',
-            (new DirectoryPath('\Windows\System32\\'))->value(),
-            'Accepts Windows UNC absolute directory paths',
+            'any/path/value',
+            (new DirectoryPath('any/path/value'))->value(),
+            'Returns raw directory path value as provided',
         );
     }
 }

--- a/tests/Unit/File/DirectoryPathTest.php
+++ b/tests/Unit/File/DirectoryPathTest.php
@@ -19,4 +19,16 @@ final class DirectoryPathTest extends TestCase
             'Returns raw directory path value as provided',
         );
     }
+
+    #[Test]
+    public function returnsPosixRoot(): void
+    {
+        self::assertSame('/', (new DirectoryPath('/'))->value());
+    }
+
+    #[Test]
+    public function returnsWindowsDriveRoot(): void
+    {
+        self::assertSame('C:\\', (new DirectoryPath('C:\\'))->value());
+    }
 }

--- a/tests/Unit/File/DirectoryPathTest.php
+++ b/tests/Unit/File/DirectoryPathTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\File;
+
+use Haspadar\Piqule\File\DirectoryPath;
+use Haspadar\Piqule\PiquleException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DirectoryPathTest extends TestCase
+{
+    #[Test]
+    public function throwsWhenEmpty(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new DirectoryPath(''))->value();
+    }
+
+    #[Test]
+    public function throwsWhenRelative(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new DirectoryPath('relative/path'))->value();
+    }
+
+    #[Test]
+    public function returnsPosixAbsolute(): void
+    {
+        self::assertSame(
+            '/var/www',
+            (new DirectoryPath('/var/www/'))->value(),
+            'Accepts POSIX absolute directory paths',
+        );
+    }
+
+    #[Test]
+    public function returnsWindowsDriveAbsolute(): void
+    {
+        self::assertSame(
+            'C:\Windows',
+            (new DirectoryPath('C:\Windows\\'))->value(),
+            'Accepts Windows drive absolute directory paths',
+        );
+    }
+
+    #[Test]
+    public function returnsWindowsUncAbsolute(): void
+    {
+        self::assertSame(
+            '\Windows\System32',
+            (new DirectoryPath('\Windows\System32\\'))->value(),
+            'Accepts Windows UNC absolute directory paths',
+        );
+    }
+}

--- a/tests/Unit/File/NormalizedDirectoryPathTest.php
+++ b/tests/Unit/File/NormalizedDirectoryPathTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\File;
+
+use Haspadar\Piqule\File\DirectoryPath;
+use Haspadar\Piqule\File\NormalizedDirectoryPath;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NormalizedDirectoryPathTest extends TestCase
+{
+    #[Test]
+    public function keepsPosixRoot(): void
+    {
+        self::assertSame(
+            '/',
+            (new NormalizedDirectoryPath(
+                new DirectoryPath('/'),
+            ))->value(),
+            'Keeps POSIX root directory path',
+        );
+    }
+
+    #[Test]
+    public function keepsWindowsDriveRoot(): void
+    {
+        self::assertSame(
+            'C:\\',
+            (new NormalizedDirectoryPath(
+                new DirectoryPath('C:\\'),
+            ))->value(),
+            'Keeps Windows drive root directory path',
+        );
+    }
+
+    #[Test]
+    public function trimsTrailingSlashFromPosixPath(): void
+    {
+        self::assertSame(
+            '/var/www',
+            (new NormalizedDirectoryPath(
+                new DirectoryPath('/var/www/'),
+            ))->value(),
+            'Removes trailing slash from POSIX directory path',
+        );
+    }
+
+    #[Test]
+    public function trimsTrailingSlashFromWindowsPath(): void
+    {
+        self::assertSame(
+            'C:\Windows',
+            (new NormalizedDirectoryPath(
+                new DirectoryPath('C:\Windows\\'),
+            ))->value(),
+            'Removes trailing slash from Windows directory path',
+        );
+    }
+
+    #[Test]
+    public function trimsTrailingSlashFromWindowsUncPath(): void
+    {
+        self::assertSame(
+            '\Windows\System32',
+            (new NormalizedDirectoryPath(
+                new DirectoryPath('\Windows\System32\\'),
+            ))->value(),
+            'Removes trailing slash from Windows UNC directory path',
+        );
+    }
+}

--- a/tests/Unit/File/NormalizedDirectoryPathTest.php
+++ b/tests/Unit/File/NormalizedDirectoryPathTest.php
@@ -60,7 +60,7 @@ final class NormalizedDirectoryPathTest extends TestCase
     }
 
     #[Test]
-    public function trimsTrailingSlashFromWindowsUncPath(): void
+    public function trimsTrailingSlashFromWindowsRootedPath(): void
     {
         self::assertSame(
             '\Windows\System32',

--- a/tests/Unit/File/ValidatedDirectoryPathTest.php
+++ b/tests/Unit/File/ValidatedDirectoryPathTest.php
@@ -46,7 +46,7 @@ final class ValidatedDirectoryPathTest extends TestCase
     public function allowsPosixAbsolute(): void
     {
         self::assertSame(
-            '/var/www',
+            '/var/www/',
             (new ValidatedDirectoryPath(
                 new DirectoryPath('/var/www/'),
             ))->value(),
@@ -58,7 +58,7 @@ final class ValidatedDirectoryPathTest extends TestCase
     public function allowsWindowsDriveAbsolute(): void
     {
         self::assertSame(
-            'C:\Windows',
+            'C:\Windows\\',
             (new ValidatedDirectoryPath(
                 new DirectoryPath('C:\Windows\\'),
             ))->value(),
@@ -70,7 +70,7 @@ final class ValidatedDirectoryPathTest extends TestCase
     public function allowsWindowsUncAbsolute(): void
     {
         self::assertSame(
-            '\Windows\System32',
+            '\Windows\System32\\',
             (new ValidatedDirectoryPath(
                 new DirectoryPath('\Windows\System32\\'),
             ))->value(),

--- a/tests/Unit/File/ValidatedDirectoryPathTest.php
+++ b/tests/Unit/File/ValidatedDirectoryPathTest.php
@@ -77,4 +77,16 @@ final class ValidatedDirectoryPathTest extends TestCase
             'Allows Windows UNC absolute directory paths',
         );
     }
+
+    #[Test]
+    public function returnsPosixRoot(): void
+    {
+        self::assertSame('/', (new DirectoryPath('/'))->value());
+    }
+
+    #[Test]
+    public function returnsWindowsDriveRoot(): void
+    {
+        self::assertSame('C:\\', (new DirectoryPath('C:\\'))->value());
+    }
 }

--- a/tests/Unit/File/ValidatedDirectoryPathTest.php
+++ b/tests/Unit/File/ValidatedDirectoryPathTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\File;
+
+use Haspadar\Piqule\File\DirectoryPath;
+use Haspadar\Piqule\File\ValidatedDirectoryPath;
+use Haspadar\Piqule\PiquleException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ValidatedDirectoryPathTest extends TestCase
+{
+    #[Test]
+    public function throwsWhenEmpty(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new ValidatedDirectoryPath(
+            new DirectoryPath(''),
+        ))->value();
+    }
+
+    #[Test]
+    public function throwsWhenRelative(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new ValidatedDirectoryPath(
+            new DirectoryPath('relative/path'),
+        ))->value();
+    }
+
+    #[Test]
+    public function throwsWhenDriveLetterIsNotAtStart(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new ValidatedDirectoryPath(
+            new DirectoryPath('fooC:\Windows'),
+        ))->value();
+    }
+
+    #[Test]
+    public function allowsPosixAbsolute(): void
+    {
+        self::assertSame(
+            '/var/www',
+            (new ValidatedDirectoryPath(
+                new DirectoryPath('/var/www/'),
+            ))->value(),
+            'Allows POSIX absolute directory paths',
+        );
+    }
+
+    #[Test]
+    public function allowsWindowsDriveAbsolute(): void
+    {
+        self::assertSame(
+            'C:\Windows',
+            (new ValidatedDirectoryPath(
+                new DirectoryPath('C:\Windows\\'),
+            ))->value(),
+            'Allows Windows drive absolute directory paths',
+        );
+    }
+
+    #[Test]
+    public function allowsWindowsUncAbsolute(): void
+    {
+        self::assertSame(
+            '\Windows\System32',
+            (new ValidatedDirectoryPath(
+                new DirectoryPath('\Windows\System32\\'),
+            ))->value(),
+            'Allows Windows UNC absolute directory paths',
+        );
+    }
+}

--- a/tests/Unit/File/ValidatedDirectoryPathTest.php
+++ b/tests/Unit/File/ValidatedDirectoryPathTest.php
@@ -77,16 +77,4 @@ final class ValidatedDirectoryPathTest extends TestCase
             'Allows Windows UNC absolute directory paths',
         );
     }
-
-    #[Test]
-    public function returnsPosixRoot(): void
-    {
-        self::assertSame('/', (new DirectoryPath('/'))->value());
-    }
-
-    #[Test]
-    public function returnsWindowsDriveRoot(): void
-    {
-        self::assertSame('C:\\', (new DirectoryPath('C:\\'))->value());
-    }
 }


### PR DESCRIPTION
- Added DirectoryPath value object with lazy validation for absolute directory paths
- Added unit tests covering POSIX and Windows absolute path variants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added directory path value objects: raw storage, normalization (preserves roots, trims trailing separators) and validation.

* **Bug Fixes / Behavior**
  * Validation now rejects empty or non-absolute paths and enforces absolute-path formats across POSIX, Windows drive, and UNC styles.

* **Tests**
  * Added unit tests covering normalization and validation scenarios (roots, trailing separators, empty/relative, drive/UNC formats).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->