### PR TITLE
Unify Formula Args Representation 

### DIFF
--- a/src/Formula/Args/Args.php
+++ b/src/Formula/Args/Args.php
@@ -5,22 +5,18 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Formula\Args;
 
 /**
- * Represents arguments of a single DSL action
+ * Represents a sequence of runtime values flowing through a DSL action pipeline
  *
- * Exposes arguments in explicit DSL forms
- * Does not perform semantic interpretation
+ * Args is a value container
+ * It does not perform formatting, parsing, or semantic interpretation
+ * Each action transforms one Args instance into another
  */
 interface Args
 {
     /**
-     * Returns argument in linear DSL form
-     */
-    public function text(): string;
-
-    /**
-     * Returns argument parsed as PHP-style list literal
+     * Returns ordered values produced by the previous action
      *
-     * @return list<string>
+     * @return list<int|float|string|bool>
      */
-    public function list(): array;
+    public function values(): array;
 }

--- a/src/Formula/Args/ListArgs.php
+++ b/src/Formula/Args/ListArgs.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+use Override;
+
+final readonly class ListArgs implements Args
+{
+    /**
+     * @param list<int|float|string|bool> $values
+     */
+    public function __construct(
+        private array $values,
+    ) {}
+
+    /**
+     * @return list<int|float|string|bool>
+     */
+    #[Override]
+    public function values(): array
+    {
+        return $this->values;
+    }
+}

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+use InvalidArgumentException;
+use Override;
+
+final readonly class ParsedArgs implements Args
+{
+    public function __construct(
+        private Args $origin,
+    ) {}
+
+    /**
+     * @return list<int|float|string|bool>
+     */
+    #[Override]
+    public function values(): array
+    {
+        $values = $this->origin->values();
+
+        if ($values === []) {
+            throw new InvalidArgumentException(
+                'Expected php list literal, got empty input',
+            );
+        }
+
+        $raw = $values[0];
+
+        if (!is_string($raw)) {
+            throw new InvalidArgumentException(
+                sprintf('Expected php list literal string, got %s', get_debug_type($raw)),
+            );
+        }
+
+        if ($raw === '' || $raw[0] !== '[' || $raw[strlen($raw) - 1] !== ']') {
+            throw new InvalidArgumentException(
+                sprintf('Expected php list literal, got "%s"', $raw),
+            );
+        }
+
+        $inner = trim(substr($raw, 1, -1));
+
+        if ($inner === '') {
+            return [];
+        }
+
+        return explode(',', $inner);
+    }
+}

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -28,6 +28,15 @@ final readonly class ParsedArgs implements Args
             );
         }
 
