### PR TITLE
Support Composer-Installed Package Binaries

### DIFF
--- a/bin/bootstrap-autoload.php
+++ b/bin/bootstrap-autoload.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+$autoload = file_exists(__DIR__ . '/../vendor/autoload.php')
+    ? __DIR__ . '/../vendor/autoload.php'
+    : __DIR__ . '/../../../autoload.php';
+
+if (!is_file($autoload)) {
+    fwrite(STDERR, "Cannot locate Composer autoload.php\n");
+    exit(1);
+}
+
+require_once $autoload;

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -7,7 +7,11 @@ use Haspadar\Piqule\Config\Config;
 use Haspadar\Piqule\Config\DefaultConfig;
 use Haspadar\Piqule\Config\OverrideConfig;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+$autoload = file_exists(__DIR__ . '/../vendor/autoload.php')
+    ? __DIR__ . '/../vendor/autoload.php'
+    : __DIR__ . '/../../../autoload.php';
+
+require_once $autoload;
 
 $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
 

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -7,11 +7,7 @@ use Haspadar\Piqule\Config\Config;
 use Haspadar\Piqule\Config\DefaultConfig;
 use Haspadar\Piqule\Config\OverrideConfig;
 
-$autoload = file_exists(__DIR__ . '/../vendor/autoload.php')
-    ? __DIR__ . '/../vendor/autoload.php'
-    : __DIR__ . '/../../../autoload.php';
-
-require_once $autoload;
+require_once __DIR__ . '/bootstrap-autoload.php';
 
 $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
 

--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -22,11 +22,7 @@ use Haspadar\Piqule\Storage\OnceStorage;
 use Haspadar\Piqule\Storage\Reaction\ReportingStorageReaction;
 use Haspadar\Piqule\Storage\Reaction\StorageReactions;
 
-$autoload = file_exists(__DIR__ . '/../vendor/autoload.php')
-    ? __DIR__ . '/../vendor/autoload.php'
-    : __DIR__ . '/../../../autoload.php';
-
-require_once $autoload;
+require_once __DIR__ . '/bootstrap-autoload.php';
 
 $output = new Console();
 

--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -22,7 +22,11 @@ use Haspadar\Piqule\Storage\OnceStorage;
 use Haspadar\Piqule\Storage\Reaction\ReportingStorageReaction;
 use Haspadar\Piqule\Storage\Reaction\StorageReactions;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+$autoload = file_exists(__DIR__ . '/../vendor/autoload.php')
+    ? __DIR__ . '/../vendor/autoload.php'
+    : __DIR__ . '/../../../autoload.php';
+
+require_once $autoload;
 
 $output = new Console();
 


### PR DESCRIPTION
- Fixed package binaries to load the project autoloader from Composer installations
- Updated local binary loading to keep repository-based development working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved dependency loading flexibility for command-line utilities across different installation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->