### PR TITLE
Section Tests With Static Default Assertions

### DIFF
--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -87,4 +87,34 @@ final class DefaultConfigTest extends TestCase
             'hadolint must be enabled by default',
         );
     }
+
+    #[Test]
+    public function defaultsIncludeToSrc(): void
+    {
+        self::assertSame(
+            ['src'],
+            (new DefaultConfig())->list('dirs.include'),
+            'dirs.include must default to src',
+        );
+    }
+
+    #[Test]
+    public function defaultsExcludeToVendorTestsGit(): void
+    {
+        self::assertSame(
+            ['vendor', 'tests', '.git'],
+            (new DefaultConfig())->list('dirs.exclude'),
+            'dirs.exclude must default to vendor, tests, .git',
+        );
+    }
+
+    #[Test]
+    public function defaultsPhpVersionTo83(): void
+    {
+        self::assertSame(
+            ['8.3'],
+            (new DefaultConfig())->list('php.version'),
+            'php.version must default to 8.3',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/CiSectionTest.php
+++ b/tests/Unit/Config/Section/CiSectionTest.php
@@ -33,4 +33,14 @@ final class CiSectionTest extends TestCase
             'ci.php.test_version must reflect the given test version independently',
         );
     }
+
+    #[Test]
+    public function setsMaxLinesChangedTo250(): void
+    {
+        self::assertSame(
+            250,
+            (new CiSection([], []))->toArray()['ci.pr.max_lines_changed'],
+            'ci.pr.max_lines_changed must default to 250',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/CoverageSectionTest.php
+++ b/tests/Unit/Config/Section/CoverageSectionTest.php
@@ -19,4 +19,34 @@ final class CoverageSectionTest extends TestCase
             'coverage.project.target must default to 80',
         );
     }
+
+    #[Test]
+    public function setsPatchTargetTo80(): void
+    {
+        self::assertSame(
+            80,
+            (new CoverageSection())->toArray()['coverage.patch.target'],
+            'coverage.patch.target must default to 80',
+        );
+    }
+
+    #[Test]
+    public function setsPatchThresholdTo5(): void
+    {
+        self::assertSame(
+            5,
+            (new CoverageSection())->toArray()['coverage.patch.threshold'],
+            'coverage.patch.threshold must default to 5',
+        );
+    }
+
+    #[Test]
+    public function setsProjectThresholdTo2(): void
+    {
+        self::assertSame(
+            2,
+            (new CoverageSection())->toArray()['coverage.project.threshold'],
+            'coverage.project.threshold must default to 2',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/HadolintSectionTest.php
+++ b/tests/Unit/Config/Section/HadolintSectionTest.php
@@ -19,4 +19,64 @@ final class HadolintSectionTest extends TestCase
             'hadolint.ignore must reflect dirs.exclude',
         );
     }
+
+    #[Test]
+    public function setsFailureThresholdToError(): void
+    {
+        self::assertSame(
+            'error',
+            (new HadolintSection([]))->toArray()['hadolint.failure_threshold'],
+            'hadolint.failure_threshold must default to error',
+        );
+    }
+
+    #[Test]
+    public function setsIgnoredYamlToEmptyJsonList(): void
+    {
+        self::assertSame(
+            '[]',
+            (new HadolintSection([]))->toArray()['hadolint.ignored_yaml'],
+            'hadolint.ignored_yaml must default to empty JSON list',
+        );
+    }
+
+    #[Test]
+    public function setsOverrideErrorYamlToEmptyJsonList(): void
+    {
+        self::assertSame(
+            '[]',
+            (new HadolintSection([]))->toArray()['hadolint.override.error_yaml'],
+            'hadolint.override.error_yaml must default to empty JSON list',
+        );
+    }
+
+    #[Test]
+    public function setsOverrideWarningYamlToEmptyJsonList(): void
+    {
+        self::assertSame(
+            '[]',
+            (new HadolintSection([]))->toArray()['hadolint.override.warning_yaml'],
+            'hadolint.override.warning_yaml must default to empty JSON list',
+        );
+    }
+
+    #[Test]
+    public function setsPatternsToDockerfileGlob(): void
+    {
+        self::assertSame(
+            ['Dockerfile*'],
+            (new HadolintSection([]))->toArray()['hadolint.patterns'],
+            'hadolint.patterns must default to Dockerfile*',
+        );
+    }
+
+    #[Test]
+    public function enablesHadolintByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new HadolintSection([]))->toArray()['hadolint.enabled'],
+            'hadolint.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/InfectionSectionTest.php
+++ b/tests/Unit/Config/Section/InfectionSectionTest.php
@@ -19,4 +19,34 @@ final class InfectionSectionTest extends TestCase
             'infection.source.directories must reflect the given includes',
         );
     }
