### PR TITLE
Warn When Required GitHub Secrets Are Missing

### DIFF
--- a/bin/piqule
+++ b/bin/piqule
@@ -18,11 +18,13 @@ case "$COMMAND" in
   sync)
     "$(dirname "$0")/piqule-sync" "$@"
     "$(dirname "$0")/piqule-pin"
+    "$(dirname "$0")/piqule-tokens-check"
     ;;
   check|fix)
     ensure_project_root
     "$(dirname "$0")/piqule-verify"
     "$(dirname "$0")/piqule-${COMMAND}" "$@"
+    "$(dirname "$0")/piqule-tokens-check"
     ;;
   *)
     echo "Usage: piqule [sync|check|fix]"

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -1,0 +1,74 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\Config\DefaultConfig;
+use Haspadar\Piqule\Config\OverrideConfig;
+use Haspadar\Piqule\Output\Console;
+use Haspadar\Piqule\Token\CodecovToken;
+use Haspadar\Piqule\Token\InfectionToken;
+use Haspadar\Piqule\Token\Tokens;
+
+require_once __DIR__ . '/bootstrap-autoload.php';
+
+$output = new Console();
+
+$projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
+
+$config = file_exists($projectRoot . '/.piqule.php')
+    ? require $projectRoot . '/.piqule.php'
+    : new OverrideConfig(new DefaultConfig(), []);
+
+$tokens = new Tokens([
+    new CodecovToken(),
+    new InfectionToken(),
+]);
+
+$enabled = array_filter(
+    $tokens->items(),
+    fn($token) => $token->enabled($config),
+);
+
+if ($enabled === []) {
+    exit(0);
+}
+
+exec('command -v gh', $out, $ghExists);
+
+if ($ghExists !== 0) {
+    $output->info('[TOKEN] Install GitHub CLI to verify secrets: https://cli.github.com');
+    exit(0);
+}
+
+exec('gh auth status 2>/dev/null', $out, $authStatus);
+
+if ($authStatus !== 0) {
+    $output->info('[TOKEN] Run: gh auth login — to enable secret verification');
+    exit(0);
+}
+
+exec('gh secret list --json name 2>/dev/null', $secretsJson, $secretsStatus);
+
+if ($secretsStatus !== 0) {
+    exit(0);
+}
+
+/** @var list<array{name: string}> $decoded */
+$decoded = json_decode(implode('', $secretsJson), true) ?? [];
+$existing = array_column($decoded, 'name');
+
+exec('gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null', $repoOut, $repoStatus);
+
+$repo = $repoStatus === 0 ? trim($repoOut[0] ?? '') : '';
+$org = $repo !== '' ? explode('/', $repo)[0] : '';
+
+foreach ($enabled as $token) {
+    if (in_array($token->secret(), $existing, true)) {
+        continue;
+    }
+
+    $output->info(sprintf('[TOKEN] %s is missing. Get it at: %s', $token->secret(), $token->url($org)));
+    $output->info(sprintf('[TOKEN] Add it at: https://github.com/%s/settings/secrets/actions/new', $repo));
+}

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -35,14 +35,14 @@ if ($enabled === []) {
     exit(0);
 }
 
-exec('command -v gh', $out, $ghExists);
+exec('command -v gh', $ghOut, $ghExists);
 
 if ($ghExists !== 0) {
     $output->info('[TOKEN] Install GitHub CLI to verify secrets: https://cli.github.com');
     exit(0);
 }
 
-exec('gh auth status 2>/dev/null', $out, $authStatus);
+exec('gh auth status 2>/dev/null', $authOut, $authStatus);
 
 if ($authStatus !== 0) {
     $output->info('[TOKEN] Run: gh auth login — to enable secret verification');
@@ -70,5 +70,7 @@ foreach ($enabled as $token) {
     }
 
     $output->info(sprintf('[TOKEN] %s is missing. Get it at: %s', $token->secret(), $token->url($org)));
-    $output->info(sprintf('[TOKEN] Add it at: https://github.com/%s/settings/secrets/actions/new', $repo));
+    if ($repo !== '') {
+        $output->info(sprintf('[TOKEN] Add it at: https://github.com/%s/settings/secrets/actions/new', $repo));
+    }
 }

