### PR TITLE
phpunit.php_options Config Key

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:
   contents: write

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -71,6 +71,7 @@ use Override;
  *   'phpstan.level'?: list<int|float>,
  *   'phpstan.memory'?: string,
  *   'phpstan.paths'?: list<string>,
+ *   'phpunit.php_options'?: string,
  *   'phpunit.source.include'?: list<string>,
  *   'phpunit.testsuites.integration'?: list<string>,
  *   'phpunit.testsuites.unit'?: list<string>,

--- a/src/Config/Section/PhpUnitSection.php
+++ b/src/Config/Section/PhpUnitSection.php
@@ -21,6 +21,7 @@ final readonly class PhpUnitSection implements ConfigSection
             'phpunit.source.include' => $this->includes,
             'phpunit.testsuites.integration' => ['../../tests/Integration'],
             'phpunit.testsuites.unit' => ['../../tests/Unit'],
+            'phpunit.php_options' => '-d memory_limit=1G',
             'phpunit.enabled' => true,
         ];
     }

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -35,4 +35,5 @@ if [ -n "$SEED" ]; then
   ARGS+=(--random-order-seed="$SEED")
 fi
 
-"$BIN" "${ARGS[@]}"
+PHP_OPTIONS="<< config(phpunit.php_options) >>"
+php $PHP_OPTIONS "$BIN" "${ARGS[@]}"

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -36,4 +36,4 @@ if [ -n "$SEED" ]; then
 fi
 
 PHP_OPTIONS="<< config(phpunit.php_options) >>"
-php $PHP_OPTIONS "$BIN" "${ARGS[@]}"
+php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"

--- a/tests/Unit/Config/Section/PhpUnitSectionTest.php
+++ b/tests/Unit/Config/Section/PhpUnitSectionTest.php
@@ -31,6 +31,16 @@ final class PhpUnitSectionTest extends TestCase
     }
 
     #[Test]
+    public function setsPhpOptionsToMemoryLimit(): void
+    {
+        self::assertSame(
+            '-d memory_limit=1G',
+            (new PhpUnitSection([]))->toArray()['phpunit.php_options'],
+            'phpunit.php_options must default to 1G memory limit',
+        );
+    }
+
+    #[Test]
     public function enablesPhpUnitByDefault(): void
     {
         self::assertSame(


### PR DESCRIPTION
- Added `phpunit.php_options` config key with default `-d memory_limit=1G`
- Updated phpunit command template to pass PHP options on invocation
- Added `phpunit.php_options` to OverrideConfig PHPDoc map
- Added test covering the default value

Closes #411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PHPUnit test runs can receive configurable PHP runtime options.
  * Default PHP options set a 1GB memory_limit to improve test stability.

* **Tests**
  * Added coverage to verify the default PHP runtime options and 1GB memory_limit.

* **Chores**
  * Release drafting workflow now runs only on direct pushes to main.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->