+        if (count($values) !== 1) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expected single php list literal, got %d values',
+                    count($values),
+                ),
+            );
+        }
+
         $raw = $values[0];
 
         if (!is_string($raw)) {

--- a/src/Formula/Args/StringifiedArgs.php
+++ b/src/Formula/Args/StringifiedArgs.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Args;
+
+use Override;
+
+final readonly class StringifiedArgs implements Args
+{
+    public function __construct(
+        private Args $origin,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    public function values(): array
+    {
+        return array_map(
+            fn(int|float|string|bool $value): string =>
+            $this->stringify($value),
+            $this->origin->values(),
+        );
+    }
+
+    private function stringify(int|float|string|bool $value): string
+    {
+        return match ($value) {
+            true => 'true',
+            false => 'false',
+            default => (string) $value,
+        };
+    }
+}

--- a/src/Formula/Args/TrimmedArgs.php
+++ b/src/Formula/Args/TrimmedArgs.php
@@ -12,18 +12,21 @@ final readonly class TrimmedArgs implements Args
         private Args $origin,
     ) {}
 
+    /**
+     * @return list<int|float|string|bool>
+     */
     #[Override]
-    public function text(): string
-    {
-        return trim($this->origin->text());
-    }
-
-    #[Override]
-    public function list(): array
+    public function values(): array
     {
         return array_map(
-            static fn(string $value) => trim($value),
-            $this->origin->list(),
+            static function (int|float|string|bool $value): int|float|string|bool {
+                if (!is_string($value)) {
+                    return $value;
+                }
+
+                return trim($value);
+            },
+            $this->origin->values(),
         );
     }
 }

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -8,33 +8,39 @@ use Override;
 
 final readonly class UnquotedArgs implements Args
 {
-    public function __construct(private Args $origin) {}
+    public function __construct(
+        private Args $origin,
+    ) {}
 
+    /**
+     * @return list<int|float|string|bool>
+     */
     #[Override]
-    public function text(): string
-    {
-        return $this->trim(
-            $this->origin->text(),
-        );
-    }
-
-    #[Override]
-    public function list(): array
+    public function values(): array
     {
         return array_map(
-            fn(string $value) => $this->trim($value),
-            $this->origin->list(),
+            fn(int|float|string|bool $value) =>
+            is_string($value)
+                ? $this->unquote($value)
+                : $value,
+            $this->origin->values(),
         );
     }
 
-    private function trim(string $text): string
+    private function unquote(string $text): string
     {
+        $length = strlen($text);
+
+        if ($length < 2) {
+            return $text;
+        }
+
+        $first = $text[0];
+        $last = $text[$length - 1];
+
         if (
-            strlen($text) >= 2
-            && (
-                ($text[0] === '"' && $text[-1] === '"')
-                || ($text[0] === "'" && $text[-1] === "'")
-            )
+            ($first === '"' && $last === '"')
+            || ($first === "'" && $last === "'")
         ) {
             return substr($text, 1, -1);
         }

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -6,6 +6,11 @@ namespace Haspadar\Piqule\Formula\Args;
 
 use Override;
 
+/**
+ * Removes matching outer single or double quotes
+ *
+ * Escape sequences inside the string are not processed
+ */
 final readonly class UnquotedArgs implements Args
 {
     public function __construct(

--- a/tests/Unit/Formula/Args/ListArgsTest.php
+++ b/tests/Unit/Formula/Args/ListArgsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ListArgsTest extends TestCase
+{
+    #[Test]
+    public function returnsValuesAsList(): void
+    {
+        self::assertSame(
+            ['alpha', 'beta', 'gamma'],
+            (new ListArgs(['alpha', 'beta', 'gamma']))->values(),
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenConstructedWithEmptyArray(): void
+    {
+        self::assertSame(
+            [],
+            (new ListArgs([]))->values(),
+        );
+    }
+}

--- a/tests/Unit/Formula/Args/ParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ParsedArgsTest.php
@@ -147,4 +147,14 @@ final class ParsedArgsTest extends TestCase
             new ListArgs(['[new stdClass()]']),
         ))->values();
     }
+
+    #[Test]
+    public function throwsWhenMoreThanOneLiteralProvided(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['[1,2]', '[3,4]']),
+        ))->values();
+    }
 }

