### PR TITLE
PHPStan Rule for Mandatory @throws PHPDoc Annotations

### DIFF
--- a/.piqule/phpstan/phpstan.neon
+++ b/.piqule/phpstan/phpstan.neon
@@ -10,3 +10,9 @@ parameters:
     checkUninitializedProperties: true
     checkClassCaseSensitivity: true
     checkDynamicProperties: true
+
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+        checkedExceptionClasses:
+            - \Throwable

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -20,6 +20,7 @@ interface Config
      * Missing paths and explicitly empty lists are both represented as an empty list
      *
      * @return list<scalar>
+     * @throws \Haspadar\Piqule\PiquleException
      */
     public function list(string $name): array;
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -19,8 +19,9 @@ interface Config
      *
      * Missing paths and explicitly empty lists are both represented as an empty list
      *
-     * @return list<scalar>
      * @throws \Haspadar\Piqule\PiquleException
+     *
+     * @return list<scalar>
      */
     public function list(string $name): array;
 }

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -71,6 +71,7 @@ use Override;
  *   'phpstan.level'?: list<int|float>,
  *   'phpstan.memory'?: string,
  *   'phpstan.paths'?: list<string>,
+ *   'phpstan.checked_exceptions'?: list<string>,
  *   'phpunit.php_options'?: string,
  *   'phpunit.source.include'?: list<string>,
  *   'phpunit.testsuites.integration'?: list<string>,
@@ -127,6 +128,9 @@ final readonly class OverrideConfig implements Config
         return $this->defaults->has($name);
     }
 
+    /**
+     * @throws PiquleException
+     */
     #[Override]
     public function list(string $name): array
     {
@@ -145,6 +149,7 @@ final readonly class OverrideConfig implements Config
 
     /**
      * @return list<scalar>
+     * @throws PiquleException
      */
     private function normalizedValue(mixed $value, string $name): array
     {

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -148,8 +148,9 @@ final readonly class OverrideConfig implements Config
     }
 
     /**
-     * @return list<scalar>
      * @throws PiquleException
+     *
+     * @return list<scalar>
      */
     private function normalizedValue(mixed $value, string $name): array
     {

--- a/src/Config/Section/PhpStanSection.php
+++ b/src/Config/Section/PhpStanSection.php
@@ -21,6 +21,7 @@ final readonly class PhpStanSection implements ConfigSection
             'phpstan.level' => [9],
             'phpstan.memory' => '1G',
             'phpstan.paths' => $this->includes,
+            'phpstan.checked_exceptions' => ['\Throwable'],
             'phpstan.enabled' => true,
         ];
     }

--- a/src/File/ConfiguredFile.php
+++ b/src/File/ConfiguredFile.php
@@ -33,6 +33,9 @@ final readonly class ConfiguredFile implements File
         return $this->origin->name();
     }
 
+    /**
+     * @throws PiquleException
+     */
     #[Override]
     public function contents(): string
     {
@@ -49,6 +52,7 @@ final readonly class ConfiguredFile implements File
         return $this->origin->mode();
     }
 
+    /** @throws PiquleException */
     private function replaced(string $expression): string
     {
         try {

--- a/src/Files/FolderFiles.php
+++ b/src/Files/FolderFiles.php
@@ -23,8 +23,9 @@ final readonly class FolderFiles implements Files
     ) {}
 
     /**
-     * @return iterable<TextFile>
      * @throws \Haspadar\Piqule\PiquleException
+     *
+     * @return iterable<TextFile>
      */
     #[Override]
     public function all(): iterable

--- a/src/Files/FolderFiles.php
+++ b/src/Files/FolderFiles.php
@@ -24,6 +24,7 @@ final readonly class FolderFiles implements Files
 
     /**
      * @return iterable<TextFile>
+     * @throws \Haspadar\Piqule\PiquleException
      */
     #[Override]
     public function all(): iterable

--- a/src/Formula/Action/ConfigAction.php
+++ b/src/Formula/Action/ConfigAction.php
@@ -24,6 +24,8 @@ final readonly class ConfigAction implements Action
      * Returns configuration values for the given key
      *
      * Input arguments are ignored because this action acts as a value source
+     *
+     * @throws \Haspadar\Piqule\PiquleException
      */
     #[Override]
     public function transformed(Args $args): Args

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -46,8 +46,15 @@ final readonly class FormatAction implements Action
 
         $scalar = (new StringifiedArgs($args))->values()[0];
 
-        return new ListArgs([
-            sprintf($template, $scalar),
-        ]);
+        try {
+            $result = sprintf($template, $scalar);
+        } catch (\Throwable $e) {
+            throw new PiquleException(
+                sprintf('format() failed: %s', $e->getMessage()),
+                previous: $e,
+            );
+        }
+
+        return new ListArgs([$result]);
     }
 }

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -20,6 +20,9 @@ final readonly class FormatAction implements Action
         private string $raw,
     ) {}
 
