### PR TITLE
Use Shared Infra Image In CI

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -60,17 +60,6 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c8ad1c5d0f6f39c2bc446b807fa8ea2afadcddb6
-
-      - name: Build infra image
-        run: |
-          docker buildx build \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            -t piqule-infra:local \
-            --load .
-
       - name: Run check
         run: bin/piqule check ${{ matrix.check }}
 

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -60,17 +60,6 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c8ad1c5d0f6f39c2bc446b807fa8ea2afadcddb6
-
-      - name: Build infra image
-        run: |
-          docker buildx build \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            -t piqule-infra:local \
-            --load .
-
       - name: Run check
         run: << config(ci.piqule_bin)|join("") >> check ${{ matrix.check }}
 


### PR DESCRIPTION
- Removed the local infra image build from the infra CI job
- Updated the workflow template to rely on the shared infra image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow by removing unnecessary build steps, streamlining the infrastructure check process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->