### PR TITLE
Parameterize hadolint configuration

### DIFF
--- a/.piqule/codecov/coverage.xml
+++ b/.piqule/codecov/coverage.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<psalm xmlns="https://getpsalm.org/schema/config" errorLevel="1" findUnusedCode="false">
-  <projectFiles>
-    <directory name="../../src"/>
-    <ignoreFiles>
-      <directory name="../../vendor"/>
-    </ignoreFiles>
-  </projectFiles>
-</psalm>

--- a/templates/root/.piqule/codecov/coverage.xml
+++ b/templates/root/.piqule/codecov/coverage.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<psalm xmlns="https://getpsalm.org/schema/config" errorLevel="1" findUnusedCode="false">
-  <projectFiles>
-    <directory name="../../src"/>
-    <ignoreFiles>
-      <directory name="../../vendor"/>
-    </ignoreFiles>
-  </projectFiles>
-</psalm>

--- a/templates/root/.piqule/hadolint/.hadolint.yml
+++ b/templates/root/.piqule/hadolint/.hadolint.yml
@@ -21,7 +21,7 @@ ignored:
 # failure-threshold — minimum severity that will cause the workflow to fail
 # ------------------------------------------------------------------------------
 
-failure-threshold: error
+failure-threshold: {{HADOLINT_FAILURE_THRESHOLD | default('error')}}
 # Meaning: error → fail; warning → allowed
 
 


### PR DESCRIPTION
- Removed a misplaced Psalm configuration file from Codecov templates
- Parameterized the hadolint configuration to allow project-specific strictness

Part of #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused code coverage configuration files from project templates.
  * Enhanced Docker linting configuration to support customizable failure threshold settings through configuration variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->