### PR TITLE
Add PHP placeholders and stabilize template substitution 

### DIFF
--- a/.piqule/markdownlint/.markdownlint-cli2.jsonc
+++ b/.piqule/markdownlint/.markdownlint-cli2.jsonc
@@ -10,10 +10,5 @@
   },
 
   // Ignore dependency/vendor directories to avoid linting third-party content.
-  "ignores": [
-    "**/vendor/**",
-    "**/node_modules/**",
-    "**/coverage/**",
-    "**/.git/**"
-  ]
+  "ignores": ["**/vendor/**","**/node_modules/**","**/coverage/**","**/.git/**"]
 }

--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -19,9 +19,9 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PER-CS2.0' => true,
-        '@PHP83Migration' => true,
-        '@PHP84Migration' => true,
-        '@PHP85Migration' => true,
+        '@PHP8x3Migration' => true,
+        '@PHP8x4Migration' => true,
+        '@PHP8x5Migration' => true,
 
         // Arrays
         'array_syntax' => ['syntax' => 'short'],

--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -19,7 +19,9 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PER-CS2.0' => true,
-        '@PHP82Migration' => true,
+        '@PHP83Migration' => true,
+        '@PHP84Migration' => true,
+        '@PHP85Migration' => true,
 
         // Arrays
         'array_syntax' => ['syntax' => 'short'],

--- a/bin/piqule-sync.php
+++ b/bin/piqule-sync.php
@@ -14,6 +14,7 @@ use Haspadar\Piqule\Output\Console;
 use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Placeholders\CombinedPlaceholders;
 use Haspadar\Piqule\Placeholders\JsonPlaceholders;
+use Haspadar\Piqule\Placeholders\PhpPlaceholders;
 use Haspadar\Piqule\Placeholders\YamlPlaceholders;
 use Haspadar\Piqule\Storage\DiffingStorage;
 use Haspadar\Piqule\Storage\DiskStorage;
@@ -40,6 +41,7 @@ try {
                 new CombinedPlaceholders([
                     new YamlPlaceholders($file),
                     new JsonPlaceholders($file),
+                    new PhpPlaceholders($file),
                 ]),
             ),
         ),

--- a/src/Placeholders/PhpPlaceholders.php
+++ b/src/Placeholders/PhpPlaceholders.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Placeholders;
+
+use Haspadar\Piqule\File\File;
+use Haspadar\Piqule\Placeholder\DefaultPlaceholder;
+use Override;
+
+final readonly class PhpPlaceholders implements Placeholders
+{
+    public function __construct(
+        private File $file,
+    ) {}
+
+    #[Override]
+    public function all(): iterable
+    {
+        preg_match_all(
+            '/\[
+                \s*(?:\'|")\$placeholder(?:\'|")\s*=>\s*(?:\'|")(?<name>[A-Z0-9_]+)(?:\'|")\s*,\s*
+                (?:\'|")default(?:\'|")\s*=>\s*(?<default>
+                    \[[^\]]*\]        # array
+                    |
+                    [^,\]]+           # scalar
+                )
+            \s*,?\s*
+            \]/sx',
+            $this->file->contents(),
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        foreach ($matches as $match) {
+            yield new DefaultPlaceholder(
+                $match[0],
+                trim($match['default']),
+            );
+        }
+    }
+}

--- a/src/Placeholders/PhpPlaceholders.php
+++ b/src/Placeholders/PhpPlaceholders.php
@@ -8,12 +8,59 @@ use Haspadar\Piqule\File\File;
 use Haspadar\Piqule\Placeholder\DefaultPlaceholder;
 use Override;
 
