### PR TITLE
Isolate Formula Argument Parsing into Explicit Args Decorators 

### DIFF
--- a/src/Formula/Args/Args.php
+++ b/src/Formula/Args/Args.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+/**
+ * Represents arguments of a single DSL action
+ *
+ * Exposes arguments in explicit DSL forms
+ * Does not perform semantic interpretation
+ */
+interface Args
+{
+    /**
+     * Returns argument in linear DSL form
+     */
+    public function text(): string;
+
+    /**
+     * Returns argument parsed as PHP-style list literal
+     *
+     * @return list<string>
+     */
+    public function list(): array;
+}

--- a/src/Formula/Args/ListParsedArgs.php
+++ b/src/Formula/Args/ListParsedArgs.php
@@ -9,9 +9,7 @@ use Override;
 
 final readonly class ListParsedArgs implements Args
 {
-    public function __construct(private Args $origin)
-    {
-    }
+    public function __construct(private Args $origin) {}
 
     #[Override]
     public function text(): string

--- a/src/Formula/Args/ListParsedArgs.php
+++ b/src/Formula/Args/ListParsedArgs.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+use InvalidArgumentException;
+use Override;
+
+final readonly class ListParsedArgs implements Args
+{
+    public function __construct(private Args $origin) {}
+
+    #[Override]
+    public function text(): string
+    {
+        return $this->origin->text();
+    }
+
+    #[Override]
+    public function list(): array
+    {
+        $raw = $this->origin->text();
+
+        if ($raw[0] !== '[' || $raw[strlen($raw) - 1] !== ']') {
+            throw new InvalidArgumentException(
+                sprintf('Expected php list literal, got "%s"', $raw),
+            );
+        }
+
+        $inner = trim(substr($raw, 1, -1));
+
+        return explode(',', $inner);
+    }
+}

--- a/src/Formula/Args/ListParsedArgs.php
+++ b/src/Formula/Args/ListParsedArgs.php
@@ -22,7 +22,7 @@ final readonly class ListParsedArgs implements Args
     {
         $raw = $this->origin->text();
 
-        if ($raw[0] !== '[' || $raw[strlen($raw) - 1] !== ']') {
+        if ($raw === '' || $raw[0] !== '[' || $raw[strlen($raw) - 1] !== ']') {
             throw new InvalidArgumentException(
                 sprintf('Expected php list literal, got "%s"', $raw),
             );

--- a/src/Formula/Args/ListParsedArgs.php
+++ b/src/Formula/Args/ListParsedArgs.php
@@ -9,7 +9,9 @@ use Override;
 
 final readonly class ListParsedArgs implements Args
 {
-    public function __construct(private Args $origin) {}
+    public function __construct(private Args $origin)
+    {
+    }
 
     #[Override]
     public function text(): string
@@ -29,6 +31,10 @@ final readonly class ListParsedArgs implements Args
         }
 
         $inner = trim(substr($raw, 1, -1));
+
+        if ($inner === '') {
+            return [];
+        }
 
         return explode(',', $inner);
     }

--- a/src/Formula/Args/RawArgs.php
+++ b/src/Formula/Args/RawArgs.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+use LogicException;
+use Override;
+
+final readonly class RawArgs implements Args
+{
+    public function __construct(private string $raw) {}
+
+    #[Override]
+    public function text(): string
+    {
+        return $this->raw;
+    }
+
+    #[Override]
+    public function list(): array
+    {
+        throw new LogicException('RawArgs does not support list parsing');
+    }
+}

--- a/src/Formula/Args/TrimmedArgs.php
+++ b/src/Formula/Args/TrimmedArgs.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+use Override;
+
+final readonly class TrimmedArgs implements Args
+{
+    public function __construct(
+        private Args $origin,
+    ) {}
+
+    #[Override]
+    public function text(): string
+    {
+        return trim($this->origin->text());
+    }
+
+    #[Override]
+    public function list(): array
+    {
+        return array_map(
+            static fn(string $value) => trim($value),
+            $this->origin->list(),
+        );
+    }
+}

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -29,6 +29,16 @@ final readonly class UnquotedArgs implements Args
 
     private function trim(string $text): string
     {
-        return trim($text, "\"'");
+        if (
+            strlen($text) >= 2
+            && (
+                ($text[0] === '"' && $text[-1] === '"')
+                || ($text[0] === "'" && $text[-1] === "'")
+            )
+        ) {
+            return substr($text, 1, -1);
+        }
+
+        return $text;
     }
 }

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+use Override;
+
+final readonly class UnquotedArgs implements Args
+{
+    public function __construct(private Args $origin) {}
+
+    #[Override]
+    public function text(): string
+    {
+        return $this->trim(
+            $this->origin->text(),
+        );
+    }
+
+    #[Override]
+    public function list(): array
+    {
+        return array_map(
+            fn(string $value) => $this->trim($value),
+            $this->origin->list(),
+        );
+    }
+
+    private function trim(string $text): string
+    {
+        return trim($text, "\"'");
+    }
+}

--- a/tests/Constraint/Formula/Args/HasArgsList.php
+++ b/tests/Constraint/Formula/Args/HasArgsList.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Constraint\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\Args;
+use PHPUnit\Framework\Constraint\Constraint;
+
+final class HasArgsList extends Constraint
+{
+    /**
+     * @param list<string> $expected
+     */
+    public function __construct(
+        private readonly array $expected,
+    ) {}
+
+    public function toString(): string
+    {
+        return 'has args list ' . $this->export($this->expected);
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Args) {
+            return false;
+        }
+
+        return $other->list() === $this->expected;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'args ' . $this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Args) {
+            return "\nBut object of type "
+                . get_debug_type($other)
+                . ' was given instead of Args';
+        }
+
+        return "\nExpected: {$this->export($this->expected)}"
+            . "\nBut was:  {$this->export($other->list())}";
+    }
+
+    private function export(mixed $value): string
+    {
+        return var_export($value, true);
+    }
+}

