### PR TITLE
Make CI Workflow Parameters Configurable

### DIFF
--- a/.piqule/config.php
+++ b/.piqule/config.php
@@ -27,6 +27,18 @@ return [
     ],
 
     'ci' => [
+        'php' => [
+            'matrix' => ['8.3', '8.5'],
+        ],
+
+        'phpmd' => [
+            'php_version' => '8.3',
+        ],
+
+        'tests' => [
+            'php_version' => '8.3',
+        ],
+
         'pr' => [
             'max_lines_changed' => 400,
         ],

--- a/templates/root/.github/workflows/ci.yml
+++ b/templates/root/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     name: PHPCS
     uses: ./.github/workflows/_phpcs.yml
     with:
-      php-matrix: '["8.3","8.5"]'
+      php-matrix: << config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -72,7 +72,7 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: '["8.3","8.5"]'
+      php-matrix: << config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -81,7 +81,7 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: '["8.3","8.5"]'
+      php-matrix: << config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>
 
   # ------------------------------------------------------------
   # PHPMetrics (hard gate)
@@ -97,7 +97,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
-      php-version: '8.3'
+      php-version: << config(ci.phpmd.php_version)|default(["8.3"])|scalar >>
       ruleset: .piqule/phpmd/phpmd.xml
 
   # ------------------------------------------------------------
@@ -114,7 +114,7 @@ jobs:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: '8.3'
+      php-version: << config(ci.tests.php_version)|default(["8.3"])|scalar >>
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}


### PR DESCRIPTION
- Added CI-related configuration keys to project config
- Replaced hardcoded PHP versions and PR size limits with placeholders
- Preserved existing workflow structure and comments
- Kept references to .piqule configuration files unchanged

Closes #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to support PHP 8.3 and 8.5 versions
  * Refactored workflow configuration to use dynamic settings instead of hardcoded values for improved flexibility and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->