### PR TITLE
Standardize File Discovery

### DIFF
--- a/.piqule/hadolint/.hadolint.yml
+++ b/.piqule/hadolint/.hadolint.yml
@@ -1,57 +1,9 @@
-# Hadolint configuration
-# ------------------------------------------------------------------------------
-# ignored — rules that are explicitly disabled
-# ------------------------------------------------------------------------------
-
-ignored:
-  # DL3008: Pin versions in apt-get install
-  # ---------------------------------------
-  # Hadolint recommends pinning package versions.
-  # We intentionally rely on the latest packages from Debian stable.
-  - DL3008
-
-  # DL3013: Pin versions in pip install
-  # -----------------------------------
-  # Same rationale as DL3008.
-  # We want the latest version of the reuse tool, not pinned releases.
-  - DL3013
-
-
-# ------------------------------------------------------------------------------
-# failure-threshold — minimum severity that will cause the workflow to fail
-# ------------------------------------------------------------------------------
+# Hadolint configuration (Piqule managed)
 
 failure-threshold: error
-# Meaning: error → fail; warning → allowed
 
-
-# ------------------------------------------------------------------------------
-# override — change severity level for selected rules
-# ------------------------------------------------------------------------------
+ignored: []
 
 override:
-  error:
-    # DL3002: Last USER should not be root
-    # ------------------------------------
-    # Important security best practice.
-    # Raised to "error" to enforce non-root final-stage images.
-    - DL3002
-
-    # DL3025: Use JSON notation for CMD and ENTRYPOINT
-    # ------------------------------------------------
-    # JSON form avoids subtle shell interpretation issues.
-    # Raised to "error" to enforce consistent ENTRYPOINT/CMD formatting.
-    - DL3025
-
-  warning:
-    # DL3009: Delete apt-get cache
-    # ----------------------------
-    # Hadolint prefers removing apt cache to minimize image size.
-    # Not always critical for our builds; lowered to "warning".
-    - DL3009
-
-    # DL3015: Avoid additional packages
-    # ---------------------------------
-    # Suggests avoiding unnecessary packages.
-    # Useful recommendation but not always applicable; lowered to "warning".
-    - DL3015
+  error: []
+  warning: []

--- a/.piqule/hadolint/args.sh
+++ b/.piqule/hadolint/args.sh
@@ -1,0 +1,5 @@
+git ls-files -- \
+'Dockerfile*' \
+':!:vendor/**' \
+  ':!:node_modules/**' \
+  ':!:.git/**'

--- a/.piqule/jsonlint/config.json
+++ b/.piqule/jsonlint/config.json
@@ -1,0 +1,17 @@
+{
+  "mode": "json5",
+  "compact": true,
+  "continue": true,
+  "duplicate-keys": false,
+  "patterns": [
+    "**/*.json",
+    "**/*.json5",
+    "**/*.jsonc",
+    "!**/vendor/**",
+    "!**/node_modules/**",
+    "!**/.git/**",
+    "!**/coverage/**",
+    "!**/build/**",
+    "!**/var/**"
+  ]
+}

--- a/.piqule/prettier/.prettierignore
+++ b/.piqule/prettier/.prettierignore
@@ -1,6 +1,0 @@
-vendor/
-node_modules/
-.piqule/
-**/phpmetrics/**
-**/coverage-report/**
-**/*.md

--- a/.piqule/prettier/.prettierrc.yml
+++ b/.piqule/prettier/.prettierrc.yml
@@ -1,9 +1,0 @@
-# Prettier config for piqule
-# Used primarily as a syntax validator for JSON/YAML
-
-# Neutral, widely compatible defaults
-tabWidth: 2
-useTabs: false
-
-# Keep line wrapping conservative
-printWidth: 120

--- a/.piqule/shellcheck/.shellcheckrc
+++ b/.piqule/shellcheck/.shellcheckrc
@@ -1,0 +1,18 @@
+# ============================================================
+# ShellCheck configuration (Piqule managed)
+# ============================================================
+
+# Target shell (bash, sh, dash, ksh)
+shell=bash
+
+# Minimum severity: error, warning, info, style
+severity=warning
+
+# Allow sourcing external files
+external-sources=true
+
+# Additional include path for sourced files (optional)
+# source-path=.
+
+# Excluded rules (comma-separated)
+

--- a/.piqule/shellcheck/args.sh
+++ b/.piqule/shellcheck/args.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tracked files only (faster + stable); output is NUL-separated.
+git ls-files -z -- \
+  ':!:vendor/**' \
+  ':!:node_modules/**' \
+  ':!:.git/**' \
+  ':!:coverage/**' \
+  ':!:build/**' \
+  ':!:var/**' \
+| while IFS= read -r -d '' file; do
+    # Only executable files
+    if [ ! -x "$file" ]; then
+      continue
+    fi
+
+    # Only shell scripts by shebang
+    if head -n1 "$file" | grep -qE '^#!/.*\b(bash|sh)\b'; then
+      printf '%s\0' "$file"
+    fi
+  done

