### PR TITLE
Stabilize Piqule Fix Execution

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -30,10 +30,10 @@ jobs:
 
 
   # ============================================================
-  # INFRA CHECKS (Docker runtime)
+  # INFRA CHECKS
   # ============================================================
   infra:
-    name: ${{ matrix.check }} (infra)
+    name: ${{ matrix.check }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/bin/piqule-fix
+++ b/bin/piqule-fix
@@ -6,7 +6,6 @@ PROJECT="$(pwd)"
 # Psalm auto-fix
 vendor/bin/psalm \
   --config=.piqule/psalm/psalm.xml \
-  --no-plugins \
   --no-cache \
   --alter \
   --issues=MissingOverrideAttribute

--- a/templates/root/.github/workflows/piqule.yml
+++ b/templates/root/.github/workflows/piqule.yml
@@ -30,10 +30,10 @@ jobs:
 
 
   # ============================================================
-  # INFRA CHECKS (Docker runtime)
+  # INFRA CHECKS
   # ============================================================
   infra:
-    name: ${{ matrix.check }} (infra)
+    name: ${{ matrix.check }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- Removed deprecated Psalm CLI argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Psalm auto-fix now runs with plugins enabled by default.
  * CI workflow display labels simplified: an infra job name and header comment no longer include the "(infra)" / "(Docker runtime)" suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->