+
+    #[Test]
+    public function setsPhpOptionsToMemoryLimit(): void
+    {
+        self::assertSame(
+            '-d memory_limit=1G',
+            (new InfectionSection([]))->toArray()['infection.php_options'],
+            'infection.php_options must default to 1G memory limit',
+        );
+    }
+
+    #[Test]
+    public function setsTimeoutTo30(): void
+    {
+        self::assertSame(
+            '30',
+            (new InfectionSection([]))->toArray()['infection.timeout'],
+            'infection.timeout must default to 30',
+        );
+    }
+
+    #[Test]
+    public function enablesInfectionByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new InfectionSection([]))->toArray()['infection.enabled'],
+            'infection.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/JsonlintSectionTest.php
+++ b/tests/Unit/Config/Section/JsonlintSectionTest.php
@@ -19,4 +19,54 @@ final class JsonlintSectionTest extends TestCase
             'jsonlint.patterns must include negated glob patterns from dirs.exclude',
         );
     }
+
+    #[Test]
+    public function enablesCompactOutputByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new JsonlintSection([]))->toArray()['jsonlint.compact'],
+            'jsonlint.compact must default to true',
+        );
+    }
+
+    #[Test]
+    public function enablesContinueOnErrorByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new JsonlintSection([]))->toArray()['jsonlint.continue'],
+            'jsonlint.continue must default to true',
+        );
+    }
+
+    #[Test]
+    public function disablesDuplicateKeyCheckByDefault(): void
+    {
+        self::assertSame(
+            false,
+            (new JsonlintSection([]))->toArray()['jsonlint.duplicate_keys'],
+            'jsonlint.duplicate_keys must default to false',
+        );
+    }
+
+    #[Test]
+    public function setsModeToJson5(): void
+    {
+        self::assertSame(
+            ['json5'],
+            (new JsonlintSection([]))->toArray()['jsonlint.mode'],
+            'jsonlint.mode must default to json5',
+        );
+    }
+
+    #[Test]
+    public function enablesJsonlintByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new JsonlintSection([]))->toArray()['jsonlint.enabled'],
+            'jsonlint.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/MarkdownlintSectionTest.php
+++ b/tests/Unit/Config/Section/MarkdownlintSectionTest.php
@@ -19,4 +19,14 @@ final class MarkdownlintSectionTest extends TestCase
             'markdownlint.ignores must use trailing /** glob patterns from dirs.exclude',
         );
     }
+
+    #[Test]
+    public function enablesMarkdownlintByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new MarkdownlintSection([]))->toArray()['markdownlint.enabled'],
+            'markdownlint.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/PhpCsFixerSectionTest.php
+++ b/tests/Unit/Config/Section/PhpCsFixerSectionTest.php
@@ -19,4 +19,34 @@ final class PhpCsFixerSectionTest extends TestCase
             'php_cs_fixer.exclude must reflect dirs.exclude',
         );
     }
+
+    #[Test]
+    public function setsAllowUnsupportedToTrue(): void
+    {
+        self::assertSame(
+            ['true'],
+            (new PhpCsFixerSection([]))->toArray()['php_cs_fixer.allow_unsupported'],
+            'php_cs_fixer.allow_unsupported must default to true',
+        );
+    }
+
+    #[Test]
+    public function setsPathsToProjectRoot(): void
+    {
+        self::assertSame(
+            ['../..'],
+            (new PhpCsFixerSection([]))->toArray()['php_cs_fixer.paths'],
+            'php_cs_fixer.paths must default to project root',
+        );
+    }
+
+    #[Test]
+    public function enablesPhpCsFixerByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new PhpCsFixerSection([]))->toArray()['php-cs-fixer.enabled'],
+            'php-cs-fixer.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/PhpCsSectionTest.php
+++ b/tests/Unit/Config/Section/PhpCsSectionTest.php
@@ -29,4 +29,14 @@ final class PhpCsSectionTest extends TestCase
             'phpcs.excludes must reflect the given excludes',
         );
     }