--- a/templates/git/hooks/pre-push
+++ b/templates/git/hooks/pre-push
@@ -1,18 +1,15 @@
 #!/usr/bin/env sh
 set -e
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required to run composer check"
-  exit 1
+if [ -x "vendor/bin/piqule" ]; then
+  vendor/bin/piqule check
+  exit $?
 fi
 
-if ! docker info >/dev/null 2>&1; then
-  echo "Docker daemon is not running"
-  exit 1
+if command -v composer >/dev/null 2>&1; then
+  composer exec -- piqule check
+  exit $?
 fi
 
-docker run --rm \
-  -v "$PWD:/app" \
-  -w /app \
-  piqule \
-  composer check
+echo "Piqule is not installed"
+exit 1

--- a/templates/root/.github/workflows/ci.yml
+++ b/templates/root/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     name: PHPCS
     uses: ./.github/workflows/_phpcs.yml
     with:
-      php-matrix: << config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>
+      php-matrix: '[<< config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>]'
 
   # ------------------------------------------------------------
   # PHPStan (min + max)
@@ -72,7 +72,7 @@ jobs:
     name: PHPStan
     uses: ./.github/workflows/_phpstan.yml
     with:
-      php-matrix: << config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>
+      php-matrix: '[<< config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>]'
 
   # ------------------------------------------------------------
   # Psalm (min + max)
@@ -81,7 +81,7 @@ jobs:
     name: Psalm
     uses: ./.github/workflows/_psalm.yml
     with:
-      php-matrix: << config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>
+      php-matrix: '[<< config(ci.php.matrix)|default(["8.3","8.5"])|format('"%s"')|join(",") >>]'
 
   # ------------------------------------------------------------
   # PHPMetrics (hard gate)
@@ -97,7 +97,7 @@ jobs:
     name: PHPMD
     uses: ./.github/workflows/_phpmd.yml
     with:
-      php-version: << config(ci.phpmd.php_version)|default(["8.3"])|scalar >>
+      php-version: '<< config(ci.phpmd.php_version)|default(["8.3"])|scalar >>'
       ruleset: .piqule/phpmd/phpmd.xml
 
   # ------------------------------------------------------------
@@ -114,7 +114,7 @@ jobs:
     name: Tests with coverage
     uses: ./.github/workflows/_tests.yml
     with:
-      php-version: << config(ci.tests.php_version)|default(["8.3"])|scalar >>
+      php-version: '<< config(ci.tests.php_version)|default(["8.3"])|scalar >>'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/templates/root/.piqule/hadolint/.hadolint.yml
+++ b/templates/root/.piqule/hadolint/.hadolint.yml
@@ -1,57 +1,9 @@
-# Hadolint configuration
-# ------------------------------------------------------------------------------
-# ignored — rules that are explicitly disabled
-# ------------------------------------------------------------------------------
-
-ignored:
-  # DL3008: Pin versions in apt-get install
-  # ---------------------------------------
-  # Hadolint recommends pinning package versions.
-  # We intentionally rely on the latest packages from Debian stable.
-  - DL3008
-
-  # DL3013: Pin versions in pip install
-  # -----------------------------------
-  # Same rationale as DL3008.
-  # We want the latest version of the reuse tool, not pinned releases.
-  - DL3013
-
-
-# ------------------------------------------------------------------------------
-# failure-threshold — minimum severity that will cause the workflow to fail
-# ------------------------------------------------------------------------------
+# Hadolint configuration (Piqule managed)
 
 failure-threshold: << config(hadolint.failure_threshold)|default(["error"])|scalar >>
-# Meaning: error → fail; warning → allowed
 
-
-# ------------------------------------------------------------------------------
-# override — change severity level for selected rules
-# ------------------------------------------------------------------------------
+ignored: << config(hadolint.ignored_yaml)|default(["[]"])|scalar >>
 
 override:
-  error:
-    # DL3002: Last USER should not be root
-    # ------------------------------------
-    # Important security best practice.
-    # Raised to "error" to enforce non-root final-stage images.
-    - DL3002
-
-    # DL3025: Use JSON notation for CMD and ENTRYPOINT
-    # ------------------------------------------------
-    # JSON form avoids subtle shell interpretation issues.
-    # Raised to "error" to enforce consistent ENTRYPOINT/CMD formatting.
-    - DL3025
-
-  warning:
-    # DL3009: Delete apt-get cache
-    # ----------------------------
-    # Hadolint prefers removing apt cache to minimize image size.
-    # Not always critical for our builds; lowered to "warning".
-    - DL3009
-
-    # DL3015: Avoid additional packages
-    # ---------------------------------
-    # Suggests avoiding unnecessary packages.
-    # Useful recommendation but not always applicable; lowered to "warning".
-    - DL3015
+  error: << config(hadolint.override.error_yaml)|default(["[]"])|scalar >>
+  warning: << config(hadolint.override.warning_yaml)|default(["[]"])|scalar >>

