### PR TITLE
SonarCloud Branch Coverage Integration

### DIFF
--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -105,6 +105,7 @@ use Override;
  *   'sonar.sources'?: list<string>,
  *   'sonar.tests'?: list<string>,
  *   'sonar.exclusions'?: list<string>,
+ *   'sonar.coverage.reportPath'?: list<string>,
  *   'sonar.enabled'?: bool
  * }
  */

--- a/src/Config/Section/SonarSection.php
+++ b/src/Config/Section/SonarSection.php
@@ -21,6 +21,7 @@ final readonly class SonarSection implements ConfigSection
             'sonar.sources' => $this->includes,
             'sonar.tests' => ['../../tests'],
             'sonar.exclusions' => [],
+            'sonar.coverage.reportPath' => ['.piqule/codecov/coverage.xml'],
             'sonar.enabled' => true,
         ];
     }

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -108,6 +108,8 @@ jobs:
     needs: php-static
     permissions:
       contents: read
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -150,10 +152,10 @@ jobs:
       # Upload coverage to SonarCloud (branch coverage)
       # ------------------------------------------------------------
       - name: Upload coverage to SonarCloud
-        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && secrets.SONAR_TOKEN != ''
+        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@aa494459f52eeafd71ad7fbf9d3695be4e803e6e
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 
       # ------------------------------------------------------------
       # Infection (if config exists)

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -150,7 +150,7 @@ jobs:
       # Upload coverage to SonarCloud (branch coverage)
       # ------------------------------------------------------------
       - name: Upload coverage to SonarCloud
-        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != ''
+        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && secrets.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@aa494459f52eeafd71ad7fbf9d3695be4e803e6e
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -147,6 +147,15 @@ jobs:
           fail_ci_if_error: true
 
       # ------------------------------------------------------------
+      # Upload coverage to SonarCloud (branch coverage)
+      # ------------------------------------------------------------
+      - name: Upload coverage to SonarCloud
+        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != ''
+        uses: SonarSource/sonarqube-scan-action@aa494459f52eeafd71ad7fbf9d3695be4e803e6e
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # ------------------------------------------------------------
       # Infection (if config exists)
       # ------------------------------------------------------------
       - name: Infection

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -131,12 +131,13 @@ jobs:
           php -d memory_limit=1G \
           vendor/bin/phpunit \
             -c .piqule/phpunit/phpunit.xml \
+            --path-coverage \
             --coverage-clover=.piqule/codecov/coverage.xml
 
       # ------------------------------------------------------------
       # Upload coverage to Codecov (if coverage exists)
       # ------------------------------------------------------------
-      - name: Upload coverage
+      - name: Upload coverage to Codecov
         if: hashFiles('.piqule/codecov/coverage.xml') != ''
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad
         with:

--- a/templates/always/sonar-project.properties
+++ b/templates/always/sonar-project.properties
@@ -1,3 +1,4 @@
 sonar.sources=<< config(sonar.sources)|join(",") >>
 sonar.tests=<< config(sonar.tests)|join(",") >>
 sonar.exclusions=<< config(sonar.exclusions)|join(",") >>
+sonar.php.coverage.reportPaths=<< config(sonar.coverage.reportPath)|join("") >>

--- a/templates/always/sonar-project.properties
+++ b/templates/always/sonar-project.properties
@@ -1,4 +1,4 @@
 sonar.sources=<< config(sonar.sources)|join(",") >>
 sonar.tests=<< config(sonar.tests)|join(",") >>
 sonar.exclusions=<< config(sonar.exclusions)|join(",") >>
-sonar.php.coverage.reportPaths=<< config(sonar.coverage.reportPath)|join("") >>
+sonar.php.coverage.reportPaths=<< config(sonar.coverage.reportPath)|join(",") >>

--- a/tests/Unit/Config/Section/SonarSectionTest.php
+++ b/tests/Unit/Config/Section/SonarSectionTest.php
@@ -41,6 +41,16 @@ final class SonarSectionTest extends TestCase
     }
 
     #[Test]
+    public function setsCoverageReportPathToDefault(): void
+    {
+        self::assertSame(
+            ['.piqule/codecov/coverage.xml'],
+            (new SonarSection([]))->toArray()['sonar.coverage.reportPath'],
+            'sonar.coverage.reportPath must default to clover report path',
+        );
+    }
+
+    #[Test]
     public function enablesSonarByDefault(): void
     {
         self::assertSame(


### PR DESCRIPTION
- Added `sonar.coverage.reportPath` key to `SonarSection` and `OverrideConfig` type map
- Updated `sonar-project.properties` template to pass coverage report path to SonarCloud
- Updated PHPUnit step to collect branch coverage via `--path-coverage`
- Added SonarCloud scan step to CI workflow

Part of #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SonarQube integration support for specifying coverage report paths and enabled SonarCloud scanning in CI when coverage and credentials are present.

* **Bug Fixes / CI**
  * CI now generates path-level coverage data and uploads it to Codecov; SonarCloud scan runs conditionally when coverage and token are available.

* **Tests**
  * Added a unit test asserting the default coverage report path configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->