### PR TITLE
XML placeholder containers support

### DIFF
--- a/.piqule/phpcs/phpcs.xml
+++ b/.piqule/phpcs/phpcs.xml
@@ -10,6 +10,5 @@
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
 
-    <!-- Minimal non-formatting sniff -->
     <rule ref="Generic.PHP.Syntax"/>
 </ruleset>

--- a/bin/piqule-sync.php
+++ b/bin/piqule-sync.php
@@ -15,6 +15,7 @@ use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Placeholders\CombinedPlaceholders;
 use Haspadar\Piqule\Placeholders\JsonPlaceholders;
 use Haspadar\Piqule\Placeholders\PhpPlaceholders;
+use Haspadar\Piqule\Placeholders\XmlPlaceholders;
 use Haspadar\Piqule\Placeholders\YamlPlaceholders;
 use Haspadar\Piqule\Storage\DiffingStorage;
 use Haspadar\Piqule\Storage\DiskStorage;
@@ -42,6 +43,7 @@ try {
                     new YamlPlaceholders($file),
                     new JsonPlaceholders($file),
                     new PhpPlaceholders($file),
+                    new XmlPlaceholders($file),
                 ]),
             ),
         ),

--- a/src/Placeholders/XmlPlaceholders.php
+++ b/src/Placeholders/XmlPlaceholders.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Placeholders;
+
+use Haspadar\Piqule\File\File;
+use Haspadar\Piqule\Placeholder\DefaultPlaceholder;
+use Override;
+
+/**
+ * Extracts XML placeholders defined as plain placeholder container tags.
+ *
+ * The parser scans the XML contents and detects placeholder blocks
+ * written in the following form:
+ *
+ * <placeholder>
+ * <file>../../src</file>
+ * <file>../../app</file>
+ * </placeholder>
+ *
+ * Each detected placeholder block is replaced with its inner XML fragment
+ * via string substitution.
+ *
+ * Design constraints:
+ * - XML documents remain syntactically valid before and after substitution.
+ * - The file contents are treated as plain text.
+ * - No XML parsing, tokenization, DOM, schema, or AST is performed.
+ * - Placeholder detection relies solely on regular expression matching.
+ *
+ * Intended scope:
+ * - XML configuration templates (e.g. phpcs.xml)
+ * - Templates that require grouping of repeated XML elements
+ * - Safe to combine with other Placeholders implementations, as unmatched
+ *   formats yield no placeholders.
+ *
+ * Explicit limitations:
+ * - Placeholder blocks are anonymous and do not carry names.
+ * - Nested <placeholder> blocks are intentionally not supported.
+ * - Placeholder contents must not rely on indentation or formatting.
+ * - Placeholder block structure must remain syntactically stable.
+ */
+final readonly class XmlPlaceholders implements Placeholders
+{
+    public function __construct(
+        private File $file,
+    ) {}
+
+    /**
+     * Returns all XML placeholder blocks found in the file.
+     *
+     * Each placeholder is returned as a DefaultPlaceholder where:
+     * - expression() is the full <placeholder>...</placeholder> block
+     * - replacement() is the extracted inner XML fragment
+     *
+     * @return iterable<DefaultPlaceholder>
+     */
+    #[Override]
+    public function all(): iterable
+    {
+        preg_match_all(
+            '/<placeholder>\s*([\s\S]*?)\s*<\/placeholder>/',
+            $this->file->contents(),
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        foreach ($matches as $match) {
+            yield new DefaultPlaceholder(
+                $match[0],
+                trim($match[1]),
+            );
+        }
+    }
+}

--- a/templates/root/.piqule/phpcs/phpcs.xml
+++ b/templates/root/.piqule/phpcs/phpcs.xml
@@ -2,14 +2,17 @@
 <ruleset name="Piqule PHPCS Rules">
     <description>Structural and semantic PHP rules</description>
 
+    <placeholder>
     <file>../../src</file>
+    </placeholder>
 
+    <placeholder>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>tests/*</exclude-pattern>
+    </placeholder>
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
 
-    <!-- Minimal non-formatting sniff -->
     <rule ref="Generic.PHP.Syntax"/>
 </ruleset>

--- a/tests/Unit/Placeholders/XmlPlaceholdersTest.php
+++ b/tests/Unit/Placeholders/XmlPlaceholdersTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Placeholders;
+
+use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\Placeholders\XmlPlaceholders;
+use Haspadar\Piqule\Tests\Constraint\Placeholders\HasPlaceholders;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class XmlPlaceholdersTest extends TestCase
+{
+    #[Test]
+    public function extractsGroupedElements(): void
+    {
+        self::assertThat(
+            new XmlPlaceholders(
+                new TextFile(
+                    'config.xml',
+                    '<config><placeholder><item>A</item><item>B</item></placeholder></config>',
+                ),
+            ),
+            new HasPlaceholders([
+                '<placeholder><item>A</item><item>B</item></placeholder>'
+                => '<item>A</item><item>B</item>',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsSingleWrappedElement(): void
+    {
+        self::assertThat(
+            new XmlPlaceholders(
+                new TextFile(
+                    'layout.xml',
+                    '<layout><placeholder><section>Main</section></placeholder></layout>',
+                ),
+            ),
+            new HasPlaceholders([
+                '<placeholder><section>Main</section></placeholder>'
+                => '<section>Main</section>',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function extractsMultipleIndependentPlaceholders(): void
+    {
+        self::assertThat(
+            new XmlPlaceholders(
+                new TextFile(
+                    'document.xml',
+                    '<doc>'
+                    . '<placeholder><header>Top</header></placeholder>'
+                    . '<placeholder><footer>Bottom</footer></placeholder>'
+                    . '</doc>',
+                ),
+            ),
+            new HasPlaceholders([
+                '<placeholder><header>Top</header></placeholder>'
+                => '<header>Top</header>',
+
+                '<placeholder><footer>Bottom</footer></placeholder>'
+                => '<footer>Bottom</footer>',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function ignoresXmlWithoutPlaceholderBlocks(): void
+    {
+        self::assertThat(
+            new XmlPlaceholders(
+                new TextFile(
+                    'plain.xml',
+                    '<root><value>42</value></root>',
+                ),
+            ),
+            new HasPlaceholders([]),
+        );
+    }
+
+    #[Test]
+    public function extractsMultilinePlaceholderBlock(): void
+    {
+        self::assertThat(
+            new XmlPlaceholders(
+                new TextFile(
+                    'complex.xml',
+                    '
+                    <root>
+                        <placeholder>
+                        <node>one</node>
+                        <node>two</node>
+                        </placeholder>
+                    </root>
+                    ',
+                ),
+            ),
+            new HasPlaceholders([
+                '<placeholder>
+                        <node>one</node>
+                        <node>two</node>
+                        </placeholder>'
+                => '<node>one</node>
+                        <node>two</node>',
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
- Added XML placeholder container extraction for grouped XML fragments
- Added unit tests covering XML placeholder container behavior
- Updated PHPCS template to use XML placeholder containers
- Enabled XML placeholder processing during sync
- Updated local PHPCS XML config to align with placeholder-based templates

Part of #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for XML placeholder blocks in files that are now processed alongside existing placeholder types.

* **Tests**
  * Added comprehensive unit tests validating XML placeholder extraction from various file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->