### PR TITLE
Add ReplacedFile for pure content transformation

### DIFF
--- a/src/File/ReplacedFile.php
+++ b/src/File/ReplacedFile.php
@@ -6,6 +6,8 @@ namespace Haspadar\Piqule\File;
 
 namespace Haspadar\Piqule\File;
 
+use Override;
+
 final readonly class ReplacedFile implements File
 {
     public function __construct(
@@ -14,13 +16,13 @@ final readonly class ReplacedFile implements File
         private string $replace,
     ) {}
 
-    #[\Override]
+    #[Override]
     public function name(): string
     {
         return $this->origin->name();
     }
 
-    #[\Override]
+    #[Override]
     public function contents(): string
     {
         return str_replace(

--- a/src/File/ReplacedFile.php
+++ b/src/File/ReplacedFile.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\File;
+
+namespace Haspadar\Piqule\File;
+
+final readonly class ReplacedFile implements File
+{
+    public function __construct(
+        private File $origin,
+        private string $search,
+        private string $replace,
+    ) {}
+
+    #[\Override]
+    public function name(): string
+    {
+        return $this->origin->name();
+    }
+
+    #[\Override]
+    public function contents(): string
+    {
+        return str_replace(
+            $this->search,
+            $this->replace,
+            $this->origin->contents(),
+        );
+    }
+}

--- a/tests/Unit/File/ReplacedFileTest.php
+++ b/tests/Unit/File/ReplacedFileTest.php
@@ -26,4 +26,20 @@ final class ReplacedFileTest extends TestCase
             ))->contents(),
         );
     }
+
+    #[Test]
+    public function delegatesName(): void
+    {
+        self::assertSame(
+            'config/app.ini',
+            (new ReplacedFile(
+                new TextFile(
+                    'config/app.ini',
+                    'x',
+                ),
+                'x',
+                'y',
+            ))->name(),
+        );
+    }
 }

--- a/tests/Unit/File/ReplacedFileTest.php
+++ b/tests/Unit/File/ReplacedFileTest.php
@@ -31,10 +31,10 @@ final class ReplacedFileTest extends TestCase
     public function delegatesName(): void
     {
         self::assertSame(
-            'config/app.ini',
+            'README.md',
             (new ReplacedFile(
                 new TextFile(
-                    'config/app.ini',
+                    'README.md',
                     'x',
                 ),
                 'x',

--- a/tests/Unit/File/ReplacedFileTest.php
+++ b/tests/Unit/File/ReplacedFileTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\File;
+
+use Haspadar\Piqule\File\ReplacedFile;
+use Haspadar\Piqule\File\TextFile;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ReplacedFileTest extends TestCase
+{
+    #[Test]
+    public function replacesContents(): void
+    {
+        self::assertSame(
+            'version=1.2.3',
+            (new ReplacedFile(
+                new TextFile(
+                    'config/app.ini',
+                    'version={{version}}',
+                ),
+                '{{version}}',
+                '1.2.3',
+            ))->contents(),
+        );
+    }
+}


### PR DESCRIPTION
- Added ReplacedFile as a pure File decorator that replaces contents without IO
- Added a focused unit test to document and lock the transformation behavior
