### PR TITLE
Root Namespace for phpcs TypeNameMatchesFileName From composer.json

### DIFF
--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+use Haspadar\Piqule\Config\ComposerRootNamespace;
 use Haspadar\Piqule\Config\DefaultConfig;
 use Haspadar\Piqule\Config\OverrideConfig;
 use Haspadar\Piqule\Config\Config;
@@ -36,6 +37,10 @@ try {
     $config = file_exists($projectRoot . '/.piqule.php')
         ? require $projectRoot . '/.piqule.php'
         : new OverrideConfig(new DefaultConfig(), []);
+
+    $config = new OverrideConfig($config, [
+        'phpcs.root_namespace' => (new ComposerRootNamespace($projectRoot . '/composer.json'))->toString(),
+    ]);
 
     $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
     $disk = new DiskStorage($projectRoot);

--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -38,9 +38,11 @@ try {
         ? require $projectRoot . '/.piqule.php'
         : new OverrideConfig(new DefaultConfig(), []);
 
-    $config = new OverrideConfig($config, [
-        'phpcs.root_namespace' => (new ComposerRootNamespace($projectRoot . '/composer.json'))->toString(),
-    ]);
+    if ($config->list('phpcs.root_namespace') === ['']) {
+        $config = new OverrideConfig($config, [
+            'phpcs.root_namespace' => (new ComposerRootNamespace($projectRoot . '/composer.json'))->toString(),
+        ]);
+    }
 
     $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
     $disk = new DiskStorage($projectRoot);

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -17,7 +17,7 @@ final readonly class ComposerRootNamespace
             return '';
         }
 
-        $contents = file_get_contents($this->path);
+        $contents = @file_get_contents($this->path);
 
         if ($contents === false) {
             return '';

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Config;
+
+/**
+ * Root namespace from the PSR-4 autoload section of composer.json
+ */
+final readonly class ComposerRootNamespace
+{
+    public function __construct(private string $path) {}
+
+    public function toString(): string
+    {
+        if (!is_file($this->path)) {
+            return '';
+        }
+
+        $contents = file_get_contents($this->path);
+
+        if ($contents === false) {
+            return '';
+        }
+
+        /** @var array{autoload?: array{psr-4?: array<string, string>}} $data */
+        $data = json_decode($contents, true) ?? [];
+        $psr4 = $data['autoload']['psr-4'] ?? [];
+
+        if ($psr4 === []) {
+            return '';
+        }
+
+        return rtrim(array_key_first($psr4), '\\');
+    }
+}

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -18,19 +18,10 @@ final readonly class ComposerRootNamespace
         }
 
         $contents = @file_get_contents($this->path);
-
-        if ($contents === false) {
-            return '';
-        }
-
         /** @var array{autoload?: array{psr-4?: array<string, string>}} $data */
-        $data = json_decode($contents, true) ?? [];
+        $data = json_decode($contents === false ? '{}' : $contents, true) ?? [];
         $psr4 = $data['autoload']['psr-4'] ?? [];
 
-        if ($psr4 === []) {
-            return '';
-        }
-
-        return rtrim(array_key_first($psr4), '\\');
+        return $psr4 !== [] ? rtrim(array_key_first($psr4), '\\') : '';
     }
 }

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -41,6 +41,7 @@ use Override;
  *   'php_cs_fixer.paths'?: list<string>,
  *   'phpcs.excludes'?: list<string>,
  *   'phpcs.files'?: list<string>,
+ *   'phpcs.root_namespace'?: string,
  *   'phpmd.class_complexity'?: list<int|float>,
  *   'phpmd.class_length'?: list<int|float>,
  *   'phpmd.cyclomatic'?: list<int|float>,

--- a/src/Config/Section/PhpCsSection.php
+++ b/src/Config/Section/PhpCsSection.php
@@ -18,6 +18,7 @@ final readonly class PhpCsSection implements ConfigSection
     public function __construct(
         private array $includes,
         private array $excludes,
+        private string $rootNamespace = '',
     ) {}
 
     #[Override]
@@ -26,6 +27,7 @@ final readonly class PhpCsSection implements ConfigSection
         return [
             'phpcs.excludes' => $this->excludes,
             'phpcs.files' => $this->includes,
+            'phpcs.root_namespace' => $this->rootNamespace,
             'phpcs.enabled' => true,
         ];
     }

--- a/templates/always/.piqule/phpcs/phpcs.xml
+++ b/templates/always/.piqule/phpcs/phpcs.xml
@@ -19,7 +19,7 @@
     <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
         <properties>
             <property name="rootNamespaces" type="array">
-                <element key="src" value="Haspadar\Piqule"/>
+                <element key="src" value="<< config(phpcs.root_namespace)|join("") >>"/>
             </property>
         </properties>
     </rule>