--- a/tests/Unit/Formula/Args/ParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ParsedArgsTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 final class ParsedArgsTest extends TestCase
 {
     #[Test]
-    public function parsesPhpListLiteralIntoValues(): void
+    public function parsesJsonListLiteralIntoValues(): void
     {
         self::assertSame(
             ['one', 'two', 'three'],
@@ -24,7 +24,7 @@ final class ParsedArgsTest extends TestCase
     }
 
     #[Test]
-    public function parsesPhpListLiteralWithNumbers(): void
+    public function parsesJsonListWithNumbers(): void
     {
         self::assertSame(
             [1, 2, 3],
@@ -35,7 +35,7 @@ final class ParsedArgsTest extends TestCase
     }
 
     #[Test]
-    public function parsesPhpListLiteralWithBooleans(): void
+    public function parsesJsonListWithBooleans(): void
     {
         self::assertSame(
             [true, false],
@@ -46,7 +46,7 @@ final class ParsedArgsTest extends TestCase
     }
 
     #[Test]
-    public function parsesPhpListLiteralWithMixedScalars(): void
+    public function parsesJsonListWithMixedScalars(): void
     {
         self::assertSame(
             ['x', 42, false],
@@ -57,7 +57,7 @@ final class ParsedArgsTest extends TestCase
     }
 
     #[Test]
-    public function parsesPhpListLiteralWithCommaInsideQuotedString(): void
+    public function parsesJsonListWithCommaInsideQuotedString(): void
     {
         self::assertSame(
             ['a,b', 'c'],
@@ -79,42 +79,22 @@ final class ParsedArgsTest extends TestCase
     }
 
     #[Test]
-    public function throwsWhenInputIsNotPhpListLiteral(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        (new ParsedArgs(
-            new ListArgs(['alpha,beta']),
-        ))->values();
-    }
-
-    #[Test]
-    public function throwsWhenOpeningBracketMissing(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        (new ParsedArgs(
-            new ListArgs(['foo,bar]']),
-        ))->values();
-    }
-
-    #[Test]
-    public function throwsWhenClosingBracketMissing(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        (new ParsedArgs(
-            new ListArgs(['[foo,bar']),
-        ))->values();
-    }
-
-    #[Test]
     public function throwsWhenInputIsEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         (new ParsedArgs(
             new ListArgs([]),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenMoreThanOneLiteralProvided(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['[1,2]', '[3,4]']),
         ))->values();
     }
 
@@ -139,22 +119,52 @@ final class ParsedArgsTest extends TestCase
     }
 
     #[Test]
-    public function throwsWhenLiteralContainsNonScalar(): void
+    public function throwsWhenInvalidJson(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         (new ParsedArgs(
-            new ListArgs(['[new stdClass()]']),
+            new ListArgs(['alpha,beta']),
         ))->values();
     }
 
     #[Test]
-    public function throwsWhenMoreThanOneLiteralProvided(): void
+    public function throwsWhenUsingSingleQuotes(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         (new ParsedArgs(
-            new ListArgs(['[1,2]', '[3,4]']),
+            new ListArgs(["['a','b']"]),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenTrailingCommaPresent(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['["a","b",]']),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenLiteralIsNotList(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['{"a":1}']),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenListContainsNonScalar(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['[{"a":1}]']),
         ))->values();
     }
 }

--- a/tests/Unit/Formula/Args/ParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ParsedArgsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Formula\Args\ParsedArgs;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ParsedArgsTest extends TestCase
+{
+    #[Test]
+    public function parsesPhpListLiteralIntoValues(): void
+    {
+        self::assertSame(
+            ['one', 'two', 'three'],
+            (new ParsedArgs(
+                new ListArgs(['[one,two,three]']),
+            ))->values(),
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenLiteralIsEmpty(): void
+    {
+        self::assertSame(
+            [],
+            (new ParsedArgs(
+                new ListArgs(['[]']),
+            ))->values(),
+        );
+    }
+
+    #[Test]
+    public function throwsWhenInputIsNotPhpListLiteral(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['alpha,beta']),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenOpeningBracketMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['foo,bar]']),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenClosingBracketMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['[foo,bar']),
+        ))->values();
+    }
+}

--- a/tests/Unit/Formula/Args/ParsedArgsTest.php
+++ b/tests/Unit/Formula/Args/ParsedArgsTest.php
@@ -18,7 +18,51 @@ final class ParsedArgsTest extends TestCase
         self::assertSame(
             ['one', 'two', 'three'],
             (new ParsedArgs(
-                new ListArgs(['[one,two,three]']),
+                new ListArgs(['["one","two","three"]']),
+            ))->values(),
+        );
+    }
+
+    #[Test]
+    public function parsesPhpListLiteralWithNumbers(): void
+    {
+        self::assertSame(
+            [1, 2, 3],
+            (new ParsedArgs(
+                new ListArgs(['[1,2,3]']),
+            ))->values(),
+        );
+    }
+
+    #[Test]
+    public function parsesPhpListLiteralWithBooleans(): void
+    {
+        self::assertSame(
+            [true, false],
+            (new ParsedArgs(
+                new ListArgs(['[true,false]']),
+            ))->values(),
+        );
+    }
+
+    #[Test]
+    public function parsesPhpListLiteralWithMixedScalars(): void
+    {
+        self::assertSame(
+            ['x', 42, false],
+            (new ParsedArgs(
+                new ListArgs(['["x",42,false]']),
+            ))->values(),
+        );
+    }
+
+    #[Test]
+    public function parsesPhpListLiteralWithCommaInsideQuotedString(): void
+    {
+        self::assertSame(
+            ['a,b', 'c'],
+            (new ParsedArgs(
+                new ListArgs(['["a,b","c"]']),
             ))->values(),
         );
     }
