### PR TITLE
Remove SonarCloud CI Upload in Favor of Automatic Analysis

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -108,8 +108,6 @@ jobs:
     needs: php-static
     permissions:
       contents: read
-    env:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -147,15 +145,6 @@ jobs:
           files: .piqule/codecov/coverage.xml
           codecov_yml_path: .piqule/codecov/.codecov.yml
           fail_ci_if_error: true
-
-      # ------------------------------------------------------------
-      # Upload coverage to SonarCloud (branch coverage)
-      # ------------------------------------------------------------
-      - name: Upload coverage to SonarCloud
-        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
-        env:
-          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 
       # ------------------------------------------------------------
       # Infection (if config exists)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.organization=haspadar-org
-sonar.projectKey=haspadar_piqule
-sonar.sources=src
-sonar.tests=tests
-sonar.exclusions=
-sonar.php.coverage.reportPaths=.piqule/codecov/coverage.xml

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -108,8 +108,6 @@ jobs:
     needs: php-static
     permissions:
       contents: read
-    env:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -147,15 +145,6 @@ jobs:
           files: .piqule/codecov/coverage.xml
           codecov_yml_path: .piqule/codecov/.codecov.yml
           fail_ci_if_error: true
-
-      # ------------------------------------------------------------
-      # Upload coverage to SonarCloud (branch coverage)
-      # ------------------------------------------------------------
-      - name: Upload coverage to SonarCloud
-        if: hashFiles('sonar-project.properties') != '' && hashFiles('.piqule/codecov/coverage.xml') != '' && env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
-        env:
-          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 
       # ------------------------------------------------------------
       # Infection (if config exists)

--- a/templates/always/sonar-project.properties
+++ b/templates/always/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.organization=<< config(sonar.organization)|join(",") >>
-sonar.projectKey=<< config(sonar.projectKey)|join(",") >>
-sonar.sources=<< config(sonar.sources)|join(",") >>
-sonar.tests=<< config(sonar.tests)|join(",") >>
-sonar.exclusions=<< config(sonar.exclusions)|join(",") >>
-sonar.php.coverage.reportPaths=<< config(sonar.php.coverage.reportPaths)|join(",") >>


### PR DESCRIPTION
- Removed SonarCloud upload step from php-tests job
- Removed job-level SONAR_TOKEN env from php-tests job
- Removed sonar-project.properties and its template

Closes #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed SonarCloud code quality analysis integration from the continuous integration pipeline.
  * Eliminated automated code coverage uploads to SonarCloud as part of build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->