--- a/src/Token/CodecovToken.php
+++ b/src/Token/CodecovToken.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Token;
+
+use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\PiquleException;
+use Override;
+
+/**
+ * Codecov coverage upload token
+ */
+final readonly class CodecovToken implements Token
+{
+    #[Override]
+    public function secret(): string
+    {
+        return 'CODECOV_TOKEN';
+    }
+
+    #[Override]
+    public function url(string $org): string
+    {
+        return "https://app.codecov.io/account/gh/{$org}/repositories";
+    }
+
+    /**
+     * @throws PiquleException
+     */
+    #[Override]
+    public function enabled(Config $config): bool
+    {
+        return !$config->has('phpunit.enabled')
+            || (bool) ($config->list('phpunit.enabled')[0] ?? true);
+    }
+}

--- a/src/Token/CodecovToken.php
+++ b/src/Token/CodecovToken.php
@@ -25,9 +25,7 @@ final readonly class CodecovToken implements Token
         return "https://app.codecov.io/account/gh/{$org}/repositories";
     }
 
-    /**
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     #[Override]
     public function enabled(Config $config): bool
     {

--- a/src/Token/InfectionToken.php
+++ b/src/Token/InfectionToken.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Token;
+
+use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\PiquleException;
+use Override;
+
+/**
+ * Stryker mutation testing dashboard token
+ */
+final readonly class InfectionToken implements Token
+{
+    #[Override]
+    public function secret(): string
+    {
+        return 'STRYKER_DASHBOARD_API_KEY';
+    }
+
+    #[Override]
+    public function url(string $org): string
+    {
+        return 'https://dashboard.stryker-mutator.io';
+    }
+
+    /**
+     * @throws PiquleException
+     */
+    #[Override]
+    public function enabled(Config $config): bool
+    {
+        return !$config->has('infection.enabled')
+            || (bool) ($config->list('infection.enabled')[0] ?? true);
+    }
+}

--- a/src/Token/InfectionToken.php
+++ b/src/Token/InfectionToken.php
@@ -25,9 +25,7 @@ final readonly class InfectionToken implements Token
         return 'https://dashboard.stryker-mutator.io';
     }
 
-    /**
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     #[Override]
     public function enabled(Config $config): bool
     {

--- a/src/Token/InfectionToken.php
+++ b/src/Token/InfectionToken.php
@@ -22,6 +22,7 @@ final readonly class InfectionToken implements Token
     #[Override]
     public function url(string $org): string
     {
+        // Stryker dashboard is org-agnostic
         return 'https://dashboard.stryker-mutator.io';
     }
 

--- a/src/Token/Token.php
+++ b/src/Token/Token.php
@@ -16,8 +16,6 @@ interface Token
 
     public function url(string $org): string;
 
-    /**
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     public function enabled(Config $config): bool;
 }

--- a/src/Token/Token.php
+++ b/src/Token/Token.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Token;
+
+use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\PiquleException;
+
+/**
+ * GitHub Secret required by an external service
+ */
+interface Token
+{
+    public function secret(): string;
+
+    public function url(string $org): string;
+
+    /**
+     * @throws PiquleException
+     */
+    public function enabled(Config $config): bool;
+}

