### PR TITLE
Plugin-Style Pre-Push Hook Registration

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -59,8 +59,9 @@ Flow:
 4. Scan `templates/once/`
 5. Resolve placeholders
 6. Write `templates/always/` → project root (overwrite on change)
-7. Write `templates/git/` → `.git/`
-8. Write `templates/once/` → project root (only if file doesn't exist)
+7. Write `templates/git/` (non-pre-push files) → `.git/` (overwrite on change)
+8. Write `templates/git/` (pre-push file) → `.git/hooks/pre-push` (append if marker absent)
+9. Write `templates/once/` → project root (only if file doesn't exist)
 
 Note:
 
@@ -167,7 +168,7 @@ Config → Formula → File → Files → Storage
 - **Formula** (`src/Formula/`) — evaluates `<< ... >>` placeholder expressions via a pipeline of `Action` objects
 - **File** (`src/File/`) — represents a single file with `name()`, `contents()`, `mode()`; decorators add behaviour (placeholder resolution, path prefix, string replacement)
 - **Files** (`src/Files/`) — iterable collection of `File` objects; composable via decorators
-- **Storage** (`src/Storage/`) — filesystem abstraction; decorators add write policy (diffing or once-only) and reactions
+- **Storage** (`src/Storage/`) — filesystem abstraction; decorators add write policy (diffing, once-only, or appending) and reactions
 - **Output** (`src/Output/`) — console output interface; `Console` writes to stdout, `Message` is a value object for a single line
 
 For a full description of every class and the decorator pattern, see [docs/architecture.md](docs/architecture.md).

--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -9,12 +9,13 @@ use Haspadar\Piqule\Config\Config;
 use Haspadar\Piqule\File\ConfiguredFile;
 use Haspadar\Piqule\File\File;
 use Haspadar\Piqule\File\PrefixedFile;
-use Haspadar\Piqule\Files\CombinedFiles;
 use Haspadar\Piqule\Files\EachFile;
+use Haspadar\Piqule\Files\FilteredFiles;
 use Haspadar\Piqule\Files\FolderFiles;
 use Haspadar\Piqule\Files\MappedFiles;
 use Haspadar\Piqule\Output\Console;
 use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Storage\AppendingStorage;
 use Haspadar\Piqule\Storage\DiffingStorage;
 use Haspadar\Piqule\Storage\DiskStorage;
 use Haspadar\Piqule\Storage\OnceStorage;
@@ -39,22 +40,21 @@ try {
     $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
     $disk = new DiskStorage($projectRoot);
 
-    $alwaysFiles = new CombinedFiles([
-        new MappedFiles(
-            new FolderFiles(
-                new DiskStorage($libraryRoot . '/templates/always'),
-                '',
-            ),
-            fn(File $file): File => new ConfiguredFile($file, $config),
+    $alwaysFiles = new MappedFiles(
+        new FolderFiles(
+            new DiskStorage($libraryRoot . '/templates/always'),
+            '',
         ),
-        new MappedFiles(
-            new FolderFiles(
-                new DiskStorage($libraryRoot . '/templates/git'),
-                '',
-            ),
-            fn(File $file): File => new PrefixedFile('.git', $file),
+        fn(File $file): File => new ConfiguredFile($file, $config),
+    );
+
+    $gitFiles = new MappedFiles(
+        new FolderFiles(
+            new DiskStorage($libraryRoot . '/templates/git'),
+            '',
         ),
-    ]);
+        fn(File $file): File => new PrefixedFile('.git', $file),
+    );
 
     $onceFiles = new MappedFiles(
         new FolderFiles(
@@ -64,7 +64,19 @@ try {
         fn(File $file): File => new ConfiguredFile($file, $config),
     );
 
+    $gitDiffFiles = new FilteredFiles(
+        $gitFiles,
+        fn(File $f): bool => !str_ends_with($f->name(), 'pre-push'),
+    );
+
+    $gitAppendFiles = new FilteredFiles(
+        $gitFiles,
+        fn(File $f): bool => str_ends_with($f->name(), 'pre-push'),
+    );
+
     (new EachFile($alwaysFiles, fn(File $file) => (new DiffingStorage($disk, $reactions))->write($file)))->run();
+    (new EachFile($gitDiffFiles, fn(File $file) => (new DiffingStorage($disk, $reactions))->write($file)))->run();
+    (new EachFile($gitAppendFiles, fn(File $file) => (new AppendingStorage($disk, $reactions, '# BEGIN piqule'))->write($file)))->run();
     (new EachFile($onceFiles, fn(File $file) => (new OnceStorage($disk, $reactions))->write($file)))->run();
 } catch (PiquleException $e) {
     $output->error($e->getMessage());

--- a/src/Files/FilteredFiles.php
+++ b/src/Files/FilteredFiles.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Files;
+
+use Closure;
+use Haspadar\Piqule\File\File;
+use Override;
+
+final readonly class FilteredFiles implements Files
+{
+    /**
+     * @param Closure(File): bool $predicate
+     */
+    public function __construct(
+        private Files $origin,
+        private Closure $predicate,
+    ) {}
+
+    #[Override]
+    public function all(): iterable
+    {
+        foreach ($this->origin->all() as $file) {
+            if (($this->predicate)($file)) {
+                yield $file;
+            }
+        }
+    }
+}

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -34,7 +34,7 @@ final readonly class AppendingStorage implements Storage
         $merged = new TextFile(
             $file->name(),
             $this->origin->read($file->name()) . "\n" . $file->contents(),
-            $file->mode(),
+            $this->origin->mode($file->name()),
         );
         $newOrigin = $this->origin->write($merged);
         $this->reaction->updated($file->name());

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Storage;
+
+use Haspadar\Piqule\File\File;
+use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\Storage\Reaction\StorageReaction;
+use Override;
+
+final readonly class AppendingStorage implements Storage
+{
+    public function __construct(
+        private Storage $origin,
+        private StorageReaction $reaction,
+        private string $marker,
+    ) {}
+
+    #[Override]
+    public function write(File $file): self
+    {
+        if (!$this->origin->exists($file->name())) {
+            $newOrigin = $this->origin->write($file);
+            $this->reaction->created($file->name());
+
+            return new self($newOrigin, $this->reaction, $this->marker);
+        }
+
+        if (str_contains($this->origin->read($file->name()), $this->marker)) {
+            return $this;
+        }
+
+        $merged = new TextFile(
+            $file->name(),
+            $this->origin->read($file->name()) . "\n" . $file->contents(),
+            $file->mode(),
+        );
+        $newOrigin = $this->origin->write($merged);
+        $this->reaction->updated($file->name());
+
+        return new self($newOrigin, $this->reaction, $this->marker);
+    }
+
+    #[Override]
+    public function read(string $location): string
+    {
+        return $this->origin->read($location);
+    }
+
+    #[Override]
+    public function exists(string $location): bool
+    {
+        return $this->origin->exists($location);
+    }
+
+    #[Override]
+    public function entries(string $location): iterable
+    {
+        return $this->origin->entries($location);
+    }
+
+    #[Override]
+    public function mode(string $location): int
+    {
+        return $this->origin->mode($location);
+    }
+}

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -20,24 +20,28 @@ final readonly class AppendingStorage implements Storage
     #[Override]
     public function write(File $file): self
     {
-        if (!$this->origin->exists($file->name())) {
+        $path = $file->name();
+
+        if (!$this->origin->exists($path)) {
             $newOrigin = $this->origin->write($file);
-            $this->reaction->created($file->name());
+            $this->reaction->created($path);
 
             return new self($newOrigin, $this->reaction, $this->marker);
         }
 
-        if (str_contains($this->origin->read($file->name()), $this->marker)) {
+        $current = $this->origin->read($path);
+
+        if (str_contains($current, $this->marker)) {
             return $this;
         }
 
         $merged = new TextFile(
-            $file->name(),
-            $this->origin->read($file->name()) . "\n" . $file->contents(),
-            $this->origin->mode($file->name()),
+            $path,
+            $current . "\n" . $file->contents(),
+            $this->origin->mode($path),
         );
         $newOrigin = $this->origin->write($merged);
-        $this->reaction->updated($file->name());
+        $this->reaction->updated($path);
 
         return new self($newOrigin, $this->reaction, $this->marker);
     }

--- a/templates/git/hooks/pre-push
+++ b/templates/git/hooks/pre-push
@@ -1,15 +1,4 @@
 #!/usr/bin/env sh
-set -e
-
-if [ -x "vendor/bin/piqule" ]; then
-  vendor/bin/piqule check
-  exit $?
-fi
-
-if command -v composer >/dev/null 2>&1; then
-  composer exec -- piqule check
-  exit $?
-fi
-
-echo "Piqule is not installed"
-exit 1
+# BEGIN piqule
+[ -f "$(dirname "$0")/pre-push-piqule" ] && "$(dirname "$0")/pre-push-piqule" "$@"
+# END piqule

--- a/templates/git/hooks/pre-push-piqule
+++ b/templates/git/hooks/pre-push-piqule
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -x "vendor/bin/piqule" ]; then
+  vendor/bin/piqule check
+  exit $?
+fi
+
+if command -v composer >/dev/null 2>&1; then
+  composer exec -- piqule check
+  exit $?
+fi
+
+echo "Piqule is not installed"
+exit 1

--- a/tests/Unit/Files/FilteredFilesTest.php
+++ b/tests/Unit/Files/FilteredFilesTest.php
@@ -19,15 +19,15 @@ final class FilteredFilesTest extends TestCase
         self::assertThat(
             new FilteredFiles(
                 new TextFiles([
-                    'pre-push' => '#!/usr/bin/env sh',
-                    'pre-push-piqule' => '#!/usr/bin/env sh',
-                    'commit-msg' => '#!/usr/bin/env sh',
+                    'pre-push' => 'exit 1',
+                    'pre-push-piqule' => 'exit 2',
+                    'commit-msg' => 'exit 3',
                 ]),
                 fn(File $file): bool => !str_ends_with($file->name(), 'pre-push'),
             ),
             new HasFiles([
-                'pre-push-piqule' => '#!/usr/bin/env sh',
-                'commit-msg' => '#!/usr/bin/env sh',
+                'pre-push-piqule' => 'exit 2',
+                'commit-msg' => 'exit 3',
             ]),
             'FilteredFiles must exclude files that do not satisfy the predicate',
         );
@@ -39,7 +39,7 @@ final class FilteredFilesTest extends TestCase
         self::assertThat(
             new FilteredFiles(
                 new TextFiles([
-                    'pre-push' => '#!/usr/bin/env sh',
+                    'pre-push' => 'exit 0',
                 ]),
                 fn(File $file): bool => str_starts_with($file->name(), 'commit'),
             ),
@@ -54,14 +54,14 @@ final class FilteredFilesTest extends TestCase
         self::assertThat(
             new FilteredFiles(
                 new TextFiles([
-                    'pre-push' => '#!/usr/bin/env sh',
-                    'pre-commit' => '#!/usr/bin/env sh',
+                    'pre-push' => 'run push checks',
+                    'pre-commit' => 'run commit checks',
                 ]),
                 fn(File $file): bool => str_starts_with($file->name(), 'pre-'),
             ),
             new HasFiles([
-                'pre-push' => '#!/usr/bin/env sh',
-                'pre-commit' => '#!/usr/bin/env sh',
+                'pre-push' => 'run push checks',
+                'pre-commit' => 'run commit checks',
             ]),
             'FilteredFiles must return all files when every file satisfies the predicate',
         );

--- a/tests/Unit/Files/FilteredFilesTest.php
+++ b/tests/Unit/Files/FilteredFilesTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Files;
+
+use Haspadar\Piqule\File\File;
+use Haspadar\Piqule\Files\FilteredFiles;
+use Haspadar\Piqule\Files\TextFiles;
+use Haspadar\Piqule\Tests\Constraint\Files\HasFiles;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FilteredFilesTest extends TestCase
+{
+    #[Test]
+    public function returnsOnlyMatchingFilesWhenPredicateFiltersOut(): void
+    {
+        self::assertThat(
+            new FilteredFiles(
+                new TextFiles([
+                    'pre-push' => '#!/usr/bin/env sh',
+                    'pre-push-piqule' => '#!/usr/bin/env sh',
+                    'commit-msg' => '#!/usr/bin/env sh',
+                ]),
+                fn(File $file): bool => !str_ends_with($file->name(), 'pre-push'),
+            ),
+            new HasFiles([
+                'pre-push-piqule' => '#!/usr/bin/env sh',
+                'commit-msg' => '#!/usr/bin/env sh',
+            ]),
+            'FilteredFiles must exclude files that do not satisfy the predicate',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenNoFilesMatchPredicate(): void
+    {
+        self::assertThat(
+            new FilteredFiles(
+                new TextFiles([
+                    'pre-push' => '#!/usr/bin/env sh',
+                ]),
+                fn(File $file): bool => str_starts_with($file->name(), 'commit'),
+            ),
+            new HasFiles([]),
+            'FilteredFiles must return empty list when no files satisfy the predicate',
+        );
+    }
+
+    #[Test]
+    public function returnsAllFilesWhenAllMatchPredicate(): void
+    {
+        self::assertThat(
+            new FilteredFiles(
+                new TextFiles([
+                    'pre-push' => '#!/usr/bin/env sh',
+                    'pre-commit' => '#!/usr/bin/env sh',
+                ]),
+                fn(File $file): bool => str_starts_with($file->name(), 'pre-'),
+            ),
+            new HasFiles([
+                'pre-push' => '#!/usr/bin/env sh',
+                'pre-commit' => '#!/usr/bin/env sh',
+            ]),
+            'FilteredFiles must return all files when every file satisfies the predicate',
+        );
+    }
+}

--- a/tests/Unit/Storage/AppendingStorageTest.php
+++ b/tests/Unit/Storage/AppendingStorageTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Storage;
+
+use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\Storage\AppendingStorage;
+use Haspadar\Piqule\Storage\InMemoryStorage;
+use Haspadar\Piqule\Tests\Constraint\Storage\ReactionWasSilent;
+use Haspadar\Piqule\Tests\Fake\Storage\Reaction\FakeStorageReaction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AppendingStorageTest extends TestCase
+{
+    #[Test]
+    public function createsFileWhenItDoesNotExist(): void
+    {
+        $reaction = new FakeStorageReaction();
+
+        (new AppendingStorage(
+            new InMemoryStorage(),
+            $reaction,
+            '# BEGIN piqule',
+        ))->write(new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"));
+
+        self::assertSame(
+            ['pre-push'],
+            $reaction->createdPaths(),
+            'created() must be called when file does not exist',
+        );
+    }
+
+    #[Test]
+    public function appendsContentWhenMarkerIsAbsent(): void
+    {
+        $reaction = new FakeStorageReaction();
+        $storage = new AppendingStorage(
+            new InMemoryStorage([
+                'pre-push' => new TextFile('pre-push', '#!/usr/bin/env sh'),
+            ]),
+            $reaction,
+            '# BEGIN piqule',
+        );
+
+        $result = $storage->write(new TextFile('pre-push', "# BEGIN piqule\n# END piqule"));
+
+        self::assertSame(
+            ['pre-push'],
+            $reaction->updatedPaths(),
+            'updated() must be called when marker is absent',
+        );
+        self::assertStringContainsString(
+            '# BEGIN piqule',
+            $result->read('pre-push'),
+            'read() must return merged content after append',
+        );
+    }
+
+    #[Test]
+    public function skipsWriteWhenMarkerAlreadyPresent(): void
+    {
+        $reaction = new FakeStorageReaction();
+
+        (new AppendingStorage(
+            new InMemoryStorage([
+                'pre-push' => new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"),
+            ]),
+            $reaction,
+            '# BEGIN piqule',
+        ))->write(new TextFile('pre-push', "# BEGIN piqule\n# END piqule"));
+
+        self::assertThat(
+            $reaction,
+            new ReactionWasSilent(),
+            'no reaction must be triggered when marker is already present',
+        );
+    }
+
+    #[Test]
+    public function returnsSameInstanceWhenMarkerAlreadyPresent(): void
+    {
+        $storage = new AppendingStorage(
+            new InMemoryStorage([
+                'pre-push' => new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"),
+            ]),
+            new FakeStorageReaction(),
+            '# BEGIN piqule',
+        );
+
+        self::assertSame(
+            $storage,
+            $storage->write(new TextFile('pre-push', "# BEGIN piqule\n# END piqule")),
+            'write() must return the same instance when marker is already present',
+        );
+    }
+
+    #[Test]
+    public function returnsNewInstanceAfterCreation(): void
+    {
+        $storage = new AppendingStorage(
+            new InMemoryStorage(),
+            new FakeStorageReaction(),
+            '# BEGIN piqule',
+        );
+
+        $result = $storage->write(new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"));
+
+        self::assertNotSame(
+            $storage,
+            $result,
+            'write() must return a new instance to preserve immutability',
+        );
+    }
+
+    #[Test]
+    public function readsFileContentFromOrigin(): void
+    {
+        self::assertSame(
+            '#!/usr/bin/env sh',
+            (new AppendingStorage(
+                new InMemoryStorage(['pre-push' => new TextFile('pre-push', '#!/usr/bin/env sh')]),
+                new FakeStorageReaction(),
+                '# BEGIN piqule',
+            ))->read('pre-push'),
+            'read() must delegate to origin storage',
+        );
+    }
+
+    #[Test]
+    public function returnsModeFromOrigin(): void
+    {
+        self::assertSame(
+            0o755,
+            (new AppendingStorage(
+                new InMemoryStorage(['pre-push' => new TextFile('pre-push', '', 0o755)]),
+                new FakeStorageReaction(),
+                '# BEGIN piqule',
+            ))->mode('pre-push'),
+            'mode() must delegate to origin storage',
+        );
+    }
+}

--- a/tests/Unit/Storage/AppendingStorageTest.php
+++ b/tests/Unit/Storage/AppendingStorageTest.php
@@ -7,6 +7,8 @@ namespace Haspadar\Piqule\Tests\Unit\Storage;
 use Haspadar\Piqule\File\TextFile;
 use Haspadar\Piqule\Storage\AppendingStorage;
 use Haspadar\Piqule\Storage\InMemoryStorage;
+use Haspadar\Piqule\Tests\Constraint\Storage\HasEntries;
+use Haspadar\Piqule\Tests\Constraint\Storage\HasEntry;
 use Haspadar\Piqule\Tests\Constraint\Storage\ReactionWasSilent;
 use Haspadar\Piqule\Tests\Fake\Storage\Reaction\FakeStorageReaction;
 use PHPUnit\Framework\Attributes\Test;
@@ -22,39 +24,51 @@ final class AppendingStorageTest extends TestCase
         (new AppendingStorage(
             new InMemoryStorage(),
             $reaction,
-            '# BEGIN piqule',
-        ))->write(new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"));
+            '# deploy-check',
+        ))->write(new TextFile('draft.txt', '# deploy-check'));
 
         self::assertSame(
-            ['pre-push'],
+            ['draft.txt'],
             $reaction->createdPaths(),
             'created() must be called when file does not exist',
         );
     }
 
     #[Test]
-    public function appendsContentWhenMarkerIsAbsent(): void
+    public function reportsUpdatedWhenMarkerIsAbsent(): void
     {
         $reaction = new FakeStorageReaction();
-        $storage = new AppendingStorage(
+
+        (new AppendingStorage(
             new InMemoryStorage([
-                'pre-push' => new TextFile('pre-push', '#!/usr/bin/env sh'),
+                'config.php' => new TextFile('config.php', "<?php\necho 'existing';"),
             ]),
             $reaction,
-            '# BEGIN piqule',
-        );
-
-        $result = $storage->write(new TextFile('pre-push', "# BEGIN piqule\n# END piqule"));
+            '# vendor-marker',
+        ))->write(new TextFile('config.php', '# vendor-marker'));
 
         self::assertSame(
-            ['pre-push'],
+            ['config.php'],
             $reaction->updatedPaths(),
             'updated() must be called when marker is absent',
         );
-        self::assertStringContainsString(
-            '# BEGIN piqule',
-            $result->read('pre-push'),
-            'read() must return merged content after append',
+    }
+
+    #[Test]
+    public function appendsBlockAfterExistingContentWhenMarkerIsAbsent(): void
+    {
+        $result = (new AppendingStorage(
+            new InMemoryStorage([
+                'notes.md' => new TextFile('notes.md', "## Appendable\nbody"),
+            ]),
+            new FakeStorageReaction(),
+            '# merge-block',
+        ))->write(new TextFile('notes.md', '# merge-block'));
+
+        self::assertThat(
+            $result,
+            new HasEntry('notes.md', "## Appendable\nbody\n# merge-block"),
+            'storage must contain original content followed by appended block',
         );
     }
 
@@ -65,11 +79,11 @@ final class AppendingStorageTest extends TestCase
 
         (new AppendingStorage(
             new InMemoryStorage([
-                'pre-push' => new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"),
+                'rules.neon' => new TextFile('rules.neon', "includes:\n  - base.neon\n# patch-marker"),
             ]),
             $reaction,
-            '# BEGIN piqule',
-        ))->write(new TextFile('pre-push', "# BEGIN piqule\n# END piqule"));
+            '# patch-marker',
+        ))->write(new TextFile('rules.neon', '# patch-marker'));
 
         self::assertThat(
             $reaction,
@@ -83,15 +97,15 @@ final class AppendingStorageTest extends TestCase
     {
         $storage = new AppendingStorage(
             new InMemoryStorage([
-                'pre-push' => new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"),
+                'state.xml' => new TextFile('state.xml', "<config />\n# commit-marker"),
             ]),
             new FakeStorageReaction(),
-            '# BEGIN piqule',
+            '# commit-marker',
         );
 
         self::assertSame(
             $storage,
-            $storage->write(new TextFile('pre-push', "# BEGIN piqule\n# END piqule")),
+            $storage->write(new TextFile('state.xml', '# commit-marker')),
             'write() must return the same instance when marker is already present',
         );
     }
@@ -102,10 +116,10 @@ final class AppendingStorageTest extends TestCase
         $storage = new AppendingStorage(
             new InMemoryStorage(),
             new FakeStorageReaction(),
-            '# BEGIN piqule',
+            '# create-marker',
         );
 
-        $result = $storage->write(new TextFile('pre-push', "#!/usr/bin/env sh\n# BEGIN piqule\n# END piqule"));
+        $result = $storage->write(new TextFile('created.yaml', '# create-marker'));
 
         self::assertNotSame(
             $storage,
@@ -115,29 +129,115 @@ final class AppendingStorageTest extends TestCase
     }
 
     #[Test]
+    public function returnsNewInstanceAfterAppend(): void
+    {
+        $storage = new AppendingStorage(
+            new InMemoryStorage([
+                'settings.ini' => new TextFile('settings.ini', "[entry]\nname=expandable"),
+            ]),
+            new FakeStorageReaction(),
+            '# append-marker',
+        );
+
+        $result = $storage->write(new TextFile('settings.ini', '# append-marker'));
+
+        self::assertNotSame(
+            $storage,
+            $result,
+            'write() must return a new instance after appending content',
+        );
+    }
+
+    #[Test]
+    public function confirmsPresentFileExistsInOrigin(): void
+    {
+        $storage = new AppendingStorage(
+            new InMemoryStorage(['present.txt' => new TextFile('present.txt', 'data')]),
+            new FakeStorageReaction(),
+            '# exists-marker',
+        );
+
+        self::assertTrue(
+            $storage->exists('present.txt'),
+            'exists() must return true when file exists in origin',
+        );
+    }
+
+    #[Test]
+    public function confirmsAbsentFileDoesNotExistInOrigin(): void
+    {
+        $storage = new AppendingStorage(
+            new InMemoryStorage(),
+            new FakeStorageReaction(),
+            '# exists-marker',
+        );
+
+        self::assertFalse(
+            $storage->exists('missing.txt'),
+            'exists() must return false when file is absent in origin',
+        );
+    }
+
+    #[Test]
     public function readsFileContentFromOrigin(): void
     {
-        self::assertSame(
-            '#!/usr/bin/env sh',
-            (new AppendingStorage(
-                new InMemoryStorage(['pre-push' => new TextFile('pre-push', '#!/usr/bin/env sh')]),
-                new FakeStorageReaction(),
-                '# BEGIN piqule',
-            ))->read('pre-push'),
+        $storage = new AppendingStorage(
+            new InMemoryStorage(['record.json' => new TextFile('record.json', "{\"name\":\"readable\"}")]),
+            new FakeStorageReaction(),
+            '# read-marker',
+        );
+
+        self::assertThat(
+            $storage,
+            new HasEntry('record.json', "{\"name\":\"readable\"}"),
             'read() must delegate to origin storage',
+        );
+    }
+
+    #[Test]
+    public function listsEntriesFromOrigin(): void
+    {
+        $storage = new AppendingStorage(
+            new InMemoryStorage(['list.txt' => new TextFile('list.txt', 'listed')]),
+            new FakeStorageReaction(),
+            '# list-marker',
+        );
+
+        self::assertThat(
+            $storage,
+            new HasEntries('', ['list.txt']),
+            'entries() must delegate to origin storage',
+        );
+    }
+
+    #[Test]
+    public function preservesOriginalModeWhenAppending(): void
+    {
+        $result = (new AppendingStorage(
+            new InMemoryStorage(['hook' => new TextFile('hook', "#!/bin/sh\nexit 0", 0o755)]),
+            new FakeStorageReaction(),
+            '# piqule',
+        ))->write(new TextFile('hook', '# piqule', 0o644));
+
+        self::assertThat(
+            $result,
+            new HasEntry('hook', "#!/bin/sh\nexit 0\n# piqule", 0o755),
+            'appended file must retain the original file mode, not the incoming template mode',
         );
     }
 
     #[Test]
     public function returnsModeFromOrigin(): void
     {
+        $storage = new AppendingStorage(
+            new InMemoryStorage(['script.bin' => new TextFile('script.bin', '', 0o755)]),
+            new FakeStorageReaction(),
+            '# mode-marker',
+        );
+
         self::assertSame(
             0o755,
-            (new AppendingStorage(
-                new InMemoryStorage(['pre-push' => new TextFile('pre-push', '', 0o755)]),
-                new FakeStorageReaction(),
-                '# BEGIN piqule',
-            ))->mode('pre-push'),
+            $storage->mode('script.bin'),
             'mode() must delegate to origin storage',
         );
     }


### PR DESCRIPTION
- Added FilteredFiles to filter file collections by predicate
- Added AppendingStorage to idempotently append content to existing files
- Updated pre-push hook template to delegate to a separate piqule script
- Refactored sync flow to use separate passes for git hook files
- Updated DEV.md to reflect new sync flow

Closes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an appending storage mode (uses a marker prefix) alongside diffing and once-only modes.
  * Added file filtering for more granular template processing.
  * Split pre-push handling into a lightweight delegating hook and a dedicated pre-push check script.

* **Documentation**
  * Updated architecture docs to describe the new appending mode.

* **Tests**
  * Added unit tests covering filtering and appending behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->