--- a/tests/Constraint/Formula/Args/HasArgsText.php
+++ b/tests/Constraint/Formula/Args/HasArgsText.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Constraint\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\Args;
+use PHPUnit\Framework\Constraint\Constraint;
+
+final class HasArgsText extends Constraint
+{
+    public function __construct(
+        private readonly string $expected,
+    ) {}
+
+    public function toString(): string
+    {
+        return 'has args text ' . $this->export($this->expected);
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Args) {
+            return false;
+        }
+
+        return $other->text() === $this->expected;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'args ' . $this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Args) {
+            return "\nBut object of type "
+                . get_debug_type($other)
+                . ' was given instead of Args';
+        }
+
+        return "\nExpected: {$this->export($this->expected)}"
+            . "\nBut was:  {$this->export($other->text())}";
+    }
+
+    private function export(mixed $value): string
+    {
+        return var_export($value, true);
+    }
+}

--- a/tests/Unit/Formula/Args/ListParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ListParsedArgsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\ListParsedArgs;
+use Haspadar\Piqule\Formula\Args\RawArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsList;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ListParsedArgsTest extends TestCase
+{
+    #[Test]
+    public function returnsItemsWhenPhpListGiven(): void
+    {
+        self::assertThat(
+            new ListParsedArgs(
+                new RawArgs('[a,b,c]'),
+            ),
+            new HasArgsList(['a', 'b', 'c']),
+            'ListParsedArgs must split php list',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenNonListGiven(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ListParsedArgs(
+            new RawArgs('abc'),
+        ))->list();
+    }
+}

--- a/tests/Unit/Formula/Args/ListParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ListParsedArgsTest.php
@@ -66,4 +66,16 @@ final class ListParsedArgsTest extends TestCase
             new RawArgs('[abc'),
         ))->list();
     }
