### PR TITLE
Refine FilePlaceholders parsing and tests 

### DIFF
--- a/src/Placeholders/FilePlaceholders.php
+++ b/src/Placeholders/FilePlaceholders.php
@@ -27,13 +27,8 @@ final readonly class FilePlaceholders implements Placeholders
         foreach ($matches as $match) {
             yield new DefaultPlaceholder(
                 $match[0],
-                $this->unquoted($match['value']),
+                trim($match['value'], "'\" "),
             );
         }
-    }
-
-    private function unquoted(string $value): string
-    {
-        return preg_replace('/^(["\'])(.*)\1$/', '$2', $value) ?? $value;
     }
 }

--- a/src/Placeholders/FilePlaceholders.php
+++ b/src/Placeholders/FilePlaceholders.php
@@ -18,12 +18,7 @@ final readonly class FilePlaceholders implements Placeholders
     public function all(): iterable
     {
         preg_match_all(
-            '/\{\{\s*
-                (?<expression>
-                    [A-Z0-9_]+
-                    \s*\|\s*
-                    default\("(?<default>[^"]*)"\)
-                ) \s*}}/x',
+            '/\{\{\s*(?<expression>[A-Z0-9_]+\s*\|\s*default\((?<value>[^)]*)\))\s*}}/',
             $this->file->contents(),
             $matches,
             PREG_SET_ORDER,
@@ -32,8 +27,13 @@ final readonly class FilePlaceholders implements Placeholders
         foreach ($matches as $match) {
             yield new DefaultPlaceholder(
                 $match[0],
-                $match['default'],
+                $this->unquoted($match['value']),
             );
         }
+    }
+
+    private function unquoted(string $value): string
+    {
+        return preg_replace('/^(["\'])(.*)\1$/', '$2', $value) ?? $value;
     }
 }

--- a/tests/Constraint/Placeholders/HasPlaceholders.php
+++ b/tests/Constraint/Placeholders/HasPlaceholders.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Constraint\Placeholders;
+
+use Haspadar\Piqule\Placeholder\Placeholder;
+use Haspadar\Piqule\Placeholders\Placeholders;
+use PHPUnit\Framework\Constraint\Constraint;
+
+final class HasPlaceholders extends Constraint
+{
+    /**
+     * @param array<string, string> $expected expression => default
+     */
+    public function __construct(
+        private readonly array $expected,
+    ) {}
+
+    public function toString(): string
+    {
+        return 'has placeholders ' . $this->export($this->expected);
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Placeholders) {
+            return false;
+        }
+
+        $actual = [];
+
+        foreach ($other->all() as $placeholder) {
+            if (!$placeholder instanceof Placeholder) {
+                return false;
+            }
+
+            $actual[$placeholder->expression()] = $placeholder->replacement();
+        }
+
+        ksort($actual);
+        $expected = $this->expected;
+        ksort($expected);
+
+        return $actual === $expected;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'placeholders ' . $this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Placeholders) {
+            return "\nBut object of type "
+                . get_debug_type($other)
+                . ' was given instead of Placeholders';
+        }
+
+        $actual = [];
+
+        foreach ($other->all() as $placeholder) {
+            $actual[$placeholder->expression()] = $placeholder->replacement();
+        }
+
+        ksort($actual);
+
+        return "\nExpected: {$this->export($this->expected)}"
+            . "\nBut was:  {$this->export($actual)}";
+    }
+
+    private function export(mixed $value): string
+    {
+        return var_export($value, true);
+    }
+}

--- a/tests/Unit/Placeholders/FilePlaceholdersTest.php
+++ b/tests/Unit/Placeholders/FilePlaceholdersTest.php
@@ -5,27 +5,92 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Unit\Placeholders;
 
 use Haspadar\Piqule\File\TextFile;
-use Haspadar\Piqule\Placeholder\DefaultPlaceholder;
 use Haspadar\Piqule\Placeholders\FilePlaceholders;
