### PR TITLE
SonarCloud Coverage Properties

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -108,6 +108,8 @@ jobs:
     needs: php-static
     permissions:
       contents: read
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -131,12 +133,13 @@ jobs:
           php -d memory_limit=1G \
           vendor/bin/phpunit \
             -c .piqule/phpunit/phpunit.xml \
+            --path-coverage \
             --coverage-clover=.piqule/codecov/coverage.xml
 
       # ------------------------------------------------------------
       # Upload coverage to Codecov (if coverage exists)
       # ------------------------------------------------------------
-      - name: Upload coverage
+      - name: Upload coverage to Codecov
         if: hashFiles('.piqule/codecov/coverage.xml') != ''
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad
         with:
@@ -144,6 +147,15 @@ jobs:
           files: .piqule/codecov/coverage.xml
           codecov_yml_path: .piqule/codecov/.codecov.yml
           fail_ci_if_error: true
+
+      # ------------------------------------------------------------
+      # Upload coverage to SonarCloud (branch coverage)
+      # ------------------------------------------------------------
+      - name: Upload coverage to SonarCloud
+        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@aa494459f52eeafd71ad7fbf9d3695be4e803e6e
+        env:
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 
       # ------------------------------------------------------------
       # Infection (if config exists)

--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -153,7 +153,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Upload coverage to SonarCloud
         if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@aa494459f52eeafd71ad7fbf9d3695be4e803e6e
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -35,4 +35,5 @@ if [ -n "$SEED" ]; then
   ARGS+=(--random-order-seed="$SEED")
 fi
 
-"$BIN" "${ARGS[@]}"
+PHP_OPTIONS="-d memory_limit=1G"
+php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.sources=../../src
+sonar.tests=../../tests
+sonar.exclusions=
+sonar.php.coverage.reportPaths=.piqule/codecov/coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.sources=../../src
-sonar.tests=../../tests
+sonar.sources=src
+sonar.tests=tests
 sonar.exclusions=
 sonar.php.coverage.reportPaths=.piqule/codecov/coverage.xml

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -66,7 +66,7 @@ final class DefaultConfig implements Config
             new PhpUnitSection($projectIncludes),
             new PsalmSection($projectIncludes, $exclude),
             new InfectionSection($projectIncludes),
-            new SonarSection($projectIncludes),
+            new SonarSection($include),
         ];
 
         /** @var array<string, scalar|list<scalar>> $defaults */

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -105,7 +105,7 @@ use Override;
  *   'sonar.sources'?: list<string>,
  *   'sonar.tests'?: list<string>,
  *   'sonar.exclusions'?: list<string>,
- *   'sonar.coverage.reportPath'?: list<string>,
+ *   'sonar.php.coverage.reportPaths'?: list<string>,
  *   'sonar.enabled'?: bool
  * }
  */

--- a/src/Config/Section/SonarSection.php
+++ b/src/Config/Section/SonarSection.php
@@ -19,7 +19,7 @@ final readonly class SonarSection implements ConfigSection
     {
         return [
             'sonar.sources' => $this->includes,
-            'sonar.tests' => ['../../tests'],
+            'sonar.tests' => ['tests'],
             'sonar.exclusions' => [],
             'sonar.php.coverage.reportPaths' => ['.piqule/codecov/coverage.xml'],
             'sonar.enabled' => true,

--- a/src/Config/Section/SonarSection.php
+++ b/src/Config/Section/SonarSection.php
@@ -21,7 +21,7 @@ final readonly class SonarSection implements ConfigSection
             'sonar.sources' => $this->includes,
             'sonar.tests' => ['../../tests'],
             'sonar.exclusions' => [],
-            'sonar.coverage.reportPath' => ['.piqule/codecov/coverage.xml'],
+            'sonar.php.coverage.reportPaths' => ['.piqule/codecov/coverage.xml'],
             'sonar.enabled' => true,
         ];
     }

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -153,7 +153,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Upload coverage to SonarCloud
         if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@aa494459f52eeafd71ad7fbf9d3695be4e803e6e
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 

--- a/templates/always/sonar-project.properties
+++ b/templates/always/sonar-project.properties
@@ -1,4 +1,4 @@
 sonar.sources=<< config(sonar.sources)|join(",") >>
 sonar.tests=<< config(sonar.tests)|join(",") >>
 sonar.exclusions=<< config(sonar.exclusions)|join(",") >>
-sonar.php.coverage.reportPaths=<< config(sonar.coverage.reportPath)|join(",") >>
+sonar.php.coverage.reportPaths=<< config(sonar.php.coverage.reportPaths)|join(",") >>

--- a/tests/Unit/Config/Section/SonarSectionTest.php
+++ b/tests/Unit/Config/Section/SonarSectionTest.php
@@ -14,8 +14,8 @@ final class SonarSectionTest extends TestCase
     public function propagatesIncludesToSources(): void
     {
         self::assertSame(
-            ['../../src'],
-            (new SonarSection(['../../src']))->toArray()['sonar.sources'],
+            ['src'],
+            (new SonarSection(['src']))->toArray()['sonar.sources'],
             'sonar.sources must reflect the given includes',
         );
     }
@@ -34,9 +34,9 @@ final class SonarSectionTest extends TestCase
     public function setsTestsToDefaultPath(): void
     {
         self::assertSame(
-            ['../../tests'],
+            ['tests'],
             (new SonarSection([]))->toArray()['sonar.tests'],
-            'sonar.tests must default to ../../tests',
+            'sonar.tests must default to tests',
         );
     }
 

--- a/tests/Unit/Config/Section/SonarSectionTest.php
+++ b/tests/Unit/Config/Section/SonarSectionTest.php
@@ -45,8 +45,8 @@ final class SonarSectionTest extends TestCase
     {
         self::assertSame(
             ['.piqule/codecov/coverage.xml'],
-            (new SonarSection([]))->toArray()['sonar.coverage.reportPath'],
-            'sonar.coverage.reportPath must default to clover report path',
+            (new SonarSection([]))->toArray()['sonar.php.coverage.reportPaths'],
+            'sonar.php.coverage.reportPaths must default to clover report path',
         );
     }
 


### PR DESCRIPTION
- Renamed \`sonar.coverage.reportPath\` key to \`sonar.php.coverage.reportPaths\` to match the SonarCloud property name
- Added \`sonar-project.properties\` to the repository so the SonarCloud step in CI is no longer skipped

Part of #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SonarCloud integration for automated code quality and coverage uploads.

* **Improvements**
  * PHPUnit now runs with a 1GB memory limit for more reliable test runs.
  * Updated SonarQube coverage configuration to use the PHP-specific coverage path setting.
  * Coverage upload step label clarified to "Upload coverage to Codecov" and Sonar upload gated to required artifacts and token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->