### PR TITLE
Add diffing storage with created and updated reactions

### DIFF
--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -21,15 +21,21 @@ final readonly class DiffingStorage implements Storage
         $path = $file->name();
 
         if (!$this->origin->exists($path)) {
-            $this->origin->write($file);
             $this->reaction->created($path);
 
-            return $this;
+            return new self(
+                $this->origin->write($file),
+                $this->reaction,
+            );
         }
 
         if ($this->origin->read($path) !== $file->contents()) {
-            $this->origin->write($file);
             $this->reaction->updated($path);
+
+            return new self(
+                $this->origin->write($file),
+                $this->reaction,
+            );
         }
 
         return $this;

--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Storage;
+
+use Haspadar\Piqule\File\File;
+use Haspadar\Piqule\Storage\Reaction\StorageReaction;
+use Override;
+
+final readonly class DiffingStorage implements Storage
+{
+    public function __construct(
+        private Storage $origin,
+        private StorageReaction $reaction,
+    ) {}
+
+    #[Override]
+    public function write(File $file): self
+    {
+        $path = $file->name();
+
+        if (!$this->origin->exists($path)) {
+            $this->origin->write($file);
+            $this->reaction->created($path);
+
+            return $this;
+        }
+
+        if ($this->origin->read($path) !== $file->contents()) {
+            $this->origin->write($file);
+            $this->reaction->updated($path);
+        }
+
+        return $this;
+    }
+
+    #[Override]
+    public function read(string $location): string
+    {
+        return $this->origin->read($location);
+    }
+
+    #[Override]
+    public function exists(string $location): bool
+    {
+        return $this->origin->exists($location);
+    }
+
+    #[Override]
+    public function entries(string $location): iterable
+    {
+        return $this->origin->entries($location);
+    }
+}

--- a/src/Storage/Reaction/FakeStorageReaction.php
+++ b/src/Storage/Reaction/FakeStorageReaction.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Storage\Reaction;
+
+use Override;
+
+final class FakeStorageReaction implements StorageReaction
+{
+    /** @var list<string> */
+    private array $created = [];
+
+    /** @var list<string> */
+    private array $updated = [];
+
+    #[Override]
+    public function created(string $path): void
+    {
+        $this->created[] = $path;
+    }
+
+    #[Override]
+    public function updated(string $path): void
+    {
+        $this->updated[] = $path;
+    }
+
+    /** @return list<string> */
+    public function createdPaths(): array
+    {
+        return $this->created;
+    }
+
+    /** @return list<string> */
+    public function updatedPaths(): array
+    {
+        return $this->updated;
+    }
+}

--- a/src/Storage/Reaction/StorageReaction.php
+++ b/src/Storage/Reaction/StorageReaction.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Storage\Reaction;
+
+interface StorageReaction
+{
+    public function created(string $path): void;
+
+    public function updated(string $path): void;
+}

--- a/tests/Unit/Storage/DiffingStorageTest.php
+++ b/tests/Unit/Storage/DiffingStorageTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Storage;
+
+use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\Storage\DiffingStorage;
+use Haspadar\Piqule\Storage\InMemoryStorage;
+use Haspadar\Piqule\Storage\Reaction\FakeStorageReaction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DiffingStorageTest extends TestCase
+{
+    #[Test]
+    public function reportsCreatedWhenFileDoesNotExist(): void
+    {
+        $reaction = new FakeStorageReaction();
+
+        (new DiffingStorage(
+            new InMemoryStorage(),
+            $reaction,
+        ))->write(
+            new TextFile('created.txt', 'data'),
+        );
+
+        self::assertSame(
+            ['created.txt'],
+            $reaction->createdPaths(),
+        );
+    }
+
+    #[Test]
+    public function reportsUpdatedWhenFileExistsWithDifferentContents(): void
+    {
+        $reaction = new FakeStorageReaction();
+
+        (new DiffingStorage(
+            new InMemoryStorage([
+                'updated.txt' => 'old',
+            ]),
+            $reaction,
+        ))->write(
+            new TextFile('updated.txt', 'new'),
+        );
+
+        self::assertSame(
+            ['updated.txt'],
+            $reaction->updatedPaths(),
+        );
+    }
+
+    #[Test]
+    public function doesNotReportAnythingWhenContentsAreTheSame(): void
+    {
+        $reaction = new FakeStorageReaction();
+
+        (new DiffingStorage(
+            new InMemoryStorage([
+                'same.txt' => 'data',
+            ]),
+            $reaction,
+        ))->write(
+            new TextFile('same.txt', 'data'),
+        );
+
+        self::assertSame(
+            [],
+            $reaction->createdPaths(),
+        );
+    }
+}

