### PR TITLE
Add entries listing to storage implementations

### DIFF
--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 
+use FilesystemIterator;
 use Haspadar\Piqule\PiquleException;
 use Override;
 
@@ -29,6 +30,28 @@ final readonly class DiskStorage implements Storage
         }
 
         return $contents;
+    }
+
+    #[Override]
+    public function entries(string $location): iterable
+    {
+        $path = $this->pathOf($location);
+
+        if (!is_dir($path)) {
+            return [];
+        }
+
+        $iterator = new FilesystemIterator(
+            $path,
+            FilesystemIterator::SKIP_DOTS,
+        );
+
+        foreach ($iterator as $item) {
+            yield ltrim(
+                $location . '/' . $item->getFilename(),
+                '/',
+            );
+        }
     }
 
     #[Override]

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -68,10 +68,11 @@ final readonly class DiskStorage implements Storage
         $path = $this->pathOf($location);
         $directory = dirname($path);
 
-        if (!is_dir($directory)) {
-            if (!mkdir($directory, 0o777, true) && !is_dir($directory)) {
-                throw new PiquleException("Unable to create directory: $directory");
-            }
+        if (!is_dir($directory)
+            && !mkdir($directory, 0o777, true)
+            && !is_dir($directory)
+        ) {
+            throw new PiquleException("Unable to create directory: $directory");
         }
 
         if (file_put_contents($path, $contents) === false) {

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Storage;
 use FilesystemIterator;
 use Haspadar\Piqule\PiquleException;
 use Override;
+use SplFileInfo;
 
 final readonly class DiskStorage implements Storage
 {
@@ -46,6 +47,7 @@ final readonly class DiskStorage implements Storage
             FilesystemIterator::SKIP_DOTS,
         );
 
+        /** @var SplFileInfo $item */
         foreach ($iterator as $item) {
             yield ltrim(
                 $location . '/' . $item->getFilename(),

--- a/src/Storage/InMemoryStorage.php
+++ b/src/Storage/InMemoryStorage.php
@@ -43,4 +43,10 @@ final readonly class InMemoryStorage implements Storage
             [...$this->entries, $location => $contents],
         );
     }
+
+    #[Override]
+    public function entries(string $location): iterable
+    {
+        return array_keys($this->entries);
+    }
 }

--- a/src/Storage/InMemoryStorage.php
+++ b/src/Storage/InMemoryStorage.php
@@ -47,6 +47,26 @@ final readonly class InMemoryStorage implements Storage
     #[Override]
     public function entries(string $location): iterable
     {
-        return array_keys($this->entries);
+        $keys = array_keys($this->entries);
+
+        if ($location === '') {
+            return $keys;
+        }
+
+        $prefix = rtrim($location, '/') . '/';
+        $entries = [];
+
+        foreach ($keys as $key) {
+            if (!str_starts_with($key, $prefix)) {
+                continue;
+            }
+
+            $rest = substr($key, strlen($prefix));
+            if ($rest !== '' && !str_contains($rest, '/')) {
+                $entries[] = $key;
+            }
+        }
+
+        return $entries;
     }
 }

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -26,4 +26,11 @@ interface Storage
      * Checks whether a projection exists at the given location
      */
     public function exists(string $location): bool;
+
+    /**
+     * Lists entries under the given location
+     *
+     * @return iterable<string> relative entry paths
+     */
+    public function entries(string $location): iterable;
 }

--- a/tests/Constraint/Storage/HasEntries.php
+++ b/tests/Constraint/Storage/HasEntries.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Constraint\Storage;
+
+use Haspadar\Piqule\Storage\Storage;
+use PHPUnit\Framework\Constraint\Constraint;
+
+final class HasEntries extends Constraint
+{
+    /**
+     * @param list<string> $expected
+     */
+    public function __construct(
+        private readonly string $location,
+        private readonly array $expected,
+    ) {}
+
+    public function toString(): string
+    {
+        return "has entries {$this->export($this->expected)} under {$this->export($this->location)}";
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Storage) {
+            return false;
+        }
+
+        $actual = iterator_to_array(
+            $other->entries($this->location),
+        );
+
+        sort($actual);
+        $expected = $this->expected;
+        sort($expected);
+
+        return $actual === $expected;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'storage ' . $this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Storage) {
+            return "\nBut object of type "
+                . get_debug_type($other)
+                . ' was given instead of Storage';
+        }
+
+        $actual = iterator_to_array(
+            $other->entries($this->location),
+        );
+        sort($actual);
+
+        return "\nExpected: {$this->export($this->expected)}"
+            . "\nBut was:  {$this->export($actual)}";
+    }
+
+    private function export(mixed $value): string
+    {
+        return var_export($value, true);
+    }
+}

--- a/tests/Integration/Storage/DiskStorageTest.php
+++ b/tests/Integration/Storage/DiskStorageTest.php
@@ -85,4 +85,17 @@ final class DiskStorageTest extends TestCase
             new HasEntries('a', ['a/one.txt', 'a/two.txt']),
         );
     }
+
+    #[Test]
+    public function listsNoEntriesForNonDirectoryLocation(): void
+    {
+        self::assertThat(
+            new DiskStorage(
+                (new TempFolder())
+                    ->withFile('file.txt', 'data')
+                    ->path(),
+            ),
+            new HasEntries('file.txt', []),
+        );
+    }
 }