+/**
+ * Extracts PHP-style placeholders from a file using a text-based pattern.
+ *
+ * This implementation treats the file contents as plain text and searches for
+ * placeholder definitions expressed as PHP array literals in the following form:
+ *
+ * [
+ *     '$placeholder' => 'PLACEHOLDER_NAME',
+ *     'default' => DEFAULT_VALUE,
+ * ]
+ *
+ * Where:
+ * - PLACEHOLDER_NAME consists of uppercase letters, digits, and underscores
+ * - DEFAULT_VALUE is a PHP literal embedded directly in the template
+ *
+ * The entire placeholder array expression is replaced with the resolved default
+ * value via string substitution.
+ *
+ * Design notes:
+ * - This parser does not parse PHP code structurally.
+ * - No AST, tokenization, or PHP evaluation is performed.
+ * - Placeholders are detected purely by regular expression matching.
+ * - The default value is extracted as text and normalized by trimming
+ *   surrounding whitespace.
+ * - If no placeholders are found, this parser is effectively a no-op.
+ *
+ * Intended usage:
+ * - PHP configuration templates
+ * - Syntactically valid, but not necessarily executable PHP files
+ * - Safe to combine with other Placeholders implementations (e.g. YAML, JSON),
+ *   as unmatched formats simply yield no placeholders.
+ *
+ * Limitations (by design):
+ * - DEFAULT_VALUE must be a literal whose textual boundaries can be determined
+ *   without parsing PHP.
+ * - Nested or complex PHP expressions are not supported.
+ * - Placeholder definitions must remain syntactically stable.
+ */
 final readonly class PhpPlaceholders implements Placeholders
 {
     public function __construct(
         private File $file,
     ) {}
 
+    /**
+     * Returns all PHP placeholders found in the file.
+     *
+     * Each placeholder is represented as a DefaultPlaceholder where:
+     * - expression() is the full PHP array literal representing the placeholder
+     * - replacement() is the normalized default value as text
+     *
+     * @return iterable<DefaultPlaceholder>
+     */
     #[Override]
     public function all(): iterable
     {
@@ -21,9 +68,9 @@ final readonly class PhpPlaceholders implements Placeholders
             '/\[
                 \s*(?:\'|")\$placeholder(?:\'|")\s*=>\s*(?:\'|")(?<name>[A-Z0-9_]+)(?:\'|")\s*,\s*
                 (?:\'|")default(?:\'|")\s*=>\s*(?<default>
-                    \[[^\]]*\]        # array
+                    \[[^\]]*\]
                     |
-                    [^,\]]+           # scalar
+                    [^,\]]+
                 )
             \s*,?\s*
             \]/sx',

--- a/src/Placeholders/PhpPlaceholders.php
+++ b/src/Placeholders/PhpPlaceholders.php
@@ -61,7 +61,7 @@ final readonly class PhpPlaceholders implements Placeholders
     public function all(): iterable
     {
         preg_match_all(
-            '/\[\s*(?:\'|")\$placeholder(?:\'|")\s*=>\s*(?:\'|")[A-Z0-9_]+(?:\'|")\s*,\s*(?:\'|")default(?:\'|")\s*=>\s*(\[[^\]]*\]|[^,\]]+)\s*,?\s*\]/s',
+            '/\[\s*["\']\$placeholder["\']\s*=>\s*["\'][A-Z0-9_]+["\']\s*,\s*["\']default["\']\s*=>\s*(\[[^\]]*\]|[^,\]]+)\s*,?\s*\]/s',
             $this->file->contents(),
             $matches,
             PREG_SET_ORDER,

--- a/templates/root/.piqule/markdownlint/.markdownlint-cli2.jsonc
+++ b/templates/root/.piqule/markdownlint/.markdownlint-cli2.jsonc
@@ -10,10 +10,8 @@
   },
 
   // Ignore dependency/vendor directories to avoid linting third-party content.
-  "ignores": [
-    "**/vendor/**",
-    "**/node_modules/**",
-    "**/coverage/**",
-    "**/.git/**"
-  ]
+  "ignores": {
+    "$placeholder": "MARKDOWNLINT_IGNORES",
+    "default": ["**/vendor/**","**/node_modules/**","**/coverage/**","**/.git/**"]
+  }
 }

--- a/templates/root/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/templates/root/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -19,7 +19,9 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PER-CS2.0' => true,
-        '@PHP82Migration' => true,
+        '@PHP83Migration' => true,
+        '@PHP84Migration' => true,
+        '@PHP85Migration' => true,
 
         // Arrays
         'array_syntax' => ['syntax' => 'short'],
@@ -96,4 +98,7 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'ternary_operator_spaces' => true,
     ])
-    ->setUnsupportedPhpVersionAllowed(true);
+    ->setUnsupportedPhpVersionAllowed([
+        '$placeholder' => 'PHP_CS_FIXER_ALLOW_UNSUPPORTED',
+        'default' => true
+    ]);

--- a/templates/root/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/templates/root/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -98,7 +98,4 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'ternary_operator_spaces' => true,
     ])
-    ->setUnsupportedPhpVersionAllowed([
-        '$placeholder' => 'PHP_CS_FIXER_ALLOW_UNSUPPORTED',
-        'default' => true
-    ]);
+    ->setUnsupportedPhpVersionAllowed(/* @placeholder PHP_CS_FIXER_ALLOW_UNSUPPORTED default(true) */);

--- a/templates/root/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/templates/root/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -19,9 +19,9 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PER-CS2.0' => true,
-        '@PHP83Migration' => true,
-        '@PHP84Migration' => true,
-        '@PHP85Migration' => true,
+        '@PHP8x3Migration' => true,
+        '@PHP8x4Migration' => true,
+        '@PHP8x5Migration' => true,
 
         // Arrays
         'array_syntax' => ['syntax' => 'short'],

