### PR TITLE
Switch Codecov to Branch Coverage

### DIFF
--- a/.piqule/codecov/.codecov.yml
+++ b/.piqule/codecov/.codecov.yml
@@ -4,11 +4,13 @@ coverage:
       default:
         target: 80%
         threshold: 2%
+        coverage_type: branch
 
     patch:
       default:
         target: 80%
         threshold: 5%
+        coverage_type: branch
 
 comment:
   layout: "reach, diff, flags, files"

--- a/templates/always/.piqule/codecov/.codecov.yml
+++ b/templates/always/.piqule/codecov/.codecov.yml
@@ -4,11 +4,13 @@ coverage:
       default:
         target: << config(coverage.project.target)|format("%s%%") >>
         threshold: << config(coverage.project.threshold)|format("%s%%") >>
+        coverage_type: branch
 
     patch:
       default:
         target: << config(coverage.patch.target)|format("%s%%") >>
         threshold: << config(coverage.patch.threshold)|format("%s%%") >>
+        coverage_type: branch
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
- Updated .codecov.yml template to use `coverage_type: branch` for project and patch status checks
- Regenerated .codecov.yml with branch coverage type

Part of #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage evaluation in Codecov configuration to use branch coverage metrics, providing more granular coverage assessment for project and patch changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->