### PR TITLE
SonarQube Override Keys and Empty Default Exclusions

### DIFF
--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -6,7 +6,6 @@ namespace Haspadar\Piqule\Config;
 
 use Haspadar\Piqule\Config\Dirs\GlobDirs;
 use Haspadar\Piqule\Config\Dirs\ProjectDirs;
-use Haspadar\Piqule\Config\Dirs\TrailingGlobDirs;
 use Haspadar\Piqule\Config\Section\ActionlintSection;
 use Haspadar\Piqule\Config\Section\CiSection;
 use Haspadar\Piqule\Config\Section\CoverageSection;
@@ -67,7 +66,7 @@ final class DefaultConfig implements Config
             new PhpUnitSection($projectIncludes),
             new PsalmSection($projectIncludes, $exclude),
             new InfectionSection($projectIncludes),
-            new SonarSection($projectIncludes, (new TrailingGlobDirs($exclude))->toList()),
+            new SonarSection($projectIncludes),
         ];
 
         /** @var array<string, scalar|list<scalar>> $defaults */

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -101,7 +101,12 @@ use Override;
  *   'phpcs.enabled'?: bool,
  *   'php-cs-fixer.enabled'?: bool,
  *   'phpunit.enabled'?: bool,
- *   'infection.enabled'?: bool
+ *   'infection.enabled'?: bool,
+ *   'sonar.sources'?: list<string>,
+ *   'sonar.tests'?: list<string>,
+ *   'sonar.cpd.exclusions'?: list<string>,
+ *   'sonar.coverage.exclusions'?: list<string>,
+ *   'sonar.enabled'?: bool
  * }
  */
 final readonly class OverrideConfig implements Config

--- a/src/Config/Section/SonarSection.php
+++ b/src/Config/Section/SonarSection.php
@@ -11,14 +11,8 @@ use Override;
  */
 final readonly class SonarSection implements ConfigSection
 {
-    /**
-     * @param list<string> $includes
-     * @param list<string> $excludes
-     */
-    public function __construct(
-        private array $includes,
-        private array $excludes,
-    ) {}
+    /** @param list<string> $includes */
+    public function __construct(private array $includes) {}
 
     #[Override]
     public function toArray(): array
@@ -26,8 +20,8 @@ final readonly class SonarSection implements ConfigSection
         return [
             'sonar.sources' => $this->includes,
             'sonar.tests' => ['../../tests'],
-            'sonar.cpd.exclusions' => $this->excludes,
-            'sonar.coverage.exclusions' => $this->excludes,
+            'sonar.cpd.exclusions' => [],
+            'sonar.coverage.exclusions' => [],
             'sonar.enabled' => true,
         ];
     }

--- a/tests/Unit/Config/Section/SonarSectionTest.php
+++ b/tests/Unit/Config/Section/SonarSectionTest.php
@@ -15,28 +15,28 @@ final class SonarSectionTest extends TestCase
     {
         self::assertSame(
             ['../../src'],
-            (new SonarSection(['../../src'], []))->toArray()['sonar.sources'],
+            (new SonarSection(['../../src']))->toArray()['sonar.sources'],
             'sonar.sources must reflect the given includes',
         );
     }
 
     #[Test]
-    public function propagatesExcludesToCpdExclusions(): void
+    public function setsCpdExclusionsToEmptyByDefault(): void
     {
         self::assertSame(
-            ['vendor/**', 'tests/**'],
-            (new SonarSection([], ['vendor/**', 'tests/**']))->toArray()['sonar.cpd.exclusions'],
-            'sonar.cpd.exclusions must reflect the given excludes',
+            [],
+            (new SonarSection([]))->toArray()['sonar.cpd.exclusions'],
+            'sonar.cpd.exclusions must default to empty list',
         );
     }
 
     #[Test]
-    public function propagatesExcludesToCoverageExclusions(): void
+    public function setsCoverageExclusionsToEmptyByDefault(): void
     {
         self::assertSame(
-            ['vendor/**', 'tests/**'],
-            (new SonarSection([], ['vendor/**', 'tests/**']))->toArray()['sonar.coverage.exclusions'],
-            'sonar.coverage.exclusions must reflect the given excludes',
+            [],
+            (new SonarSection([]))->toArray()['sonar.coverage.exclusions'],
+            'sonar.coverage.exclusions must default to empty list',
         );
     }
 
@@ -45,7 +45,7 @@ final class SonarSectionTest extends TestCase
     {
         self::assertSame(
             ['../../tests'],
-            (new SonarSection([], []))->toArray()['sonar.tests'],
+            (new SonarSection([]))->toArray()['sonar.tests'],
             'sonar.tests must default to ../../tests',
         );
     }
@@ -55,7 +55,7 @@ final class SonarSectionTest extends TestCase
     {
         self::assertSame(
             true,
-            (new SonarSection([], []))->toArray()['sonar.enabled'],
+            (new SonarSection([]))->toArray()['sonar.enabled'],
             'sonar.enabled must default to true',
         );
     }


### PR DESCRIPTION
- Updated `SonarSection` to default cpd and coverage exclusions to empty list
- Added sonar keys to `OverrideConfig` type map for project-level overrides
- Updated tests to match new constructor signature and default values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable Sonar settings: `sonar.sources`, `sonar.tests`, `sonar.cpd.exclusions`, `sonar.coverage.exclusions`, and `sonar.enabled` are now available as optional override configuration keys.

* **Chores**
  * Simplified default Sonar configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->