### PR TITLE
Restrict phpunit and symfony/process major versions 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,14 +82,14 @@
     "require": {
       "php": ">=8.3",
       "friendsofphp/php-cs-fixer": "^3.91",
-      "phpunit/phpunit": "<12.6",
+      "phpunit/phpunit": "^12.0",
       "infection/infection": "^0.32.0",
       "phpstan/phpstan": "^2.1",
       "vimeo/psalm": "^6.14",
       "phpmd/phpmd": "^2.15",
       "phpmetrics/phpmetrics": "^2.9",
       "phpcsstandards/php_codesniffer": "^4.0",
-      "symfony/process": "<8.0"
+      "symfony/process": "^7.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60a9b5642fcafc24534cbe6256b33020",
+    "content-hash": "647b3a6585bcef88caafbd24c85ffde0",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3330,16 +3330,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.2",
+            "version": "12.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b"
+                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4a9739b51cbcb355f6e95659612f92e282a7077b",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b015312f28dd75b75d3422ca37dff2cd1a565e8d",
+                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d",
                 "shasum": ""
             },
             "require": {
@@ -3395,7 +3395,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.3"
             },
             "funding": [
                 {
@@ -3415,7 +3415,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:03:04+00:00"
+            "time": "2026-02-06T06:01:44+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",


### PR DESCRIPTION
- Updated phpunit/phpunit constraint to allow only 12.x
- Updated symfony/process constraint to allow only 7.x
- Regenerated composer.lock to match updated constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHPUnit to version 12.0+
  * Updated Symfony Process to version 7.0+

<!-- end of auto-generated comment: release notes by coderabbit.ai -->