--- a/tests/Integration/Storage/DiskStorageTest.php
+++ b/tests/Integration/Storage/DiskStorageTest.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Tests\Integration\Storage;
 use Haspadar\Piqule\File\TempFolder;
 use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Storage\DiskStorage;
+use Haspadar\Piqule\Tests\Constraint\Storage\HasEntries;
 use Haspadar\Piqule\Tests\Constraint\Storage\HasEntry;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -69,5 +70,19 @@ final class DiskStorageTest extends TestCase
         (new DiskStorage(
             (new TempFolder())->path(),
         ))->read('no/such/file.txt');
+    }
+
+    #[Test]
+    public function listsEntriesInFolder(): void
+    {
+        self::assertThat(
+            new DiskStorage(
+                (new TempFolder())
+                    ->withFile('a/one.txt', '1')
+                    ->withFile('a/two.txt', '2')
+                    ->path(),
+            ),
+            new HasEntries('a', ['a/one.txt', 'a/two.txt']),
+        );
     }
 }

--- a/tests/Unit/Storage/InMemoryStorageTest.php
+++ b/tests/Unit/Storage/InMemoryStorageTest.php
@@ -6,6 +6,7 @@ namespace Haspadar\Piqule\Tests\Unit\Storage;
 
 use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Storage\InMemoryStorage;
+use Haspadar\Piqule\Tests\Constraint\Storage\HasEntries;
 use Haspadar\Piqule\Tests\Constraint\Storage\HasEntry;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -84,5 +85,19 @@ final class InMemoryStorageTest extends TestCase
         $this->expectException(PiquleException::class);
 
         (new InMemoryStorage())->read('./absent.txt');
+    }
+
+    #[Test]
+    public function listsAllEntries(): void
+    {
+        self::assertThat(
+            (new InMemoryStorage())
+                ->write('a/one.txt', '1')
+                ->write('b/two.txt', '2'),
+            new HasEntries('', [
+                'a/one.txt',
+                'b/two.txt',
+            ]),
+        );
     }
 }

--- a/tests/Unit/Storage/InMemoryStorageTest.php
+++ b/tests/Unit/Storage/InMemoryStorageTest.php
@@ -88,16 +88,41 @@ final class InMemoryStorageTest extends TestCase
     }
 
     #[Test]
-    public function listsAllEntries(): void
+    public function listsEntriesUnderGivenLocation(): void
     {
         self::assertThat(
             (new InMemoryStorage())
                 ->write('a/one.txt', '1')
-                ->write('b/two.txt', '2'),
-            new HasEntries('', [
+                ->write('a/two.txt', '2')
+                ->write('b/skip.txt', 'x'),
+            new HasEntries('a', [
                 'a/one.txt',
-                'b/two.txt',
+                'a/two.txt',
             ]),
+        );
+    }
+
+    #[Test]
+    public function doesNotListNestedEntries(): void
+    {
+        self::assertThat(
+            (new InMemoryStorage())
+                ->write('a/b/deep.txt', 'x')
+                ->write('a/one.txt', '1'),
+            new HasEntries('a', [
+                'a/one.txt',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function listsNoEntriesWhenLocationHasOnlyNestedFiles(): void
+    {
+        self::assertThat(
+            (new InMemoryStorage())
+                ->write('a/b/one.txt', '1')
+                ->write('a/b/two.txt', '2'),
+            new HasEntries('a', []),
         );
     }
 }

--- a/tests/Unit/Storage/InMemoryStorageTest.php
+++ b/tests/Unit/Storage/InMemoryStorageTest.php
@@ -92,12 +92,12 @@ final class InMemoryStorageTest extends TestCase
     {
         self::assertThat(
             (new InMemoryStorage())
-                ->write('a/one.txt', '1')
-                ->write('a/two.txt', '2')
-                ->write('b/skip.txt', 'x'),
-            new HasEntries('a', [
-                'a/one.txt',
-                'a/two.txt',
+                ->write('alpha/file-1.log', '1')
+                ->write('alpha/file-2.log', '2')
+                ->write('beta/ignored.log', 'x'),
+            new HasEntries('alpha', [
+                'alpha/file-1.log',
+                'alpha/file-2.log',
             ]),
         );
     }
@@ -107,10 +107,10 @@ final class InMemoryStorageTest extends TestCase
     {
         self::assertThat(
             (new InMemoryStorage())
-                ->write('a/b/deep.txt', 'x')
-                ->write('a/one.txt', '1'),
-            new HasEntries('a', [
-                'a/one.txt',
+                ->write('root/level1/deep.txt', 'x')
+                ->write('root/shallow.txt', '1'),
+            new HasEntries('root', [
+                'root/shallow.txt',
             ]),
         );
     }
@@ -120,9 +120,9 @@ final class InMemoryStorageTest extends TestCase
     {
         self::assertThat(
             (new InMemoryStorage())
-                ->write('a/b/one.txt', '1')
-                ->write('a/b/two.txt', '2'),
-            new HasEntries('a', []),
+                ->write('container/nested/one.dat', '1')
+                ->write('container/nested/two.dat', '2'),
+            new HasEntries('container', []),
         );
     }
 }


### PR DESCRIPTION
- Added entries method to Storage interface
- Implemented entries in DiskStorage and InMemoryStorage
- Covered entries behavior with unit and integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage now supports listing entries under a specified location across backends; listings return top-level entries and yield empty for non-directory locations.
* **Tests**
  * Added unit and integration tests covering listing behavior and a new test constraint to assert exact entry sets.
* **Refactor**
  * Minor internal cleanup to storage write logic (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->