### PR TITLE
Release Drafter Without Duplicate Drafts on Merge

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:
   contents: write


### PR DESCRIPTION
- Removed closed from pull_request event types to avoid triggering on merge alongside the push event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->