### PR TITLE
Sonar Organization and Project Key Configuration

### DIFF
--- a/.piqule.php
+++ b/.piqule.php
@@ -14,5 +14,7 @@ return new OverrideConfig(
         'ci.php.matrix' => ['8.3', '8.4', '8.5'],
         'ci.pr.max_lines_changed' => 2000,
         'ci.piqule_bin' => 'bin/piqule',
+        'sonar.organization' => ['haspadar-org'],
+        'sonar.projectKey' => ['haspadar_piqule'],
     ],
 );

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,5 @@
+sonar.organization=haspadar-org
+sonar.projectKey=haspadar_piqule
 sonar.sources=src
 sonar.tests=tests
 sonar.exclusions=

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -102,6 +102,8 @@ use Override;
  *   'php-cs-fixer.enabled'?: bool,
  *   'phpunit.enabled'?: bool,
  *   'infection.enabled'?: bool,
+ *   'sonar.organization'?: list<string>,
+ *   'sonar.projectKey'?: list<string>,
  *   'sonar.sources'?: list<string>,
  *   'sonar.tests'?: list<string>,
  *   'sonar.exclusions'?: list<string>,

--- a/src/Config/Section/SonarSection.php
+++ b/src/Config/Section/SonarSection.php
@@ -18,6 +18,8 @@ final readonly class SonarSection implements ConfigSection
     public function toArray(): array
     {
         return [
+            'sonar.organization' => [],
+            'sonar.projectKey' => [],
             'sonar.sources' => $this->includes,
             'sonar.tests' => ['tests'],
             'sonar.exclusions' => [],

--- a/templates/always/sonar-project.properties
+++ b/templates/always/sonar-project.properties
@@ -1,3 +1,5 @@
+sonar.organization=<< config(sonar.organization)|join(",") >>
+sonar.projectKey=<< config(sonar.projectKey)|join(",") >>
 sonar.sources=<< config(sonar.sources)|join(",") >>
 sonar.tests=<< config(sonar.tests)|join(",") >>
 sonar.exclusions=<< config(sonar.exclusions)|join(",") >>


### PR DESCRIPTION
- Added `sonar.organization` and `sonar.projectKey` as configurable keys in `SonarSection`
- Updated `OverrideConfig` type map with new sonar keys
- Updated sonar-project.properties template to include organization and project key
- Regenerated sonar-project.properties with organization and project key
- Set SonarCloud organization and project key for this repository

Part of #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SonarQube organization (`haspadar-org`) and project key (`haspadar_piqule`) configuration identifiers across project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->