--- a/templates/root/.piqule/hadolint/args.sh
+++ b/templates/root/.piqule/hadolint/args.sh
@@ -1,0 +1,11 @@
+git ls-files -- \
+<< config(hadolint.patterns)
+   |default(["Dockerfile*"])
+   |format("'%s'")
+   |join(" \\\n  ")
+>> \
+<< config(hadolint.ignore)
+   |default(["vendor/**","node_modules/**",".git/**"])
+   |format("':!:%s'")
+   |join(" \\\n  ")
+>>

--- a/templates/root/.piqule/jsonlint/config.json
+++ b/templates/root/.piqule/jsonlint/config.json
@@ -1,0 +1,22 @@
+{
+  "mode": << config(jsonlint.mode)|default(["json5"])|format('"%s"')|join("") >>,
+  "compact": << config(jsonlint.compact)|default(["true"])|scalar >>,
+  "continue": << config(jsonlint.continue)|default(["true"])|scalar >>,
+  "duplicate-keys": << config(jsonlint.duplicate_keys)|default(["false"])|scalar >>,
+  "patterns": [
+<< config(jsonlint.patterns)
+   |default([
+      "**/*.json",
+      "**/*.json5",
+      "**/*.jsonc",
+      "!**/vendor/**",
+      "!**/node_modules/**",
+      "!**/.git/**",
+      "!**/coverage/**",
+      "!**/build/**",
+      "!**/var/**"
+   ])
+   |format('    "%s"')
+   |join(",\n") >>
+  ]
+}

--- a/templates/root/.piqule/prettier/.prettierignore
+++ b/templates/root/.piqule/prettier/.prettierignore
@@ -1,1 +1,0 @@
-<< config(prettierignore.paths)|default(["vendor/","node_modules/",".piqule/","**/phpmetrics/**","**/coverage-report/**","**/*.md"])|join("\n") >>

--- a/templates/root/.piqule/prettier/.prettierrc.yml
+++ b/templates/root/.piqule/prettier/.prettierrc.yml
@@ -1,9 +1,0 @@
-# Prettier config for piqule
-# Used primarily as a syntax validator for JSON/YAML
-
-# Neutral, widely compatible defaults
-tabWidth: << config(prettier.tab_width)|default(["2"])|join("") >>
-useTabs: false
-
-# Keep line wrapping conservative
-printWidth: << config(prettier.print_width)|default(["120"])|join("") >>

--- a/templates/root/.piqule/shellcheck/.shellcheckrc
+++ b/templates/root/.piqule/shellcheck/.shellcheckrc
@@ -1,0 +1,18 @@
+# ============================================================
+# ShellCheck configuration (Piqule managed)
+# ============================================================
+
+# Target shell (bash, sh, dash, ksh)
+shell=<< config(shellcheck.shell)|default(["bash"])|scalar >>
+
+# Minimum severity: error, warning, info, style
+severity=<< config(shellcheck.severity)|default(["warning"])|scalar >>
+
+# Allow sourcing external files
+external-sources=<< config(shellcheck.external_sources)|default(["true"])|scalar >>
+
+# Additional include path for sourced files (optional)
+# source-path=<< config(shellcheck.source_path)|default(["."])|scalar >>
+
+# Excluded rules (comma-separated)
+<< config(shellcheck.exclude)|default([])|join("\n") >>

--- a/templates/root/.piqule/shellcheck/args.sh
+++ b/templates/root/.piqule/shellcheck/args.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tracked files only (faster + stable); output is NUL-separated.
+git ls-files -z -- \
+<< config(shellcheck.ignore_dirs)
+   |default(["vendor","node_modules",".git","coverage","build","var"])
+   |format("  ':!:%s/**' \")
+   |join("\n")
+>>
+| while IFS= read -r -d '' file; do
+    # Only executable files
+    if [ ! -x "$file" ]; then
+      continue
+    fi
+
+    # Only shell scripts by shebang
+    if head -n1 "$file" | grep -qE '^#!/.*\b(bash|sh)\b'; then
+      printf '%s\0' "$file"
+    fi
+  done


### PR DESCRIPTION
- Refactored hadolint to use args script
- Refactored shellcheck to use git ls-files
- Updated args.sh templates to output NUL-separated file lists
- Removed legacy find-based discovery logic
- Removed hardcoded Dockerfile paths

Part of #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated and templated linting and formatting configurations across tools for more consistent project defaults.
  * Added scripts to discover relevant files for hadolint, shellcheck and jsonlint runs.
  * Removed several default ignore entries so formatter/lint tools will now consider additional paths.
  * Simplified pre-push checks to prefer a local tool binary with clear fallbacks and clearer CI workflow templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->