### PR TITLE
Global Sonar Exclusions Instead of Partial Ones

### DIFF
--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -104,8 +104,7 @@ use Override;
  *   'infection.enabled'?: bool,
  *   'sonar.sources'?: list<string>,
  *   'sonar.tests'?: list<string>,
- *   'sonar.cpd.exclusions'?: list<string>,
- *   'sonar.coverage.exclusions'?: list<string>,
+ *   'sonar.exclusions'?: list<string>,
  *   'sonar.enabled'?: bool
  * }
  */

--- a/src/Config/Section/SonarSection.php
+++ b/src/Config/Section/SonarSection.php
@@ -20,8 +20,7 @@ final readonly class SonarSection implements ConfigSection
         return [
             'sonar.sources' => $this->includes,
             'sonar.tests' => ['../../tests'],
-            'sonar.cpd.exclusions' => [],
-            'sonar.coverage.exclusions' => [],
+            'sonar.exclusions' => [],
             'sonar.enabled' => true,
         ];
     }

--- a/templates/always/sonar-project.properties
+++ b/templates/always/sonar-project.properties
@@ -1,4 +1,3 @@
 sonar.sources=<< config(sonar.sources)|join(",") >>
 sonar.tests=<< config(sonar.tests)|join(",") >>
-sonar.cpd.exclusions=<< config(sonar.cpd.exclusions)|join(",") >>
-sonar.coverage.exclusions=<< config(sonar.coverage.exclusions)|join(",") >>
+sonar.exclusions=<< config(sonar.exclusions)|join(",") >>

--- a/tests/Unit/Config/Section/SonarSectionTest.php
+++ b/tests/Unit/Config/Section/SonarSectionTest.php
@@ -21,22 +21,12 @@ final class SonarSectionTest extends TestCase
     }
 
     #[Test]
-    public function setsCpdExclusionsToEmptyByDefault(): void
+    public function setsExclusionsToEmptyByDefault(): void
     {
         self::assertSame(
             [],
-            (new SonarSection([]))->toArray()['sonar.cpd.exclusions'],
-            'sonar.cpd.exclusions must default to empty list',
-        );
-    }
-
-    #[Test]
-    public function setsCoverageExclusionsToEmptyByDefault(): void
-    {
-        self::assertSame(
-            [],
-            (new SonarSection([]))->toArray()['sonar.coverage.exclusions'],
-            'sonar.coverage.exclusions must default to empty list',
+            (new SonarSection([]))->toArray()['sonar.exclusions'],
+            'sonar.exclusions must default to empty list',
         );
     }
 


### PR DESCRIPTION
- Replaced sonar.cpd.exclusions and sonar.coverage.exclusions with sonar.exclusions
- Updated sonar-project.properties template to use the global exclusion key
- Removed outdated keys from OverrideConfig type map
- Updated SonarSection tests to reflect the new exclusion key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Unified SonarQube exclusion configuration by consolidating separate `sonar.cpd.exclusions` and `sonar.coverage.exclusions` settings into a single `sonar.exclusions` option
* Updated configuration schema, project templates, and test suite to support the unified exclusion handling
* Reduces configuration complexity with one consolidated exclusion setting instead of multiple options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->