### PR TITLE
Graceful Hadolint Skip When Config Is Missing

### DIFF
--- a/.piqule/hadolint/command.sh
+++ b/.piqule/hadolint/command.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 CONFIG=".piqule/hadolint/.hadolint.yml"
 
 if [ ! -f "$CONFIG" ]; then
-  echo "Hadolint config not found: $CONFIG"
-  exit 1
+  echo "No hadolint config found, skipping hadolint"
+  exit 0
 fi
 
 # ============================================================

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping Infection"
+  exit 0
+fi
+
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
 XDEBUG_MODE=coverage \

--- a/.piqule/phpstan/command.sh
+++ b/.piqule/phpstan/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ]; then
+  echo "No src directory found, skipping PHPStan"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpstan)"
 
 "$BIN" analyse \

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "tests" ]; then
+  echo "No tests directory found, skipping PHPUnit"
+  exit 0
+fi
+
 SEED="${PHPUNIT_SEED:-}"
 
 BIN="$(.piqule/_composer.sh phpunit)"

--- a/templates/always/.piqule/hadolint/command.sh
+++ b/templates/always/.piqule/hadolint/command.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 CONFIG=".piqule/hadolint/.hadolint.yml"
 
 if [ ! -f "$CONFIG" ]; then
-  echo "Hadolint config not found: $CONFIG"
-  exit 1
+  echo "No hadolint config found, skipping hadolint"
+  exit 0
 fi
 
 # ============================================================


### PR DESCRIPTION
- Fixed hadolint to exit gracefully instead of failing when config file is absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified build tooling to gracefully skip analysis steps when expected directories or configuration files are missing, outputting skip messages and returning success codes instead of errors.
  * Updated Hadolint configuration checks, PHP source detection for Infection, src directory validation for PHPStan, and tests directory verification for PHPUnit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->