### PR TITLE
Graceful Skip for Tools When Source Directories Are Missing

### DIFF
--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping Infection"
+  exit 0
+fi
+
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
 XDEBUG_MODE=coverage \

--- a/templates/always/.piqule/phpstan/command.sh
+++ b/templates/always/.piqule/phpstan/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ]; then
+  echo "No src directory found, skipping PHPStan"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpstan)"
 
 "$BIN" analyse \

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "tests" ]; then
+  echo "No tests directory found, skipping PHPUnit"
+  exit 0
+fi
+
 SEED="${PHPUNIT_SEED:-}"
 
 BIN="$(.piqule/_composer.sh phpunit)"


### PR DESCRIPTION
- Added early exit to PHPStan command when `src/` directory is absent
- Added early exit to PHPUnit command when `tests/` directory is absent
- Added early exit to Infection command when `src/` has no PHP files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Infection now skips gracefully when no source code is found.
  * PHPStan skips analysis when source directory is missing.
  * PHPUnit exits successfully when no tests directory exists.

All tools now provide informative messages instead of attempting to run without necessary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->