@@ -61,6 +105,46 @@ final class ParsedArgsTest extends TestCase
 
         (new ParsedArgs(
             new ListArgs(['[foo,bar']),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenInputIsEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs([]),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenFirstElementIsNotString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs([123]),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenLiteralIsEmptyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['']),
+        ))->values();
+    }
+
+    #[Test]
+    public function throwsWhenLiteralContainsNonScalar(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ParsedArgs(
+            new ListArgs(['[new stdClass()]']),
         ))->values();
     }
 }

--- a/tests/Unit/Formula/Args/StringifiedArgsTest.php
+++ b/tests/Unit/Formula/Args/StringifiedArgsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
+
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Formula\Args\StringifiedArgs;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class StringifiedArgsTest extends TestCase
+{
+    #[Test]
+    public function convertsBooleanTrueToLiteralTrue(): void
+    {
+        $args = new StringifiedArgs(
+            new ListArgs([true]),
+        );
+
+        self::assertSame(
+            ['true'],
+            $args->values(),
+        );
+    }
+
+    #[Test]
+    public function convertsBooleanFalseToLiteralFalse(): void
+    {
+        $args = new StringifiedArgs(
+            new ListArgs([false]),
+        );
+
+        self::assertSame(
+            ['false'],
+            $args->values(),
+        );
+    }
+
+    #[Test]
+    public function convertsMixedValuesToStrings(): void
+    {
+        $args = new StringifiedArgs(
+            new ListArgs([
+                true,
+                false,
+                10,
+                3.14,
+                'x',
+            ]),
+        );
+
+        self::assertSame(
+            ['true', 'false', '10', '3.14', 'x'],
+            $args->values(),
+        );
+    }
+}

--- a/tests/Unit/Formula/Args/TrimmedArgsTest.php
+++ b/tests/Unit/Formula/Args/TrimmedArgsTest.php
@@ -4,39 +4,39 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
 
-use Haspadar\Piqule\Formula\Args\ListParsedArgs;
-use Haspadar\Piqule\Formula\Args\RawArgs;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Formula\Args\ParsedArgs;
 use Haspadar\Piqule\Formula\Args\TrimmedArgs;