--- a/tests/Unit/Placeholders/PhpPlaceholdersTest.php
+++ b/tests/Unit/Placeholders/PhpPlaceholdersTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Placeholders;
+
+use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\Placeholders\PhpPlaceholders;
+use Haspadar\Piqule\Tests\Constraint\Placeholders\HasPlaceholders;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PhpPlaceholdersTest extends TestCase
+{
+    #[Test]
+    public function extractsNumericDefault(): void
+    {
+        self::assertThat(
+            new PhpPlaceholders(
+                new TextFile(
+                    'timeout.php',
+                    "setTimeout(['\$placeholder' => 'TIMEOUT', 'default' => 30]);",
+                ),
+            ),
+            new HasPlaceholders([
+                "['\$placeholder' => 'TIMEOUT', 'default' => 30]" => '30',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsStringDefault(): void
+    {
+        self::assertThat(
+            new PhpPlaceholders(
+                new TextFile(
+                    'path.php',
+                    "setPath(['\$placeholder' => 'BASE_PATH', 'default' => '../app']);",
+                ),
+            ),
+            new HasPlaceholders([
+                "['\$placeholder' => 'BASE_PATH', 'default' => '../app']" => "'../app'",
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsArrayDefault(): void
+    {
+        self::assertThat(
+            new PhpPlaceholders(
+                new TextFile(
+                    'rules.php',
+                    "setRules(['\$placeholder' => 'RULES', 'default' => ['a' => 1, 'b' => 2]]);",
+                ),
+            ),
+            new HasPlaceholders([
+                "['\$placeholder' => 'RULES', 'default' => ['a' => 1, 'b' => 2]]"
+                => "['a' => 1, 'b' => 2]",
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsMultiplePlaceholdersFromSameFile(): void
+    {
+        self::assertThat(
+            new PhpPlaceholders(
+                new TextFile(
+                    'multiple.php',
+                    "configure(
+                        ['\$placeholder' => 'FIRST', 'default' => true],
+                        ['\$placeholder' => 'SECOND', 'default' => ['x', 'y']]
+                    );",
+                ),
+            ),
+            new HasPlaceholders([
+                "['\$placeholder' => 'FIRST', 'default' => true]" => 'true',
+                "['\$placeholder' => 'SECOND', 'default' => ['x', 'y']]"
+                => "['x', 'y']",
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsBooleanDefaultFromMultilineArray(): void
+    {
+        self::assertThat(
+            new PhpPlaceholders(
+                new TextFile(
+                    'php-cs-fixer.php',
+                    "setFlag([
+                        '\$placeholder' => 'ALLOW_UNSUPPORTED',
+                        'default' => true,
+                    ]);",
+                ),
+            ),
+            new HasPlaceholders([
+                "[
+                        '\$placeholder' => 'ALLOW_UNSUPPORTED',
+                        'default' => true,
+                    ]" => 'true',
+            ]),
+        );
+    }
+}

--- a/tests/Unit/Placeholders/PhpPlaceholdersTest.php
+++ b/tests/Unit/Placeholders/PhpPlaceholdersTest.php
@@ -19,11 +19,27 @@ final class PhpPlaceholdersTest extends TestCase
             new PhpPlaceholders(
                 new TextFile(
                     'timeout.php',
-                    "setTimeout(['\$placeholder' => 'TIMEOUT', 'default' => 30]);",
+                    '/* @placeholder TIMEOUT default(30) */',
                 ),
             ),
             new HasPlaceholders([
-                "['\$placeholder' => 'TIMEOUT', 'default' => 30]" => '30',
+                '/* @placeholder TIMEOUT default(30) */' => '30',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsBooleanDefault(): void
+    {
+        self::assertThat(
+            new PhpPlaceholders(
+                new TextFile(
+                    'flags.php',
+                    '/* @placeholder ALLOW_UNSUPPORTED default(true) */',
+                ),
+            ),
+            new HasPlaceholders([
+                '/* @placeholder ALLOW_UNSUPPORTED default(true) */' => 'true',
             ]),
         );
     }
@@ -35,28 +51,11 @@ final class PhpPlaceholdersTest extends TestCase
             new PhpPlaceholders(
                 new TextFile(
                     'path.php',
-                    "setPath(['\$placeholder' => 'BASE_PATH', 'default' => '../app']);",
+                    "/* @placeholder BASE_PATH default('../app') */",
                 ),
             ),
             new HasPlaceholders([
-                "['\$placeholder' => 'BASE_PATH', 'default' => '../app']" => "'../app'",
-            ]),
-        );
-    }
-
-    #[Test]
-    public function extractsArrayDefault(): void
-    {
-        self::assertThat(
-            new PhpPlaceholders(
-                new TextFile(
-                    'rules.php',
-                    "setRules(['\$placeholder' => 'RULES', 'default' => ['a' => 1, 'b' => 2]]);",
-                ),
-            ),
-            new HasPlaceholders([
-                "['\$placeholder' => 'RULES', 'default' => ['a' => 1, 'b' => 2]]"
-                => "['a' => 1, 'b' => 2]",
+                "/* @placeholder BASE_PATH default('../app') */" => "'../app'",
             ]),
         );
     }
@@ -68,61 +67,30 @@ final class PhpPlaceholdersTest extends TestCase
             new PhpPlaceholders(
                 new TextFile(
                     'multiple.php',
-                    "configure(
-                        ['\$placeholder' => 'FIRST', 'default' => true],
-                        ['\$placeholder' => 'SECOND', 'default' => ['x', 'y']]
-                    );",
+                    '
+                    /* @placeholder FIRST default(true) */
+                    /* @placeholder SECOND default(42) */
+                    ',
                 ),
             ),
             new HasPlaceholders([
-                "['\$placeholder' => 'FIRST', 'default' => true]" => 'true',
-                "['\$placeholder' => 'SECOND', 'default' => ['x', 'y']]"
-                => "['x', 'y']",
+                '/* @placeholder FIRST default(true) */' => 'true',
+                '/* @placeholder SECOND default(42) */' => '42',
             ]),
         );
     }
 
     #[Test]
-    public function extractsBooleanDefaultFromMultilineArray(): void
+    public function ignoresNonPlaceholderComments(): void
     {
         self::assertThat(
             new PhpPlaceholders(
                 new TextFile(
-                    'php-cs-fixer.php',
-                    "setFlag([
-                        '\$placeholder' => 'ALLOW_UNSUPPORTED',
-                        'default' => true,
-                    ]);",
+                    'noop.php',
+                    '/* just a regular comment */',
                 ),
             ),
-            new HasPlaceholders([
-                "[
-                        '\$placeholder' => 'ALLOW_UNSUPPORTED',
-                        'default' => true,
-                    ]" => 'true',
-            ]),
-        );
-    }
-
-    #[Test]
-    public function extractsBooleanDefaultFromMultilineArrayWithoutTrailingComma(): void
-    {
-        self::assertThat(
-            new PhpPlaceholders(
-                new TextFile(
-                    'php-cs-fixer.php',
-                    "setFlag([
-                    '\$placeholder' => 'ALLOW_UNSUPPORTED',
-                    'default' => true
-                ]);",
-                ),
-            ),
-            new HasPlaceholders([
-                "[
-                    '\$placeholder' => 'ALLOW_UNSUPPORTED',
-                    'default' => true
-                ]" => 'true',
-            ]),
+            new HasPlaceholders([]),
         );
     }
 }

--- a/tests/Unit/Placeholders/PhpPlaceholdersTest.php
+++ b/tests/Unit/Placeholders/PhpPlaceholdersTest.php
@@ -103,4 +103,26 @@ final class PhpPlaceholdersTest extends TestCase
             ]),
         );
     }
