### PR TITLE
Wire kubawerlos/php-cs-fixer-custom-fixers into php-cs-fixer config

### DIFF
--- a/templates/always/.piqule/php-cs-fixer/kubawerlos-code.php
+++ b/templates/always/.piqule/php-cs-fixer/kubawerlos-code.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// kubawerlos/php-cs-fixer-custom-fixers: code quality rules
+return [
+    PhpCsFixerCustomFixers\Fixer\ClassConstantUsageFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\CommentSurroundedBySpacesFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\ForeachUseValueFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\FunctionParameterSeparationFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\IssetToArrayKeyExistsFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoPhpStormGeneratedCommentFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoReferenceInFunctionDefinitionFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoSuperfluousConcatenationFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessDirnameCallFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessParenthesisFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessStrlenFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\SingleSpaceBeforeStatementFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\TrimKeyFixer::name() => true,
+];

--- a/templates/always/.piqule/php-cs-fixer/kubawerlos-phpdoc.php
+++ b/templates/always/.piqule/php-cs-fixer/kubawerlos-phpdoc.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+// kubawerlos/php-cs-fixer-custom-fixers: PHPDoc rules
+return [
+    PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocParamTypeFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocPropertySortedFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocSelfAccessorFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocTypeListFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocTypesCommaSpacesFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocTypesTrimFixer::name() => true,
+];

--- a/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -15,9 +15,16 @@ declare(strict_types=1);
  * configuration belong to the consuming project.
  */
 
+$customFixers = new PhpCsFixerCustomFixers\Fixers();
+
 return (new PhpCsFixer\Config())
+    ->registerCustomFixers($customFixers)
     ->setRiskyAllowed(true)
-    ->setRules([
+    ->setRules(array_merge(
+        require __DIR__ . '/kubawerlos-code.php',
+        require __DIR__ . '/kubawerlos-phpdoc.php',
+    [
+
         '@PER-CS2.0' => true,
         '@PHP8x3Migration' => true,
         '@PHP8x4Migration' => true,
@@ -44,13 +51,13 @@ return (new PhpCsFixer\Config())
 
         // Strict types
         'declare_strict_types' => true,
+        'declare_equal_normalize' => ['space' => 'single'],
 
         // Final & visibility
         'final_class' => true,
         'final_internal_class' => true,
 
         // Types
-        'fully_qualified_strict_types' => true,
         'native_type_declaration_casing' => true,
 
         // Formatting
@@ -59,6 +66,7 @@ return (new PhpCsFixer\Config())
             'elements' => ['method' => 'one', 'property' => 'one'],
         ],
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'no_blank_lines_after_class_opening' => true,
         'no_extra_blank_lines' => ['tokens' => ['extra', 'throw', 'use']],
         'no_trailing_comma_in_singleline' => true,
         'no_whitespace_in_blank_line' => true,
@@ -69,7 +77,6 @@ return (new PhpCsFixer\Config())
         'phpdoc_no_empty_return' => true,
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
-        'phpdoc_separation' => true,
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
@@ -97,5 +104,5 @@ return (new PhpCsFixer\Config())
         'full_opening_tag' => true,
         'single_quote' => true,
         'ternary_operator_spaces' => true,
-    ])
+    ]))
     ->setUnsupportedPhpVersionAllowed(<< config(php_cs_fixer.allow_unsupported)|join("") >>);


### PR DESCRIPTION
- Registered kubawerlos custom fixers in php-cs-fixer config
- Extracted kubawerlos rules into separate include files by category (code, phpdoc)
- Removed `phpdoc_separation` rule to resolve conflict with Slevomat `DocCommentSpacing`
- Added `declare_equal_normalize` and `no_blank_lines_after_class_opening` rules

Part of #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened PHP code quality standards and formatting rules by introducing custom fixers for code structure validation, PHPDoc documentation formatting, and improved code consistency across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->