-use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsList;
-use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsText;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class TrimmedArgsTest extends TestCase
 {
     #[Test]
-    public function trimsTextWhenWhitespacePresent(): void
+    public function trimsSingleStringValue(): void
     {
-        self::assertThat(
-            new TrimmedArgs(
-                new RawArgs('  abc  '),
-            ),
-            new HasArgsText('abc'),
-            'TrimmedArgs must trim text',
+        $args = new TrimmedArgs(
+            new ListArgs(['  abc  ']),
+        );
+
+        self::assertSame(
+            ['abc'],
+            $args->values(),
         );
     }
 
     #[Test]
-    public function trimsItemsWhenListContainsWhitespace(): void
+    public function trimsItemsInsideParsedList(): void
     {
-        self::assertThat(
-            new TrimmedArgs(
-                new ListParsedArgs(
-                    new RawArgs('[ a , b ]'),
-                ),
+        $args = new TrimmedArgs(
+            new ParsedArgs(
+                new ListArgs(['[ a , b ]']),
             ),
-            new HasArgsList(['a', 'b']),
-            'TrimmedArgs must trim list items',
+        );
+
+        self::assertSame(
+            ['a', 'b'],
+            $args->values(),
         );
     }
 }

--- a/tests/Unit/Formula/Args/TrimmedArgsTest.php
+++ b/tests/Unit/Formula/Args/TrimmedArgsTest.php
@@ -26,16 +26,44 @@ final class TrimmedArgsTest extends TestCase
     }
 
     #[Test]
-    public function trimsItemsInsideParsedList(): void
+    public function doesNotModifyNonStringValues(): void
+    {
+        $args = new TrimmedArgs(
+            new ListArgs([1, true, 3.14]),
+        );
+
+        self::assertSame(
+            [1, true, 3.14],
+            $args->values(),
+        );
+    }
+
+    #[Test]
+    public function trimsItemsInsideParsedJsonList(): void
     {
         $args = new TrimmedArgs(
             new ParsedArgs(
-                new ListArgs(['[ a , b ]']),
+                new ListArgs(['[" a "," b "]']),
             ),
         );
 
         self::assertSame(
             ['a', 'b'],
+            $args->values(),
+        );
+    }
+
+    #[Test]
+    public function trimsMixedParsedJsonList(): void
+    {
+        $args = new TrimmedArgs(
+            new ParsedArgs(
+                new ListArgs(['[" x ",42,false]']),
+            ),
+        );
+
+        self::assertSame(
+            ['x', 42, false],
             $args->values(),
         );
     }

--- a/tests/Unit/Formula/Args/UnquotedArgsTest.php
+++ b/tests/Unit/Formula/Args/UnquotedArgsTest.php
@@ -4,75 +4,78 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Tests\Unit\Formula\Args;
 
-use Haspadar\Piqule\Formula\Args\ListParsedArgs;
-use Haspadar\Piqule\Formula\Args\RawArgs;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Formula\Args\ParsedArgs;
 use Haspadar\Piqule\Formula\Args\UnquotedArgs;
-use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsList;
-use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsText;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class UnquotedArgsTest extends TestCase
 {
     #[Test]
-    public function removesWrappingQuotesWhenTextIsQuoted(): void
+    public function removesWrappingQuotesFromSingleValue(): void
     {
-        self::assertThat(
-            new UnquotedArgs(
-                new RawArgs('"a\'b"'),
-            ),
-            new HasArgsText("a'b"),
-            'UnquotedArgs must remove wrapping quotes from text',
+        $args = new UnquotedArgs(
+            new ListArgs(['"a\'b"']),
         );
-    }
 
-    #[Test]
-    public function removesWrappingQuotesWhenListItemsQuoted(): void
-    {
-        self::assertThat(
-            new UnquotedArgs(
-                new ListParsedArgs(
-                    new RawArgs('["a\'b","c"]'),
-                ),
-            ),
-            new HasArgsList(["a'b", 'c']),
-            'UnquotedArgs must remove wrapping quotes from list items',
-        );
-    }
-
-    #[Test]
-    public function returnsSameTextWhenInputIsNotQuoted(): void
-    {
         self::assertSame(
-            'hello',
-            (new UnquotedArgs(
-                new RawArgs('hello'),
-            ))->text(),
-            'UnquotedArgs must return original text when no quotes are present',
+            ["a'b"],
+            $args->values(),
         );
     }
 
     #[Test]
-    public function returnsEmptyStringWhenEmptyQuotedStringGiven(): void
+    public function removesWrappingQuotesFromParsedListItems(): void
     {
+        $args = new UnquotedArgs(
+            new ParsedArgs(
+                new ListArgs(['["a\'b","c"]']),
+            ),
+        );
+
         self::assertSame(
-            '',
-            (new UnquotedArgs(
-                new RawArgs('""'),
-            ))->text(),
-            'UnquotedArgs must return empty string for empty quoted input',
+            ["a'b", 'c'],
+            $args->values(),
+        );
+    }
+
+    #[Test]
+    public function leavesUnquotedValueUnchanged(): void
+    {
+        $args = new UnquotedArgs(
+            new ListArgs(['hello']),
+        );
+
+        self::assertSame(
+            ['hello'],
+            $args->values(),
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyStringForEmptyQuotedString(): void
+    {
+        $args = new UnquotedArgs(
+            new ListArgs(['""']),
+        );
+
+        self::assertSame(
+            [''],
+            $args->values(),
         );
     }
 
     #[Test]
     public function removesOnlySingleMatchingQuoteLayer(): void
     {
+        $args = new UnquotedArgs(
+            new ListArgs(['""value""']),
+        );
+
         self::assertSame(
-            '"value"',
-            (new UnquotedArgs(
-                new RawArgs('""value""'),
-            ))->text(),
-            'UnquotedArgs must remove only one matching quote layer',
+            ['"value"'],
+            $args->values(),
         );
     }
 }


### PR DESCRIPTION
- Removed text() and list() accessors from Args
- Added unified values() accessor
- Introduced ListArgs implementation
- Added ParsedArgs decorator
- Added StringifiedArgs decorator
- Refactored TrimmedArgs implementation
- Refactored UnquotedArgs implementation
- Added unit tests for new args behavior

Part of #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified argument access into a single values() API, replacing text()/list() and expanding allowed scalar types (int, float, string, bool).
  * Updated argument decorators (parsing, trimming, unquoting, stringification) to operate via values() with improved validation and consistent behavior.

* **Tests**
  * Added and updated unit tests covering parsing, trimming, unquoting, stringification and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->