### PR TITLE
Switch XML placeholders to named containers to allow future custom value overrides 

### DIFF
--- a/src/Placeholders/XmlPlaceholders.php
+++ b/src/Placeholders/XmlPlaceholders.php
@@ -9,12 +9,12 @@ use Haspadar\Piqule\Placeholder\DefaultPlaceholder;
 use Override;
 
 /**
- * Extracts XML placeholders defined as plain placeholder container tags.
+ * Extracts XML placeholders defined as named placeholder container tags.
  *
  * The parser scans the XML contents and detects placeholder blocks
  * written in the following form:
  *
- * <placeholder>
+ * <placeholder name="PLACEHOLDER_NAME">
  * <file>../../src</file>
  * <file>../../app</file>
  * </placeholder>
@@ -30,12 +30,12 @@ use Override;
  *
  * Intended scope:
  * - XML configuration templates (e.g. phpcs.xml)
- * - Templates that require grouping of repeated XML elements
+ * - Templates that require grouping and future override of XML fragments
  * - Safe to combine with other Placeholders implementations, as unmatched
  *   formats yield no placeholders.
  *
  * Explicit limitations:
- * - Placeholder blocks are anonymous and do not carry names.
+ * - Placeholder blocks must declare a name attribute.
  * - Nested <placeholder> blocks are intentionally not supported.
  * - Placeholder contents must not rely on indentation or formatting.
  * - Placeholder block structure must remain syntactically stable.
@@ -47,10 +47,10 @@ final readonly class XmlPlaceholders implements Placeholders
     ) {}
 
     /**
-     * Returns all XML placeholder blocks found in the file.
+     * Returns all named XML placeholder blocks found in the file.
      *
      * Each placeholder is returned as a DefaultPlaceholder where:
-     * - expression() is the full <placeholder>...</placeholder> block
+     * - expression() is the full <placeholder name="...">...</placeholder> block
      * - replacement() is the extracted inner XML fragment
      *
      * @return iterable<DefaultPlaceholder>
@@ -59,7 +59,7 @@ final readonly class XmlPlaceholders implements Placeholders
     public function all(): iterable
     {
         preg_match_all(
-            '/<placeholder>\s*([\s\S]*?)\s*<\/placeholder>/',
+            '/<placeholder\s+name="([A-Z0-9_]+)">\s*([\s\S]*?)\s*<\/placeholder>/',
             $this->file->contents(),
             $matches,
             PREG_SET_ORDER,
@@ -68,7 +68,7 @@ final readonly class XmlPlaceholders implements Placeholders
         foreach ($matches as $match) {
             yield new DefaultPlaceholder(
                 $match[0],
-                trim($match[1]),
+                trim($match[2]),
             );
         }
     }

--- a/templates/root/.piqule/phpcs/phpcs.xml
+++ b/templates/root/.piqule/phpcs/phpcs.xml
@@ -2,11 +2,11 @@
 <ruleset name="Piqule PHPCS Rules">
     <description>Structural and semantic PHP rules</description>
 
-    <placeholder>
+    <placeholder name="FILES">
     <file>../../src</file>
     </placeholder>
 
-    <placeholder>
+    <placeholder name="EXCLUDES">
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>tests/*</exclude-pattern>
     </placeholder>

--- a/tests/Unit/Placeholders/XmlPlaceholdersTest.php
+++ b/tests/Unit/Placeholders/XmlPlaceholdersTest.php
@@ -19,11 +19,11 @@ final class XmlPlaceholdersTest extends TestCase
             new XmlPlaceholders(
                 new TextFile(
                     'config.xml',
-                    '<config><placeholder><item>A</item><item>B</item></placeholder></config>',
+                    '<config><placeholder name="ITEMS"><item>A</item><item>B</item></placeholder></config>',
                 ),
             ),
             new HasPlaceholders([
-                '<placeholder><item>A</item><item>B</item></placeholder>'
+                '<placeholder name="ITEMS"><item>A</item><item>B</item></placeholder>'
                 => '<item>A</item><item>B</item>',
             ]),
         );
@@ -36,11 +36,11 @@ final class XmlPlaceholdersTest extends TestCase
             new XmlPlaceholders(
                 new TextFile(
                     'layout.xml',
-                    '<layout><placeholder><section>Main</section></placeholder></layout>',
+                    '<layout><placeholder name="SECTION"><section>Main</section></placeholder></layout>',
                 ),
             ),
             new HasPlaceholders([
-                '<placeholder><section>Main</section></placeholder>'
+                '<placeholder name="SECTION"><section>Main</section></placeholder>'
                 => '<section>Main</section>',
             ]),
         );
@@ -54,16 +54,16 @@ final class XmlPlaceholdersTest extends TestCase
                 new TextFile(
                     'document.xml',
                     '<doc>'
-                    . '<placeholder><header>Top</header></placeholder>'
-                    . '<placeholder><footer>Bottom</footer></placeholder>'
+                    . '<placeholder name="HEADER"><header>Top</header></placeholder>'
+                    . '<placeholder name="FOOTER"><footer>Bottom</footer></placeholder>'
                     . '</doc>',
                 ),
             ),
             new HasPlaceholders([
-                '<placeholder><header>Top</header></placeholder>'
+                '<placeholder name="HEADER"><header>Top</header></placeholder>'
                 => '<header>Top</header>',
 
-                '<placeholder><footer>Bottom</footer></placeholder>'
+                '<placeholder name="FOOTER"><footer>Bottom</footer></placeholder>'
                 => '<footer>Bottom</footer>',
             ]),
         );
@@ -92,7 +92,7 @@ final class XmlPlaceholdersTest extends TestCase
                     'complex.xml',
                     '
                     <root>
-                        <placeholder>
+                        <placeholder name="NODES">
                         <node>one</node>
                         <node>two</node>
                         </placeholder>
@@ -101,7 +101,7 @@ final class XmlPlaceholdersTest extends TestCase
                 ),
             ),
             new HasPlaceholders([
-                '<placeholder>
+                '<placeholder name="NODES">
                         <node>one</node>
                         <node>two</node>
                         </placeholder>'


### PR DESCRIPTION
- Updated XML placeholders to require explicit names
- Adjusted placeholder extraction logic to support named containers
- Updated unit tests to reflect named XML placeholder behavior

Part of #295