### PR TITLE
Link to Available Override Keys in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ return new DefaultConfig(
 );
 ```
 
-Use `OverrideConfig` to replace any individual key:
+Use `OverrideConfig` to replace any individual key. The full list of available keys is declared in [`src/Config/OverrideConfig.php`](src/Config/OverrideConfig.php):
 
 ```php
 <?php


### PR DESCRIPTION
- Updated README to reference `OverrideConfig.php` as the source of all available configuration keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * README configuration guidance now includes a direct reference to the complete list of available configuration keys for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->