+    /**
+     * @throws PiquleException
+     */
     #[Override]
     public function transformed(Args $args): Args
     {

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -10,6 +10,7 @@ use Haspadar\Piqule\Formula\Args\StringifiedArgs;
 use Haspadar\Piqule\Formula\Args\UnquotedArgs;
 use Haspadar\Piqule\PiquleException;
 use Override;
+use Throwable;
 
 /**
  * Applies a sprintf template to a single incoming value
@@ -48,7 +49,7 @@ final readonly class FormatAction implements Action
 
         try {
             $result = sprintf($template, $scalar);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             throw new PiquleException(
                 sprintf('format() failed: %s', $e->getMessage()),
                 previous: $e,

--- a/src/Formula/Actions/ParsedActions.php
+++ b/src/Formula/Actions/ParsedActions.php
@@ -27,8 +27,9 @@ final readonly class ParsedActions implements Actions
      * DSL intentionally does not support nested parentheses
      * in action arguments. Arguments are treated as flat strings.
      *
-     * @return list<Action>
      * @throws PiquleException
+     *
+     * @return list<Action>
      */
     #[Override]
     public function all(): array

--- a/src/Formula/Actions/ParsedActions.php
+++ b/src/Formula/Actions/ParsedActions.php
@@ -28,6 +28,7 @@ final readonly class ParsedActions implements Actions
      * in action arguments. Arguments are treated as flat strings.
      *
      * @return list<Action>
+     * @throws PiquleException
      */
     #[Override]
     public function all(): array

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -19,6 +19,7 @@ final readonly class ParsedArgs implements Args
 
     /**
      * @return list<int|float|string|bool>
+     * @throws InvalidArgumentException
      */
     #[Override]
     public function values(): array
@@ -31,6 +32,7 @@ final readonly class ParsedArgs implements Args
         return $decoded;
     }
 