+
+    #[Test]
+    public function enablesPhpCsByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new PhpCsSection([], []))->toArray()['phpcs.enabled'],
+            'phpcs.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/PhpMdSectionTest.php
+++ b/tests/Unit/Config/Section/PhpMdSectionTest.php
@@ -19,4 +19,94 @@ final class PhpMdSectionTest extends TestCase
             'phpmd.paths must reflect the given includes',
         );
     }
+
+    #[Test]
+    public function setsClassComplexityThresholdTo50(): void
+    {
+        self::assertSame(
+            [50],
+            (new PhpMdSection([]))->toArray()['phpmd.class_complexity'],
+            'phpmd.class_complexity must default to 50',
+        );
+    }
+
+    #[Test]
+    public function setsClassLengthThresholdTo200(): void
+    {
+        self::assertSame(
+            [200],
+            (new PhpMdSection([]))->toArray()['phpmd.class_length'],
+            'phpmd.class_length must default to 200',
+        );
+    }
+
+    #[Test]
+    public function setsCyclomaticComplexityTo10(): void
+    {
+        self::assertSame(
+            [10],
+            (new PhpMdSection([]))->toArray()['phpmd.cyclomatic'],
+            'phpmd.cyclomatic must default to 10',
+        );
+    }
+
+    #[Test]
+    public function setsMaxFieldsTo10(): void
+    {
+        self::assertSame(
+            [10],
+            (new PhpMdSection([]))->toArray()['phpmd.max_fields'],
+            'phpmd.max_fields must default to 10',
+        );
+    }
+
+    #[Test]
+    public function setsMaxMethodsTo10(): void
+    {
+        self::assertSame(
+            [10],
+            (new PhpMdSection([]))->toArray()['phpmd.max_methods'],
+            'phpmd.max_methods must default to 10',
+        );
+    }
+
+    #[Test]
+    public function setsMaxParametersTo5(): void
+    {
+        self::assertSame(
+            [5],
+            (new PhpMdSection([]))->toArray()['phpmd.max_parameters'],
+            'phpmd.max_parameters must default to 5',
+        );
+    }
+
+    #[Test]
+    public function setsMethodLengthThresholdTo50(): void
+    {
+        self::assertSame(
+            [50],
+            (new PhpMdSection([]))->toArray()['phpmd.method_length'],
+            'phpmd.method_length must default to 50',
+        );
+    }
+
+    #[Test]
+    public function setsNpathComplexityTo200(): void
+    {
+        self::assertSame(
+            [200],
+            (new PhpMdSection([]))->toArray()['phpmd.npath'],
+            'phpmd.npath must default to 200',
+        );
+    }
+
+    #[Test]
+    public function enablesPhpMdByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new PhpMdSection([]))->toArray()['phpmd.enabled'],
+            'phpmd.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/PhpMetricsSectionTest.php
+++ b/tests/Unit/Config/Section/PhpMetricsSectionTest.php
@@ -21,4 +21,184 @@ final class PhpMetricsSectionTest extends TestCase
             'phpmetrics.excludes must reflect dirs.exclude',
         );
     }