--- a/tests/Unit/Storage/DiffingStorageTest.php
+++ b/tests/Unit/Storage/DiffingStorageTest.php
@@ -69,6 +69,10 @@ final class DiffingStorageTest extends TestCase
             [],
             $reaction->createdPaths(),
         );
+        self::assertSame(
+            [],
+            $reaction->updatedPaths(),
+        );
     }
 
     #[Test]

--- a/tests/Unit/Storage/DiffingStorageTest.php
+++ b/tests/Unit/Storage/DiffingStorageTest.php
@@ -93,18 +93,4 @@ final class DiffingStorageTest extends TestCase
             ))->exists('b.txt'),
         );
     }
-
-    #[Test]
-    public function delegatesEntriesToOrigin(): void
-    {
-        self::assertSame(
-            ['dir/file.txt'],
-            iterator_to_array(
-                (new DiffingStorage(
-                    new InMemoryStorage(['dir/file.txt' => 'x']),
-                    new FakeStorageReaction(),
-                ))->entries('dir'),
-            ),
-        );
-    }
 }

--- a/tests/Unit/Storage/DiffingStorageTest.php
+++ b/tests/Unit/Storage/DiffingStorageTest.php
@@ -70,4 +70,41 @@ final class DiffingStorageTest extends TestCase
             $reaction->createdPaths(),
         );
     }
+
+    #[Test]
+    public function delegatesReadToOrigin(): void
+    {
+        self::assertSame(
+            'data',
+            (new DiffingStorage(
+                new InMemoryStorage(['a.txt' => 'data']),
+                new FakeStorageReaction(),
+            ))->read('a.txt'),
+        );
+    }
+
+    #[Test]
+    public function delegatesExistsToOrigin(): void
+    {
+        self::assertTrue(
+            (new DiffingStorage(
+                new InMemoryStorage(['b.txt' => 'x']),
+                new FakeStorageReaction(),
+            ))->exists('b.txt'),
+        );
+    }
+
+    #[Test]
+    public function delegatesEntriesToOrigin(): void
+    {
+        self::assertSame(
+            ['dir/file.txt'],
+            iterator_to_array(
+                (new DiffingStorage(
+                    new InMemoryStorage(['dir/file.txt' => 'x']),
+                    new FakeStorageReaction(),
+                ))->entries('dir'),
+            ),
+        );
+    }
 }

--- a/tests/Unit/Storage/Reaction/FakeStorageReactionTest.php
+++ b/tests/Unit/Storage/Reaction/FakeStorageReactionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Storage\Reaction;
+
+use Haspadar\Piqule\Storage\Reaction\FakeStorageReaction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FakeStorageReactionTest extends TestCase
+{
+    #[Test]
+    public function collectsCreatedPaths(): void
+    {
+        $reaction = new FakeStorageReaction();
+
+        $reaction->created('a.txt');
+
+        self::assertSame(
+            ['a.txt'],
+            $reaction->createdPaths(),
+        );
+    }
+
+    #[Test]
+    public function collectsUpdatedPaths(): void
+    {
+        $reaction = new FakeStorageReaction();
+
+        $reaction->updated('b.txt');
+
+        self::assertSame(
+            ['b.txt'],
+            $reaction->updatedPaths(),
+        );
+    }
+}


### PR DESCRIPTION
- Added DiffingStorage to detect file creation and updates based on content comparison
- Introduced StorageReaction abstraction with created and updated notifications
- Added FakeStorageReaction for collecting storage events
- Added unit tests covering diffing behavior and reaction collection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects file creations vs. content updates and emits corresponding change events
  * Read/exists/entries operations continue to delegate to underlying storage

* **Tests**
  * Added unit tests validating create/update detection and delegation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->