+
+    #[Test]
+    public function returnsEmptyArrayWhenEmptyListGiven(): void
+    {
+        self::assertThat(
+            new ListParsedArgs(
+                new RawArgs('[]'),
+            ),
+            new HasArgsList([]),
+            'ListParsedArgs must return empty list for empty php list literal',
+        );
+    }
 }

--- a/tests/Unit/Formula/Args/ListParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ListParsedArgsTest.php
@@ -46,4 +46,24 @@ final class ListParsedArgsTest extends TestCase
             'ListParsedArgs must delegate text() to origin',
         );
     }
+
+    #[Test]
+    public function throwsWhenMissingOpeningBracket(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ListParsedArgs(
+            new RawArgs('abc]'),
+        ))->list();
+    }
+
+    #[Test]
+    public function throwsWhenMissingClosingBracket(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ListParsedArgs(
+            new RawArgs('[abc'),
+        ))->list();
+    }
 }

--- a/tests/Unit/Formula/Args/ListParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ListParsedArgsTest.php
@@ -34,4 +34,16 @@ final class ListParsedArgsTest extends TestCase
             new RawArgs('abc'),
         ))->list();
     }
+
+    #[Test]
+    public function returnsOriginalText(): void
+    {
+        self::assertSame(
+            '[a,b,c]',
+            (new ListParsedArgs(
+                new RawArgs('[a,b,c]'),
+            ))->text(),
+            'ListParsedArgs must delegate text() to origin',
+        );
+    }
 }

--- a/tests/Unit/Formula/Args/ListParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ListParsedArgsTest.php
@@ -18,9 +18,9 @@ final class ListParsedArgsTest extends TestCase
     {
         self::assertThat(
             new ListParsedArgs(
-                new RawArgs('[a,b,c]'),
+                new RawArgs('[one,two,three]'),
             ),
-            new HasArgsList(['a', 'b', 'c']),
+            new HasArgsList(['one', 'two', 'three']),
             'ListParsedArgs must split php list',
         );
     }
@@ -31,7 +31,7 @@ final class ListParsedArgsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new ListParsedArgs(
-            new RawArgs('abc'),
+            new RawArgs('alpha,beta'),
         ))->list();
     }
 
@@ -39,9 +39,9 @@ final class ListParsedArgsTest extends TestCase
     public function returnsOriginalText(): void
     {
         self::assertSame(
-            '[a,b,c]',
+            '[x,y]',
             (new ListParsedArgs(
-                new RawArgs('[a,b,c]'),
+                new RawArgs('[x,y]'),
             ))->text(),
             'ListParsedArgs must delegate text() to origin',
         );
@@ -53,7 +53,7 @@ final class ListParsedArgsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new ListParsedArgs(
-            new RawArgs('abc]'),
+            new RawArgs('foo,bar]'),
         ))->list();
     }
 
@@ -63,7 +63,7 @@ final class ListParsedArgsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new ListParsedArgs(
-            new RawArgs('[abc'),
+            new RawArgs('[foo,bar'),
         ))->list();
     }
 