+
+    #[Test]
+    public function propagatesIncludes(): void
+    {
+        self::assertSame(
+            ['src'],
+            (new PhpMetricsSection(['src'], []))->toArray()['phpmetrics.includes'],
+            'phpmetrics.includes must reflect dirs.include',
+        );
+    }
+
+    #[Test]
+    public function setsMaxCyclomaticPerMethodTo10(): void
+    {
+        self::assertSame(
+            [10],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.complexity.max_cyclomatic_per_method'],
+            'phpmetrics.complexity.max_cyclomatic_per_method must default to 10',
+        );
+    }
+
+    #[Test]
+    public function setsMaxWeightedMethodsPerClassTo20(): void
+    {
+        self::assertSame(
+            [20],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.complexity.max_weighted_methods_per_class'],
+            'phpmetrics.complexity.max_weighted_methods_per_class must default to 20',
+        );
+    }
+
+    #[Test]
+    public function setsMaxAfferentTo10(): void
+    {
+        self::assertSame(
+            [10],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.coupling.max_afferent'],
+            'phpmetrics.coupling.max_afferent must default to 10',
+        );
+    }
+
+    #[Test]
+    public function setsMaxEfferentTo10(): void
+    {
+        self::assertSame(
+            [10],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.coupling.max_efferent'],
+            'phpmetrics.coupling.max_efferent must default to 10',
+        );
+    }
+
+    #[Test]
+    public function setsExtensionsToPhp(): void
+    {
+        self::assertSame(
+            ['php'],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.extensions'],
+            'phpmetrics.extensions must default to php',
+        );
+    }
+
+    #[Test]
+    public function setsMaxBugsPerMethodToHalfPoint(): void
+    {
+        self::assertSame(
+            [0.5],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.halstead.max_bugs_per_method'],
+            'phpmetrics.halstead.max_bugs_per_method must default to 0.5',
+        );
+    }
+
+    #[Test]
+    public function setsMaxDifficultyPerMethodTo15(): void
+    {
+        self::assertSame(
+            [15],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.halstead.max_difficulty_per_method'],
+            'phpmetrics.halstead.max_difficulty_per_method must default to 15',
+        );
+    }
+
+    #[Test]
+    public function setsMaxEffortPerMethodTo15000(): void
+    {
+        self::assertSame(
+            [15000],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.halstead.max_effort_per_method'],
+            'phpmetrics.halstead.max_effort_per_method must default to 15000',
+        );
+    }
+
+    #[Test]
+    public function setsMaxVolumePerMethodTo1000(): void
+    {
+        self::assertSame(
+            [1000],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.halstead.max_volume_per_method'],
+            'phpmetrics.halstead.max_volume_per_method must default to 1000',
+        );
+    }
+
+    #[Test]
+    public function setsMaxInheritanceDepthTo3(): void
+    {
+        self::assertSame(
+            [3],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.inheritance.max_depth'],
+            'phpmetrics.inheritance.max_depth must default to 3',
+        );
+    }
+
+    #[Test]
+    public function setsHtmlReportFormatToHtml(): void
+    {
+        self::assertSame(
+            ['html'],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.report.html'],
+            'phpmetrics.report.html must default to html',
+        );
+    }
+
+    #[Test]
+    public function setsJsonReportPathToPhpmetricsJson(): void
+    {
+        self::assertSame(
+            ['phpmetrics.json'],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.report.json'],
+            'phpmetrics.report.json must default to phpmetrics.json',
+        );
+    }
+
+    #[Test]
+    public function setsMaxLocPerClassTo1000(): void
+    {
+        self::assertSame(
+            [1000],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.size.max_loc_per_class'],
+            'phpmetrics.size.max_loc_per_class must default to 1000',
+        );
+    }
+
+    #[Test]
+    public function setsMaxLogicalLocPerClassTo600(): void
+    {
+        self::assertSame(
+            [600],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.size.max_logical_loc_per_class'],
+            'phpmetrics.size.max_logical_loc_per_class must default to 600',
+        );
+    }
+
+    #[Test]
+    public function setsMaxLogicalLocPerMethodTo20(): void
+    {
+        self::assertSame(
+            [20],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.size.max_logical_loc_per_method'],
+            'phpmetrics.size.max_logical_loc_per_method must default to 20',
+        );
+    }
+
+    #[Test]
+    public function setsMaxMethodsPerClassTo10(): void
+    {
+        self::assertSame(
+            [10],
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.structure.max_methods_per_class'],
+            'phpmetrics.structure.max_methods_per_class must default to 10',
+        );
+    }
+
+    #[Test]
+    public function enablesPhpMetricsByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new PhpMetricsSection([], []))->toArray()['phpmetrics.enabled'],
+            'phpmetrics.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/PhpStanSectionTest.php
+++ b/tests/Unit/Config/Section/PhpStanSectionTest.php
@@ -19,4 +19,34 @@ final class PhpStanSectionTest extends TestCase
             'phpstan.paths must reflect the given includes',
         );
     }
