### PR TITLE
AppendConfig Decorator for Extending Default Lists

### DIFF
--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -10,4 +10,7 @@
             <directory name="../../vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <InvalidAttribute errorLevel="suppress" />
+    </issueHandlers>
 </psalm>

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Config;
+
+use Haspadar\Piqule\PiquleException;
+use Override;
+
+/**
+ * @phpstan-type AppendMap array<string, scalar|list<scalar>>
+ */
+final readonly class AppendConfig implements Config
+{
+    /**
+     * @param AppendMap $appends
+     */
+    public function __construct(
+        private Config $origin,
+        private array $appends,
+    ) {}
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return $this->origin->has($name);
+    }
+
+    #[Override]
+    public function list(string $name): array
+    {
+        if (!$this->origin->has($name)) {
+            throw new PiquleException(
+                sprintf('Unknown config key "%s"', $name),
+            );
+        }
+
+        if (!array_key_exists($name, $this->appends)) {
+            return $this->origin->list($name);
+        }
+
+        $extra = $this->normalizedValue($this->appends[$name], $name);
+
+        return array_values(array_unique(array_merge($this->origin->list($name), $extra)));
+    }
+
+    /**
+     * @return list<scalar>
+     */
+    private function normalizedValue(mixed $value, string $name): array
+    {
+        if (is_scalar($value)) {
+            return [$value];
+        }
+
+        if (!is_array($value) || !array_is_list($value)) {
+            throw new PiquleException(
+                sprintf('Append "%s" must be scalar or list<scalar>', $name),
+            );
+        }
+
+        foreach ($value as $item) {
+            if (!is_scalar($item)) {
+                throw new PiquleException(
+                    sprintf('Append "%s" must contain only scalars', $name),
+                );
+            }
+        }
+
+        /** @var list<scalar> $value */
+        return $value;
+    }
+}

--- a/templates/always/.piqule/psalm/psalm.xml
+++ b/templates/always/.piqule/psalm/psalm.xml
@@ -10,4 +10,7 @@
 << config(psalm.project.ignore)|format_each('            <directory name="%s" />')|join("\n") >>
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <InvalidAttribute errorLevel="suppress" />
+    </issueHandlers>
 </psalm>

--- a/tests/Unit/Config/AppendConfigTest.php
+++ b/tests/Unit/Config/AppendConfigTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Config;
+
+use Haspadar\Piqule\Config\AppendConfig;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class AppendConfigTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueWhenKeyIsDeclared(): void
+    {
+        self::assertTrue(
+            (new AppendConfig(
+                new FakeConfig(['phpstan.paths' => ['../../src']]),
+                [],
+            ))->has('phpstan.paths'),
+            'AppendConfig must report a declared key as present',
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenKeyIsNotDeclared(): void
+    {
+        self::assertFalse(
+            (new AppendConfig(
+                new FakeConfig(['phpstan.paths' => ['../../src']]),
+                [],
+            ))->has('phpstan.memory'),
+            'AppendConfig must report an undeclared key as absent',
+        );
+    }
+
+    #[Test]
+    public function returnsOriginValueWhenKeyIsNotInAppends(): void
+    {
+        self::assertSame(
+            ['../../src'],
+            (new AppendConfig(
+                new FakeConfig(['phpstan.paths' => ['../../src']]),
+                [],
+            ))->list('phpstan.paths'),
+            'AppendConfig must return the origin value when the key has no appends',
+        );
+    }
+
+    #[Test]
+    public function appendsScalarToList(): void
+    {
+        self::assertSame(
+            ['../../src', '../../app'],
+            (new AppendConfig(
+                new FakeConfig(['phpstan.paths' => ['../../src']]),
+                ['phpstan.paths' => '../../app'],
+            ))->list('phpstan.paths'),
+            'AppendConfig must append a scalar value to the origin list',
+        );
+    }
+
+    #[Test]
+    public function appendsListToList(): void
+    {
+        self::assertSame(
+            ['../../src', '../../app', '../../lib'],
+            (new AppendConfig(
+                new FakeConfig(['phpstan.paths' => ['../../src']]),
+                ['phpstan.paths' => ['../../app', '../../lib']],
+            ))->list('phpstan.paths'),
+            'AppendConfig must append a list value to the origin list',
+        );
+    }
+
+    #[Test]
+    public function deduplicatesWhenAppendedValueAlreadyExists(): void
+    {
+        self::assertSame(
+            ['../../src', '../../app'],
+            (new AppendConfig(
+                new FakeConfig(['phpstan.paths' => ['../../src']]),
+                ['phpstan.paths' => ['../../src', '../../app']],
+            ))->list('phpstan.paths'),
+            'AppendConfig must not duplicate values already present in the origin list',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenListCalledForUndeclaredKey(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendConfig(
+            new FakeConfig([]),
+            [],
+        ))->list('phpstan.paths');
+    }
+
+    #[Test]
+    public function throwsWhenAppendIsAssociativeArray(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendConfig(
+            new FakeConfig(['hadolint.ignore' => []]),
+            ['hadolint.ignore' => ['DL3008' => 'ignore']],
+        ))->list('hadolint.ignore');
+    }
+
+    #[Test]
+    public function throwsWhenAppendContainsObject(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendConfig(
+            new FakeConfig(['phpstan.paths' => []]),
+            ['phpstan.paths' => [new stdClass()]],
+        ))->list('phpstan.paths');
+    }
+}

--- a/tests/Unit/Config/AppendConfigTest.php
+++ b/tests/Unit/Config/AppendConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Unit\Config;
 
 use Haspadar\Piqule\Config\AppendConfig;
+use Haspadar\Piqule\Config\OverrideConfig;
 use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
 use PHPUnit\Framework\Attributes\Test;
@@ -120,5 +121,21 @@ final class AppendConfigTest extends TestCase
             new FakeConfig(['phpstan.paths' => []]),
             ['phpstan.paths' => [new stdClass()]],
         ))->list('phpstan.paths');
+    }
+
+    #[Test]
+    public function appendsToOverriddenValueWhenComposedWithDecorator(): void
+    {
+        self::assertSame(
+            ['../../base', '../../app'],
+            (new AppendConfig(
+                new OverrideConfig(
+                    new FakeConfig(['phpstan.paths' => ['../../src']]),
+                    ['phpstan.paths' => ['../../base']],
+                ),
+                ['phpstan.paths' => ['../../app']],
+            ))->list('phpstan.paths'),
+            'AppendConfig must append to the value produced by the inner decorator, not to the original',
+        );
     }
 }


### PR DESCRIPTION
- Added `AppendConfig` decorator that appends values to existing config lists
- Added unit tests for `AppendConfig`

Closes #401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration lists can be augmented with additional values that are merged, deduplicated, and returned consistently.
* **Validation**
  * Added strict checks for appended values with clear error messages on invalid input.
* **Tests**
  * Comprehensive unit tests covering augmentation, deduplication, error cases, and decorator interaction.
* **Chores**
  * Static analysis config updated to suppress specific attribute warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->