### PR TITLE
Renovate Without Major Composer Updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,12 @@
       "description": "Mark major updates as breaking",
       "matchUpdateTypes": ["major"],
       "labels": ["breaking"]
+    },
+    {
+      "description": "No major updates for composer packages",
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
 


### PR DESCRIPTION
- Added packageRule to disable major updates for composer packages since all dependencies use caret ranges