+    /** @throws InvalidArgumentException */
     private function singleRawValue(): string
     {
         $values = $this->origin->values();
@@ -66,6 +68,7 @@ final readonly class ParsedArgs implements Args
 
     /**
      * @return array<array-key, mixed>
+     * @throws InvalidArgumentException
      */
     private function decodeJsonList(string $raw): array
     {
@@ -93,6 +96,7 @@ final readonly class ParsedArgs implements Args
 
     /**
      * @param array<array-key, mixed> $decoded
+     * @throws InvalidArgumentException
      */
     private function assertScalarList(array $decoded, string $raw): void
     {

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -18,8 +18,9 @@ final readonly class ParsedArgs implements Args
     ) {}
 
     /**
-     * @return list<int|float|string|bool>
      * @throws InvalidArgumentException
+     *
+     * @return list<int|float|string|bool>
      */
     #[Override]
     public function values(): array
@@ -67,8 +68,9 @@ final readonly class ParsedArgs implements Args
     }
 
     /**
-     * @return array<array-key, mixed>
      * @throws InvalidArgumentException
+     *
+     * @return array<array-key, mixed>
      */
     private function decodeJsonList(string $raw): array
     {
@@ -96,6 +98,7 @@ final readonly class ParsedArgs implements Args
 
     /**
      * @param array<array-key, mixed> $decoded
+     *
      * @throws InvalidArgumentException
      */
     private function assertScalarList(array $decoded, string $raw): void

--- a/src/Formula/ExecutedFormula.php
+++ b/src/Formula/ExecutedFormula.php
@@ -18,6 +18,9 @@ final readonly class ExecutedFormula implements Formula
         private Actions $actions,
     ) {}
 
+    /**
+     * @throws PiquleException
+     */
     #[Override]
     public function result(): string
     {

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -25,6 +25,8 @@ final readonly class AppendingStorage implements Storage
      * - Creates a new file and emits created() if the file does not exist yet.
      * - Appends contents to an existing file and emits updated() if the marker is absent.
      * - No-ops if the marker is already present in the existing file.
+     *
+     * @throws \Haspadar\Piqule\PiquleException
      */
     #[Override]
     public function write(File $file): self

--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -18,6 +18,9 @@ final readonly class DiffingStorage implements Storage
         private StorageReaction $reaction,
     ) {}
 
+    /**
+     * @throws \Haspadar\Piqule\PiquleException
+     */
     #[Override]
     public function write(File $file): self
     {

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -46,6 +46,8 @@ final readonly class DiskStorage implements Storage
      * Recursively yields relative file paths within the given folder
      *
      * @return iterable<string>
+     * @throws PiquleException
+     * @throws \UnexpectedValueException
      */
     #[Override]
     public function entries(string $location): iterable
@@ -80,6 +82,8 @@ final readonly class DiskStorage implements Storage
 
     /**
      * Checks whether a file exists at the given location
+     *
+     * @throws PiquleException
      */
     #[Override]
     public function exists(string $location): bool
@@ -140,6 +144,7 @@ final readonly class DiskStorage implements Storage
         return $perms & 0o777;
     }
 
+    /** @throws PiquleException */
     private function pathOf(string $location): string
     {
         return (new SafePath($this->root))->resolve($location);

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -9,6 +9,7 @@ use Haspadar\Piqule\File\File;
 use Haspadar\Piqule\PiquleException;
 use Override;
 use SplFileInfo;
+use UnexpectedValueException;
 
 /**
  * Filesystem-backed storage rooted at a given directory
@@ -45,9 +46,10 @@ final readonly class DiskStorage implements Storage
     /**
      * Recursively yields relative file paths within the given folder
      *
-     * @return iterable<string>
      * @throws PiquleException
-     * @throws \UnexpectedValueException
+     * @throws UnexpectedValueException
+     *
+     * @return iterable<string>
      */
     #[Override]
     public function entries(string $location): iterable

--- a/src/Storage/OnceStorage.php
+++ b/src/Storage/OnceStorage.php
@@ -18,6 +18,9 @@ final readonly class OnceStorage implements Storage
         private StorageReaction $reaction,
     ) {}
 
+    /**
+     * @throws \Haspadar\Piqule\PiquleException
+     */
     #[Override]
     public function write(File $file): self
     {

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -21,6 +21,8 @@ interface Storage
 
     /**
      * Persists the given file into this storage
+     *
+     * @throws PiquleException
      */
     public function write(File $file): self;
 

--- a/templates/always/.piqule/phpstan/phpstan.neon
+++ b/templates/always/.piqule/phpstan/phpstan.neon
@@ -10,3 +10,9 @@ parameters:
     checkUninitializedProperties: true
     checkClassCaseSensitivity: true
     checkDynamicProperties: true
+
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+        checkedExceptionClasses:
+<< config(phpstan.checked_exceptions)|format_each("            - %s")|join("\n") >>

--- a/tests/Unit/Config/Section/PhpStanSectionTest.php
+++ b/tests/Unit/Config/Section/PhpStanSectionTest.php
@@ -49,4 +49,14 @@ final class PhpStanSectionTest extends TestCase
             'phpstan.enabled must default to true',
         );
     }
+
+    #[Test]
+    public function defaultsCheckedExceptionsToThrowable(): void
+    {
+        self::assertSame(
+            ['\Throwable'],
+            (new PhpStanSection([]))->toArray()['phpstan.checked_exceptions'],
+            'phpstan.checked_exceptions must default to [\Throwable]',
+        );
+    }
 }

--- a/tests/Unit/Formula/Action/FormatActionTest.php
+++ b/tests/Unit/Formula/Action/FormatActionTest.php
@@ -42,4 +42,13 @@ final class FormatActionTest extends TestCase
         (new FormatAction('%s'))
             ->transformed(new ListArgs(['a', 'b']));
     }
+
+    #[Test]
+    public function throwsWhenSprintfFails(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new FormatAction('%1$s %2$s'))
+            ->transformed(new ListArgs(['only-one']));
+    }
 }


### PR DESCRIPTION
- Added `phpstan.checked_exceptions` config key with `\Throwable` as default
- Added `missingCheckedExceptionInThrows` rule to PHPStan template
- Updated generated PHPStan config to reflect the new exceptions rule
- Added `@throws` PHPDoc annotations across project source files

Closes #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced static code analysis configuration to improve exception documentation across the codebase, enabling more thorough validation of error-handling contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->