--- a/tests/Unit/Formula/Args/RawArgsTest.php
+++ b/tests/Unit/Formula/Args/RawArgsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\RawArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsText;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RawArgsTest extends TestCase
+{
+    #[Test]
+    public function returnsTextWhenRawValueGiven(): void
+    {
+        self::assertThat(
+            new RawArgs(' raw '),
+            new HasArgsText(' raw '),
+            'RawArgs must return text as-is',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenListRequested(): void
+    {
+        $this->expectException(LogicException::class);
+
+        (new RawArgs('[a,b]'))->list();
+    }
+}

--- a/tests/Unit/Formula/Args/TrimmedArgsTest.php
+++ b/tests/Unit/Formula/Args/TrimmedArgsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\ListParsedArgs;
+use Haspadar\Piqule\Formula\Args\RawArgs;
+use Haspadar\Piqule\Formula\Args\TrimmedArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsList;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsText;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TrimmedArgsTest extends TestCase
+{
+    #[Test]
+    public function trimsTextWhenWhitespacePresent(): void
+    {
+        self::assertThat(
+            new TrimmedArgs(
+                new RawArgs('  abc  '),
+            ),
+            new HasArgsText('abc'),
+            'TrimmedArgs must trim text',
+        );
+    }
+
+    #[Test]
+    public function trimsItemsWhenListContainsWhitespace(): void
+    {
+        self::assertThat(
+            new TrimmedArgs(
+                new ListParsedArgs(
+                    new RawArgs('[ a , b ]'),
+                ),
+            ),
+            new HasArgsList(['a', 'b']),
+            'TrimmedArgs must trim list items',
+        );
+    }
+}

--- a/tests/Unit/Formula/Args/UnquotedArgsTest.php
+++ b/tests/Unit/Formula/Args/UnquotedArgsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\ListParsedArgs;
+use Haspadar\Piqule\Formula\Args\RawArgs;
+use Haspadar\Piqule\Formula\Args\UnquotedArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsList;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsText;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class UnquotedArgsTest extends TestCase
+{
+    #[Test]
+    public function removesWrappingQuotesWhenTextIsQuoted(): void
+    {
+        self::assertThat(
+            new UnquotedArgs(
+                new RawArgs('"a\'b"'),
+            ),
+            new HasArgsText("a'b"),
+            'UnquotedArgs must remove wrapping quotes from text',
+        );
+    }
+
+    #[Test]
+    public function removesWrappingQuotesWhenListItemsQuoted(): void
+    {
+        self::assertThat(
+            new UnquotedArgs(
+                new ListParsedArgs(
+                    new RawArgs('["a\'b","c"]'),
+                ),
+            ),
+            new HasArgsList(["a'b", 'c']),
+            'UnquotedArgs must remove wrapping quotes from list items',
+        );
+    }
+}

--- a/tests/Unit/Formula/Args/UnquotedArgsTest.php
+++ b/tests/Unit/Formula/Args/UnquotedArgsTest.php
@@ -63,4 +63,16 @@ final class UnquotedArgsTest extends TestCase
             'UnquotedArgs must return empty string for empty quoted input',
         );
     }
+
+    #[Test]
+    public function removesOnlySingleMatchingQuoteLayer(): void
+    {
+        self::assertSame(
+            '"value"',
+            (new UnquotedArgs(
+                new RawArgs('""value""'),
+            ))->text(),
+            'UnquotedArgs must remove only one matching quote layer',
+        );
+    }
 }

--- a/tests/Unit/Formula/Args/UnquotedArgsTest.php
+++ b/tests/Unit/Formula/Args/UnquotedArgsTest.php
@@ -39,4 +39,28 @@ final class UnquotedArgsTest extends TestCase
             'UnquotedArgs must remove wrapping quotes from list items',
         );
     }
+
+    #[Test]
+    public function returnsSameTextWhenInputIsNotQuoted(): void
+    {
+        self::assertSame(
+            'hello',
+            (new UnquotedArgs(
+                new RawArgs('hello'),
+            ))->text(),
+            'UnquotedArgs must return original text when no quotes are present',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyStringWhenEmptyQuotedStringGiven(): void
+    {
+        self::assertSame(
+            '',
+            (new UnquotedArgs(
+                new RawArgs('""'),
+            ))->text(),
+            'UnquotedArgs must return empty string for empty quoted input',
+        );
+    }
 }


### PR DESCRIPTION
- Refactored formula argument handling into an Args interface with composable decorators
- Added explicit Raw, Trimmed, Unquoted, and List-parsing argument representations
- Removed implicit argument normalization in favor of explicit DSL boundaries
- Added unit tests covering argument parsing and decorator composition

Part of #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified argument API exposing text and list representations.
  * Added implementations for raw, parsed-list, trimmed, and unquoted argument views.
  * Added list-literal parsing with validation and explicit error behavior.

* **Tests**
  * Added unit tests and PHPUnit constraints covering text, list parsing, trimming, and quote-removal behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->