--- a/tests/Integration/Config/ComposerRootNamespaceTest.php
+++ b/tests/Integration/Config/ComposerRootNamespaceTest.php
@@ -56,4 +56,21 @@ final class ComposerRootNamespaceTest extends TestCase
 
         $folder->close();
     }
+
+    #[Test]
+    public function returnsEmptyStringWhenComposerJsonIsNotReadable(): void
+    {
+        $folder = (new TempFolder())->withFile('composer.json', '{}');
+        $path = $folder->path() . '/composer.json';
+        chmod($path, 0o000);
+
+        self::assertSame(
+            '',
+            (new ComposerRootNamespace($path))->toString(),
+            'ComposerRootNamespace must return empty string when composer.json is not readable',
+        );
+
+        chmod($path, 0o644);
+        $folder->close();
+    }
 }

--- a/tests/Integration/Config/ComposerRootNamespaceTest.php
+++ b/tests/Integration/Config/ComposerRootNamespaceTest.php
@@ -58,6 +58,25 @@ final class ComposerRootNamespaceTest extends TestCase
     }
 
     #[Test]
+    public function returnsFirstWhenMultiplePsr4NamespacesExist(): void
+    {
+        $folder = (new TempFolder())->withFile('composer.json', json_encode([
+            'autoload' => ['psr-4' => [
+                'Acme\\App\\' => 'src/',
+                'Acme\\Tests\\' => 'tests/',
+            ]],
+        ]) ?: '');
+
+        self::assertSame(
+            'Acme\\App',
+            (new ComposerRootNamespace($folder->path() . '/composer.json'))->toString(),
+            'ComposerRootNamespace must return the first PSR-4 namespace when multiple entries exist',
+        );
+
+        $folder->close();
+    }
+
+    #[Test]
     public function returnsEmptyStringWhenComposerJsonIsNotReadable(): void
     {
         $folder = (new TempFolder())->withFile('composer.json', '{}');

--- a/tests/Integration/Config/ComposerRootNamespaceTest.php
+++ b/tests/Integration/Config/ComposerRootNamespaceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Integration\Config;
+
+use Haspadar\Piqule\Config\ComposerRootNamespace;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ComposerRootNamespaceTest extends TestCase
+{
+    #[Test]
+    public function returnsFirstPsr4NamespaceFromComposerJson(): void
+    {
+        $folder = (new TempFolder())->withFile('composer.json', json_encode([
+            'autoload' => ['psr-4' => ['Acme\\App\\' => 'src/']],
+        ]) ?: '');
+
+        self::assertSame(
+            'Acme\\App',
+            (new ComposerRootNamespace($folder->path() . '/composer.json'))->toString(),
+            'ComposerRootNamespace must return the first PSR-4 namespace without trailing backslash',
+        );
+
+        $folder->close();
+    }
+
+    #[Test]
+    public function returnsEmptyStringWhenComposerJsonIsMissing(): void
+    {
+        $folder = new TempFolder();
+
+        self::assertSame(
+            '',
+            (new ComposerRootNamespace($folder->path() . '/composer.json'))->toString(),
+            'ComposerRootNamespace must return empty string when composer.json does not exist',
+        );
+
+        $folder->close();
+    }
+
+    #[Test]
+    public function returnsEmptyStringWhenPsr4SectionIsAbsent(): void
+    {
+        $folder = (new TempFolder())->withFile('composer.json', json_encode([
+            'name' => 'acme/app',
+        ]) ?: '');
+
+        self::assertSame(
+            '',
+            (new ComposerRootNamespace($folder->path() . '/composer.json'))->toString(),
+            'ComposerRootNamespace must return empty string when autoload.psr-4 is absent',
+        );
+
+        $folder->close();
+    }
+}

--- a/tests/Unit/Config/Section/PhpCsSectionTest.php
+++ b/tests/Unit/Config/Section/PhpCsSectionTest.php
@@ -39,4 +39,14 @@ final class PhpCsSectionTest extends TestCase
             'phpcs.enabled must default to true',
         );
     }
+
+    #[Test]
+    public function exposesRootNamespace(): void
+    {
+        self::assertSame(
+            'Acme\\App',
+            (new PhpCsSection([], [], 'Acme\\App'))->toArray()['phpcs.root_namespace'],
+            'phpcs.root_namespace must reflect the given root namespace',
+        );
+    }
 }


### PR DESCRIPTION
- Added `ComposerRootNamespace` to extract the PSR-4 namespace from `composer.json`
- Added `phpcs.root_namespace` config key to `PhpCsSection` and `OverrideMap`
- Updated `phpcs.xml` template to use the config key instead of a hardcoded value
- Updated `piqule-sync` to inject the project namespace at generation time

Closes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Automatic root namespace detection from project configuration now dynamically applies your PHP namespace to code standards checking, eliminating the need for manual hardcoded namespace setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->