+use Haspadar\Piqule\Tests\Constraint\Placeholders\HasPlaceholders;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class FilePlaceholdersTest extends TestCase
 {
     #[Test]
-    public function extractsDefaultPlaceholderFromFile(): void
+    public function extractsUnquotedDefault(): void
     {
-        $placeholders = new FilePlaceholders(
-            new TextFile(
-                'config.yml',
-                'coverage: {{ COVERAGE_RANGE | default("80...100") }}',
+        self::assertThat(
+            new FilePlaceholders(
+                new TextFile(
+                    'server.yml',
+                    'port: {{ PORT | default(8080) }}',
+                ),
             ),
+            new HasPlaceholders([
+                '{{ PORT | default(8080) }}' => '8080',
+            ]),
         );
+    }
 
-        self::assertEquals(
-            [new DefaultPlaceholder('{{ COVERAGE_RANGE | default("80...100") }}', '80...100')],
-            [...$placeholders->all()],
-            'FilePlaceholders did not extract default placeholder from file',
+    #[Test]
+    public function removesSingleQuotesFromDefault(): void
+    {
+        self::assertThat(
+            new FilePlaceholders(
+                new TextFile(
+                    'app.yml',
+                    "mode: {{ MODE | default('strict') }}",
+                ),
+            ),
+            new HasPlaceholders([
+                "{{ MODE | default('strict') }}" => 'strict',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function removesDoubleQuotesFromDefault(): void
+    {
+        self::assertThat(
+            new FilePlaceholders(
+                new TextFile(
+                    'log.yml',
+                    'level: {{ LEVEL | default("warn") }}',
+                ),
+            ),
+            new HasPlaceholders([
+                '{{ LEVEL | default("warn") }}' => 'warn',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function keepsBooleanDefaultAsString(): void
+    {
+        self::assertThat(
+            new FilePlaceholders(
+                new TextFile(
+                    'features.yml',
+                    'debug: {{ DEBUG | default(false) }}',
+                ),
+            ),
+            new HasPlaceholders([
+                '{{ DEBUG | default(false) }}' => 'false',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsMultiplePlaceholdersFromSameFile(): void
+    {
+        self::assertThat(
+            new FilePlaceholders(
+                new TextFile(
+                    'application.yml',
+                    'port: {{ PORT | default(8080) }}, mode: {{ MODE | default("prod") }}, debug: {{ DEBUG | default(false) }}',
+                ),
+            ),
+            new HasPlaceholders([
+                '{{ PORT | default(8080) }}' => '8080',
+                '{{ MODE | default("prod") }}' => 'prod',
+                '{{ DEBUG | default(false) }}' => 'false',
+            ]),
         );
     }
 }

--- a/tests/Unit/Placeholders/FilePlaceholdersTest.php
+++ b/tests/Unit/Placeholders/FilePlaceholdersTest.php
@@ -93,4 +93,20 @@ final class FilePlaceholdersTest extends TestCase
             ]),
         );
     }
+
+    #[Test]
+    public function removesQuotesWithSurroundingWhitespace(): void
+    {
+        self::assertThat(
+            new FilePlaceholders(
+                new TextFile(
+                    'settings.yml',
+                    "mode: {{ MODE | default( 'strict' ) }}",
+                ),
+            ),
+            new HasPlaceholders([
+                "{{ MODE | default( 'strict' ) }}" => 'strict',
+            ]),
+        );
+    }
 }


### PR DESCRIPTION
- Updated FilePlaceholders to normalize quoted default values during parsing
- Added HasPlaceholders constraint to assert placeholder contracts
- Expanded unit tests to cover quoted and unquoted defaults

Part of #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected placeholder default extraction to consistently trim surrounding quotes and whitespace, and to preserve boolean defaults as strings.

* **Tests**
  * Added comprehensive tests covering single/double-quoted defaults, surrounding whitespace, boolean-as-string cases, and multiple placeholders per file; introduced a reusable test assertion to improve clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->