### PR TITLE
PHPStan Strict Rules Enabled by Default

### DIFF
--- a/.piqule/phpstan/phpstan.neon
+++ b/.piqule/phpstan/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - ../../vendor/phpstan/phpstan-strict-rules/rules.neon
+
 parameters:
     level: 9
 

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,12 @@
         "php": "~8.3.16 || ~8.4.3 || ~8.5.0",
         "friendsofphp/php-cs-fixer": "^3.91",
         "infection/infection": "^0.32.0",
-        "squizlabs/php_codesniffer": "^4.0",
         "phpmd/phpmd": "^2.15",
         "phpmetrics/phpmetrics": "^2.9",
         "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^12.0",
+        "squizlabs/php_codesniffer": "^4.0",
         "symfony/process": "^7.0",
         "vimeo/psalm": "^6.14"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22b2de7506e03b97291eac0826dc52f4",
+    "content-hash": "d97a90094a74cd03fb5f6ddf2503b84c",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3247,6 +3247,57 @@
                 }
             ],
             "time": "2026-03-25T17:34:21+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
+                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.10"
+            },
+            "time": "2026-02-11T14:17:32+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -72,6 +72,7 @@ use Override;
  *   'phpstan.memory'?: string,
  *   'phpstan.paths'?: list<string>,
  *   'phpstan.checked_exceptions'?: list<string>,
+ *   'phpstan.neon_includes'?: list<string>,
  *   'phpunit.php_options'?: string,
  *   'phpunit.source.include'?: list<string>,
  *   'phpunit.testsuites.integration'?: list<string>,

--- a/src/Config/Section/PhpStanSection.php
+++ b/src/Config/Section/PhpStanSection.php
@@ -22,6 +22,7 @@ final readonly class PhpStanSection implements ConfigSection
             'phpstan.memory' => '1G',
             'phpstan.paths' => $this->includes,
             'phpstan.checked_exceptions' => ['\Throwable'],
+            'phpstan.neon_includes' => ['../../vendor/phpstan/phpstan-strict-rules/rules.neon'],
             'phpstan.enabled' => true,
         ];
     }

--- a/templates/always/.piqule/phpstan/phpstan.neon
+++ b/templates/always/.piqule/phpstan/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+<< config(phpstan.neon_includes)|format_each("    - %s")|join("\n") >>
+
 parameters:
     level: << config(phpstan.level)|join("") >>
 

--- a/tests/Unit/Config/Section/PhpStanSectionTest.php
+++ b/tests/Unit/Config/Section/PhpStanSectionTest.php
@@ -51,6 +51,16 @@ final class PhpStanSectionTest extends TestCase
     }
 
     #[Test]
+    public function defaultsNeonIncludesToStrictRules(): void
+    {
+        self::assertSame(
+            ['../../vendor/phpstan/phpstan-strict-rules/rules.neon'],
+            (new PhpStanSection([]))->toArray()['phpstan.neon_includes'],
+            'phpstan.neon_includes must default to strict-rules extension',
+        );
+    }
+
+    #[Test]
     public function defaultsCheckedExceptionsToThrowable(): void
     {
         self::assertSame(


### PR DESCRIPTION
- Added `phpstan/phpstan-strict-rules` dependency for stricter static analysis
- Added `phpstan.neon_includes` config key to control included neon extensions
- Updated PHPStan template to render `includes:` block from config
- Added test verifying the default value of `phpstan.neon_includes`

Closes #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for PHPStan strict rules configuration, enabling stricter code quality standards.
  
* **Dependencies**
  * Added phpstan-strict-rules package to provide enhanced rule definitions.

* **Tests**
  * Added test coverage for PHPStan strict rules configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->