+
+    #[Test]
+    public function setsAnalysisLevelTo9(): void
+    {
+        self::assertSame(
+            [9],
+            (new PhpStanSection([]))->toArray()['phpstan.level'],
+            'phpstan.level must default to 9',
+        );
+    }
+
+    #[Test]
+    public function setsMemoryLimitTo1G(): void
+    {
+        self::assertSame(
+            '1G',
+            (new PhpStanSection([]))->toArray()['phpstan.memory'],
+            'phpstan.memory must default to 1G',
+        );
+    }
+
+    #[Test]
+    public function enablesPhpStanByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new PhpStanSection([]))->toArray()['phpstan.enabled'],
+            'phpstan.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/PhpUnitSectionTest.php
+++ b/tests/Unit/Config/Section/PhpUnitSectionTest.php
@@ -19,4 +19,24 @@ final class PhpUnitSectionTest extends TestCase
             'phpunit.source.include must reflect the given includes',
         );
     }
+
+    #[Test]
+    public function setsIntegrationTestsuitePath(): void
+    {
+        self::assertSame(
+            ['../../tests/Integration'],
+            (new PhpUnitSection([]))->toArray()['phpunit.testsuites.integration'],
+            'phpunit.testsuites.integration must default to ../../tests/Integration',
+        );
+    }
+
+    #[Test]
+    public function enablesPhpUnitByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new PhpUnitSection([]))->toArray()['phpunit.enabled'],
+            'phpunit.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/PsalmSectionTest.php
+++ b/tests/Unit/Config/Section/PsalmSectionTest.php
@@ -19,4 +19,34 @@ final class PsalmSectionTest extends TestCase
             'psalm.project.ignore must prefix dirs.exclude with ../../',
         );
     }
+
+    #[Test]
+    public function propagatesIncludesToProjectDirectories(): void
+    {
+        self::assertSame(
+            ['../../src'],
+            (new PsalmSection(['../../src'], []))->toArray()['psalm.project.directories'],
+            'psalm.project.directories must reflect dirs.include',
+        );
+    }
+
+    #[Test]
+    public function setsErrorLevelTo1(): void
+    {
+        self::assertSame(
+            [1],
+            (new PsalmSection([], []))->toArray()['psalm.error_level'],
+            'psalm.error_level must default to 1',
+        );
+    }
+
+    #[Test]
+    public function enablesPsalmByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new PsalmSection([], []))->toArray()['psalm.enabled'],
+            'psalm.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/ShellcheckSectionTest.php
+++ b/tests/Unit/Config/Section/ShellcheckSectionTest.php
@@ -19,4 +19,14 @@ final class ShellcheckSectionTest extends TestCase
             'shellcheck.ignore_dirs must reflect dirs.exclude',
         );
     }
+
+    #[Test]
+    public function enablesShellcheckByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new ShellcheckSection([]))->toArray()['shellcheck.enabled'],
+            'shellcheck.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/TyposSectionTest.php
+++ b/tests/Unit/Config/Section/TyposSectionTest.php
@@ -19,4 +19,14 @@ final class TyposSectionTest extends TestCase
             'typos.exclude must use trailing slash patterns from dirs.exclude',
         );
     }
+
+    #[Test]
+    public function enablesTyposByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new TyposSection([]))->toArray()['typos.enabled'],
+            'typos.enabled must default to true',
+        );
+    }
 }

--- a/tests/Unit/Config/Section/YamllintSectionTest.php
+++ b/tests/Unit/Config/Section/YamllintSectionTest.php
@@ -19,4 +19,24 @@ final class YamllintSectionTest extends TestCase
             'yamllint.ignore must combine dirs.exclude glob patterns with .piqule internal paths',
         );
     }
+
+    #[Test]
+    public function enablesYamllintByDefault(): void
+    {
+        self::assertSame(
+            true,
+            (new YamllintSection([]))->toArray()['yamllint.enabled'],
+            'yamllint.enabled must default to true',
+        );
+    }
+
+    #[Test]
+    public function setsLineLengthMaxTo120(): void
+    {
+        self::assertSame(
+            [120],
+            (new YamllintSection([]))->toArray()['yamllint.line_length.max'],
+            'yamllint.line_length.max must default to 120',
+        );
+    }
 }


### PR DESCRIPTION
- Added assertions for all static scalar defaults in section `toArray()` methods
- Updated `DefaultConfigTest` to pin default `include`, `exclude`, and `php.version` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for default configuration values across all supported tools and modules, including PHPUnit, PHPStan, Psalm, PHP CS Fixer, PHP Metrics, Hadolint, Jsonlint, Yamllint, and others.
  * Tests validate that all configuration sections initialize with expected default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->