--- a/src/Token/Tokens.php
+++ b/src/Token/Tokens.php
@@ -10,7 +10,9 @@ namespace Haspadar\Piqule\Token;
 final readonly class Tokens
 {
     /** @param list<Token> $items */
-    public function __construct(private array $items) {}
+    public function __construct(private array $items)
+    {
+    }
 
     /** @return list<Token> */
     public function items(): array

--- a/src/Token/Tokens.php
+++ b/src/Token/Tokens.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Token;
+
+/**
+ * Collection of external service tokens
+ */
+final readonly class Tokens
+{
+    /** @param list<Token> $items */
+    public function __construct(private array $items) {}
+
+    /** @return list<Token> */
+    public function items(): array
+    {
+        return $this->items;
+    }
+}

--- a/src/Token/Tokens.php
+++ b/src/Token/Tokens.php
@@ -10,9 +10,7 @@ namespace Haspadar\Piqule\Token;
 final readonly class Tokens
 {
     /** @param list<Token> $items */
-    public function __construct(private array $items)
-    {
-    }
+    public function __construct(private array $items) {}
 
     /** @return list<Token> */
     public function items(): array

--- a/tests/Unit/Token/CodecovTokenTest.php
+++ b/tests/Unit/Token/CodecovTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Token;
+
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use Haspadar\Piqule\Token\CodecovToken;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CodecovTokenTest extends TestCase
+{
+    #[Test]
+    public function enabledWhenPhpUnitEnabled(): void
+    {
+        self::assertSame(
+            true,
+            (new CodecovToken())->enabled(new FakeConfig(['phpunit.enabled' => [true]])),
+            'CodecovToken must be enabled when phpunit.enabled is true',
+        );
+    }
+
+    #[Test]
+    public function enabledWhenKeyAbsent(): void
+    {
+        self::assertSame(
+            true,
+            (new CodecovToken())->enabled(new FakeConfig([])),
+            'CodecovToken must be enabled when phpunit.enabled key is absent',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenPhpUnitDisabled(): void
+    {
+        self::assertSame(
+            false,
+            (new CodecovToken())->enabled(new FakeConfig(['phpunit.enabled' => [false]])),
+            'CodecovToken must be disabled when phpunit.enabled is false',
+        );
+    }
+
+    #[Test]
+    public function returnsCorrectSecret(): void
+    {
+        self::assertSame(
+            'CODECOV_TOKEN',
+            (new CodecovToken())->secret(),
+            'CodecovToken secret must be CODECOV_TOKEN',
+        );
+    }
+
+    #[Test]
+    public function returnsUrlWithOrg(): void
+    {
+        self::assertSame(
+            'https://app.codecov.io/account/gh/acme/repositories',
+            (new CodecovToken())->url('acme'),
+            'CodecovToken url must include the org name',
+        );
+    }
+}

--- a/tests/Unit/Token/InfectionTokenTest.php
+++ b/tests/Unit/Token/InfectionTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Token;
+
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use Haspadar\Piqule\Token\InfectionToken;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class InfectionTokenTest extends TestCase
+{
+    #[Test]
+    public function enabledWhenInfectionEnabled(): void
+    {
+        self::assertSame(
+            true,
+            (new InfectionToken())->enabled(new FakeConfig(['infection.enabled' => [true]])),
+            'InfectionToken must be enabled when infection.enabled is true',
+        );
+    }
+
+    #[Test]
+    public function enabledWhenKeyAbsent(): void
+    {
+        self::assertSame(
+            true,
+            (new InfectionToken())->enabled(new FakeConfig([])),
+            'InfectionToken must be enabled when infection.enabled key is absent',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenInfectionDisabled(): void
+    {
+        self::assertSame(
+            false,
+            (new InfectionToken())->enabled(new FakeConfig(['infection.enabled' => [false]])),
+            'InfectionToken must be disabled when infection.enabled is false',
+        );
+    }
+
+    #[Test]
+    public function returnsCorrectSecret(): void
+    {
+        self::assertSame(
+            'STRYKER_DASHBOARD_API_KEY',
+            (new InfectionToken())->secret(),
+            'InfectionToken secret must be STRYKER_DASHBOARD_API_KEY',
+        );
+    }
+
+    #[Test]
+    public function returnsUrlIgnoringOrg(): void
+    {
+        self::assertSame(
+            'https://dashboard.stryker-mutator.io',
+            (new InfectionToken())->url('acme'),
+            'InfectionToken url must be the Stryker dashboard url',
+        );
+    }
+}

--- a/tests/Unit/Token/TokensTest.php
+++ b/tests/Unit/Token/TokensTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Token;
+
+use Haspadar\Piqule\Token\CodecovToken;
+use Haspadar\Piqule\Token\InfectionToken;
+use Haspadar\Piqule\Token\Tokens;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TokensTest extends TestCase
+{
+    #[Test]
+    public function returnsAllItems(): void
+    {
+        $codecov = new CodecovToken();
+        $infection = new InfectionToken();
+
+        self::assertSame(
+            [$codecov, $infection],
+            (new Tokens([$codecov, $infection]))->items(),
+            'Tokens must return all items in order',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenNoItems(): void
+    {
+        self::assertSame(
+            [],
+            (new Tokens([]))->items(),
+            'Tokens must return empty list when constructed with no items',
+        );
+    }
+}


### PR DESCRIPTION
- Added `Token` interface and `CodecovToken`, `InfectionToken` implementations representing required GitHub Secrets
- Added `Tokens` collection to iterate over enabled service tokens
- Added unit tests covering token enablement and secret names
- Added `bin/piqule-tokens-check` script that checks missing secrets via `gh` CLI
- Updated `bin/piqule` to run tokens check after `sync`, `check`, and `fix`

Closes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated token validation that checks GitHub Actions secrets for Codecov and Stryker (Infection) integrations.
  * Token checks now run as part of sync, check, and fix command flows.
  * Prints actionable guidance and direct secret-creation links when required secrets are missing or credentials are absent.
* **Tests**
  * Added unit tests covering token behavior, availability checks, and URL/secret values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->