+
+    #[Test]
+    public function extractsBooleanDefaultFromMultilineArrayWithoutTrailingComma(): void
+    {
+        self::assertThat(
+            new PhpPlaceholders(
+                new TextFile(
+                    'php-cs-fixer.php',
+                    "setFlag([
+                    '\$placeholder' => 'ALLOW_UNSUPPORTED',
+                    'default' => true
+                ]);",
+                ),
+            ),
+            new HasPlaceholders([
+                "[
+                    '\$placeholder' => 'ALLOW_UNSUPPORTED',
+                    'default' => true
+                ]" => 'true',
+            ]),
+        );
+    }
 }


### PR DESCRIPTION
- Added PHP placeholders to support template substitution in PHP config files
- Integrated PHP placeholders into the file generation pipeline
- Updated php-cs-fixer templates to use placeholder-based configuration overrides
- Normalized markdownlint ignores formatting to prevent placeholder-induced diffs

Part of #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PHP placeholder support for file templating.
  * Extended PHP CS Fixer to recognize PHP 8.3–8.5 migration rules and updated unsupported-version handling.

* **Tests**
  * Added unit tests validating PHP placeholder extraction across numeric, boolean, string, multiple, and non-placeholder cases.

* **Chores**
  * Reformatted markdownlint configuration and updated template config structures for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->