### PR TITLE
Switch to unified Docker-based CI workflow

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   piqule:
-    name: Piqule / ${{ matrix.check }} (PHP ${{ matrix.php }})
+    name: ${{ matrix.check }} / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -39,14 +39,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Install project dependencies
-        run: composer install --no-interaction --no-progress
-
       - name: Run ${{ matrix.check }}
         run: |
           docker run --rm \
-            --user "$(id -u):$(id -g)" \
-          -v "$PWD:/project" \
-          -w /project \
-          ghcr.io/${{ github.repository_owner }}/piqule:${{ matrix.php }} \
-          check ${{ matrix.check }}
+            -v "$PWD:/project" \
+            -w /project \
+            ghcr.io/${{ github.repository_owner }}/piqule:${{ matrix.php }} \
+            check ${{ matrix.check }}

--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [<< config(ci.php.matrix)|default(["8.3"])|format('"%s"')|join(", ") >>]
+        php: ["8.3", "8.4", "8.5"]
         check:
           - actionlint
           - hadolint

--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   piqule:
-    name: ${{ matrix.check }} / PHP ${{ matrix.php }}
+    name: ${{ matrix.check }} (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -42,6 +42,7 @@ jobs:
       - name: Run ${{ matrix.check }}
         run: |
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
             -v "$PWD:/project" \
             -w /project \
             ghcr.io/${{ github.repository_owner }}/piqule:${{ matrix.php }} \

--- a/.piqule/config.php
+++ b/.piqule/config.php
@@ -42,17 +42,8 @@ return [
 
     'ci' => [
         'php' => [
-            'matrix' => ['8.3', '8.5'],
+            'matrix' => ['8.3', '8.4', '8.5'],
         ],
-
-        'phpmd' => [
-            'php_version' => '8.3',
-        ],
-
-        'tests' => [
-            'php_version' => '8.3',
-        ],
-
         'pr' => [
             'max_lines_changed' => 400,
         ],

--- a/DEV.md
+++ b/DEV.md
@@ -4,19 +4,15 @@
 
 Location:
 
-```bash
-templates/root/
-```
+`templates/root/`
 
 Structure mirrors target project root.
 
 Example:
 
-```bash
-templates/root/.github/workflows/ci.yml
-templates/root/.piqule/phpstan.neon
-templates/root/docker/Dockerfile
-```
+`templates/root/.github/workflows/ci.yml`  
+`templates/root/.piqule/phpstan.neon`  
+`templates/root/docker/Dockerfile`
 
 Everything under `templates/root/` is copied relative to project root.
 
@@ -26,9 +22,7 @@ Everything under `templates/root/` is copied relative to project root.
 
 Run:
 
-```bash
-bin/piqule-sync.php
-```
+`bin/piqule sync`
 
 Flow:
 
@@ -43,30 +37,22 @@ Flow:
 
 Syntax:
 
-```bash
-<< config(path.to.value) >>
-```
+`<< config(path.to.value) >>`
 
 Example:
 
-```bash
-<< config(coverage.project.target) >>
-```
+`<< config(coverage.project.target) >>`
 
 Supported actions:
 
-```bash
-default([...])
-join(',')
-format('%s')
-scalar
-```
+- `default([...])`
+- `join(',')`
+- `format('%s')`
+- `scalar`
 
 Example:
 
-```bash
-<< config(paths)|default(['src'])|join(',') >>
-```
+`<< config(paths)|default(['src'])|join(',') >>`
 
 ---
 
@@ -74,9 +60,7 @@ Example:
 
 Optional file:
 
-```bash
-.piqule/config.php
-```
+`.piqule/config.php`
 
 Example:
 
@@ -94,34 +78,46 @@ return [
 
 Accessed via dot notation:
 
-```bash
-coverage.project.target
-```
+`coverage.project.target`
 
 ---
 
 ## Docker
 
-Build:
+### Build
 
 ```bash
 docker buildx build -f docker/Dockerfile -t piqule:latest --load .
 ```
 
-Run shell:
+### Run all checks
+
+```bash
+docker run --rm \
+  -v "$PWD:/project" \
+  -w /project \
+  piqule:latest \
+  check
+```
+
+### Run specific check
+
+```bash
+docker run --rm \
+  -v "$PWD:/project" \
+  -w /project \
+  piqule:latest \
+  check phpunit
+```
+
+### Open interactive shell
 
 ```bash
 docker run --rm -it \
   --entrypoint bash \
   -v "$PWD:/project" \
   -w /project \
-  piqule:latest 
-```
-
-Run checks:
-
-```bash
-bash docker/bin/check
+  piqule:latest
 ```
 
 ---
@@ -130,9 +126,7 @@ bash docker/bin/check
 
 Pinned in:
 
-```bash
-docker/Dockerfile
-```
+`docker/Dockerfile`
 
 Updated via `ARG` variables.
 
@@ -140,6 +134,4 @@ Updated via `ARG` variables.
 
 ## Entry Point
 
-```bash
-/usr/local/lib/piqule/entrypoint
-```
+`/usr/local/lib/piqule/entrypoint`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -210,6 +210,4 @@ RUN chmod +x /usr/local/lib/piqule/*
 ENTRYPOINT ["/usr/local/lib/piqule/entrypoint"]
 
 USER appuser
-ENV COMPOSER_HOME=/home/appuser/.composer
-ENV PATH="$COMPOSER_HOME/vendor/bin:$PATH"
 WORKDIR /project

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,6 +85,7 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 # ------------------------------------------------------------
 
 ENV COMPOSER_HOME=/opt/composer
+ENV COMPOSER_CACHE_DIR=/home/appuser/.cache/composer
 ENV PATH="$COMPOSER_HOME/vendor/bin:/usr/local/bin:/usr/local/lib/node_modules/.bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 ENV XDEBUG_MODE=off
 
@@ -193,9 +194,11 @@ RUN set -eux; \
         "infection/infection:^${INFECTION_VERSION}"; \
     \
     # --------------------------------------------------------\
-    # Non-root user\
+    # Non-root user and writable dirs\
     # --------------------------------------------------------\
-    useradd --uid 1000 --create-home --shell /bin/bash appuser
+    useradd --uid 1000 --create-home --shell /bin/bash appuser; \
+    mkdir -p /home/appuser/.cache/composer; \
+    chown -R appuser:appuser /home/appuser
 
 # ------------------------------------------------------------
 # Runtime scripts
@@ -207,4 +210,6 @@ RUN chmod +x /usr/local/lib/piqule/*
 ENTRYPOINT ["/usr/local/lib/piqule/entrypoint"]
 
 USER appuser
+ENV COMPOSER_HOME=/home/appuser/.composer
+ENV PATH="$COMPOSER_HOME/vendor/bin:$PATH"
 WORKDIR /project

--- a/docker/bin/check
+++ b/docker/bin/check
@@ -14,6 +14,27 @@ fi
 
 cd "$PROJECT"
 
+VENDOR_READY=false
+
+ensure_vendor() {
+  if [ ! -f composer.json ]; then
+    return 0
+  fi
+
+  if [ "$VENDOR_READY" = true ]; then
+    return 0
+  fi
+
+  if [ -f vendor/autoload.php ]; then
+    VENDOR_READY=true
+    return 0
+  fi
+
+  printf "\033[34m[RUN]  Composer install\033[0m\n"
+  composer install --no-interaction --no-progress
+  VENDOR_READY=true
+}
+
 TITLE_WIDTH=18
 CURRENT=0
 REQUESTED_KEY="${1:-}"
@@ -75,9 +96,19 @@ done
 
 run_check() {
   local title="$1"
-  local cmd="$2"
+  local key="$2"
+  local cmd="$3"
 
   CURRENT=$((CURRENT + 1))
+
+  # ------------------------------------------------------------
+  # Ensure project dependencies for checks that need autoload
+  # ------------------------------------------------------------
+  case "$key" in
+    phpunit|infection|phpstan|psalm)
+      ensure_vendor
+      ;;
+  esac
 
   if [ "$TOTAL" -gt 1 ]; then
     printf "\033[34m[RUN]  %-${TITLE_WIDTH}s (%d/%d)\033[0m\n" \
@@ -125,7 +156,7 @@ for i in "${!CHECK_TITLES[@]}"; do
   fi
 
   matched=true
-  run_check "$title" "$cmd"
+  run_check "$title" "$key" "$cmd"
 done
 
 if [ -n "$REQUESTED_KEY" ] && [ "$matched" = false ]; then


### PR DESCRIPTION
- Replaced multiple GitHub Actions workflows with a single unified CI workflow
- Switched all checks to run through the Docker-based Piqule runtime
- Added PHP version matrix support via configuration
- Removed direct GitHub Actions-based tool integrations
- Standardized CI execution model across projects

Part of #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated CI into a single matrix-driven pipeline across PHP 8.3–8.5, running a unified set of quality checks via published container images.
  * Streamlined and reorganized CI targets for consistent multi-PHP validation.
  * Improved container runtime so Composer cache is writable for non-root execution.

* **Documentation**
  * Reformatted developer docs (inline code and list spacing) for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->