### PR TITLE
Disable major Renovate updates for phpunit and symfony/process 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,6 +67,16 @@
       "description": "Group CI toolchain updates",
       "groupName": "CI toolchain",
       "matchManagers": ["github-actions", "custom.regex"]
+    },
+    {
+      "description": "No major updates for PHP toolchain",
+      "matchManagers": ["composer"],
+      "matchPackageNames": [
+        "phpunit/phpunit",
+        "symfony/process"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
- Disable major Renovate updates for phpunit/phpunit
- Disable major Renovate updates for symfony/process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured dependency management settings to restrict major version updates for PHP development toolchain components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->