### PR TITLE
Fix phpcs and php-cs-fixer violations across src/

### DIFF
--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -15,9 +15,16 @@ declare(strict_types=1);
  * configuration belong to the consuming project.
  */
 
+$customFixers = new PhpCsFixerCustomFixers\Fixers();
+
 return (new PhpCsFixer\Config())
+    ->registerCustomFixers($customFixers)
     ->setRiskyAllowed(true)
-    ->setRules([
+    ->setRules(array_merge(
+        require __DIR__ . '/kubawerlos-code.php',
+        require __DIR__ . '/kubawerlos-phpdoc.php',
+    [
+
         '@PER-CS2.0' => true,
         '@PHP8x3Migration' => true,
         '@PHP8x4Migration' => true,
@@ -44,13 +51,13 @@ return (new PhpCsFixer\Config())
 
         // Strict types
         'declare_strict_types' => true,
+        'declare_equal_normalize' => ['space' => 'single'],
 
         // Final & visibility
         'final_class' => true,
         'final_internal_class' => true,
 
         // Types
-        'fully_qualified_strict_types' => true,
         'native_type_declaration_casing' => true,
 
         // Formatting
@@ -59,6 +66,7 @@ return (new PhpCsFixer\Config())
             'elements' => ['method' => 'one', 'property' => 'one'],
         ],
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'no_blank_lines_after_class_opening' => true,
         'no_extra_blank_lines' => ['tokens' => ['extra', 'throw', 'use']],
         'no_trailing_comma_in_singleline' => true,
         'no_whitespace_in_blank_line' => true,
@@ -69,7 +77,6 @@ return (new PhpCsFixer\Config())
         'phpdoc_no_empty_return' => true,
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
-        'phpdoc_separation' => true,
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
@@ -97,5 +104,5 @@ return (new PhpCsFixer\Config())
         'full_opening_tag' => true,
         'single_quote' => true,
         'ternary_operator_spaces' => true,
-    ])
+    ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/.piqule/phpcs/phpcs.xml
+++ b/.piqule/phpcs/phpcs.xml
@@ -14,23 +14,11 @@
 
     <rule ref="Generic.PHP.Syntax"/>
 
-    <!-- Slevomat: class structure -->
-    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
-        <properties>
-            <property name="rootNamespaces" type="array">
-                <element key="src" value="Haspadar\Piqule"/>
-            </property>
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature">
-        <properties>
-            <property name="minParametersCount" value="2"/>
-        </properties>
-    </rule>
-
-    <!-- Slevomat: doc comments -->
-    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
-    <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
-
+    <rule ref=".piqule/phpcs/slevomat-types.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-classes.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-functions.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-namespaces.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-flow.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-style.xml"/>
 
 </ruleset>

--- a/.piqule/phpcs/slevomat-classes.xml
+++ b/.piqule/phpcs/slevomat-classes.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: classes">
+
+    <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassKeywordOrder"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassLength"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
+        <properties>
+            <property name="groups" type="array">
+                <element value="uses"/>
+                <element value="enum cases"/>
+                <element value="constants"/>
+                <element value="properties"/>
+                <element value="constructor"/>
+                <element value="static constructors"/>
+                <element value="destructor"/>
+                <element value="magic methods"/>
+                <element value="invoke method"/>
+                <element value="methods"/>
+            </property>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch"/>
+    <rule ref="SlevomatCodingStandard.Classes.EnumCaseSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ForbiddenPublicProperty"/>
+    <rule ref="SlevomatCodingStandard.Classes.MethodSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+    <rule ref="SlevomatCodingStandard.Classes.ParentCallSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.PropertySpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireAbstractOrFinal"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature">
+        <properties>
+            <property name="minLineLength" value="101"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.RequireSelfReference"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireSingleLineMethodSignature">
+        <properties>
+            <property name="maxLineLength" value="100"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousErrorNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseOrder"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
+
+    <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
+    <rule ref="SlevomatCodingStandard.Attributes.AttributesOrder">
+        <properties>
+            <property name="orderAlphabetically" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowAttributesJoining"/>
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment"/>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-flow.xml
+++ b/.piqule/phpcs/slevomat-flow.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: control flow">
+
+    <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>
+
+    <rule ref="SlevomatCodingStandard.Exceptions.CatchExceptionsOrder"/>
+    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
+
+    <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.DisallowVariableVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-functions.xml
+++ b/.piqule/phpcs/slevomat-functions.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: functions">
+
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
+        <properties>
+            <property name="spacesCountAfterKeyword" value="0"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction"/>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowNamedArguments"/>
+    <rule ref="SlevomatCodingStandard.Functions.NamedArgumentSpacing"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireMultiLineCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
+    <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
+    <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
+
+    <rule ref="SlevomatCodingStandard.Arrays.ArrayAccess"/>
+    <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+    <rule ref="SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed"/>
+    <rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>
+    <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+    <rule ref="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators"/>
+    <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
+    <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+    <rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>
+    <rule ref="SlevomatCodingStandard.Operators.SpreadOperatorSpacing"/>
+
+    <rule ref="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator"/>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-namespaces.xml
+++ b/.piqule/phpcs/slevomat-namespaces.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: namespaces">
+
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing">
+        <properties>
+            <property name="linesCountBetweenUseTypes" value="1"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-style.xml
+++ b/.piqule/phpcs/slevomat-style.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: style">
+
+    <rule ref="SlevomatCodingStandard.Commenting.AnnotationName"/>
+    <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
+    <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing"/>
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations"/>
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments"/>
+    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
+
+    <rule ref="SlevomatCodingStandard.PHP.DisallowDirectMagicInvokeCall"/>
+    <rule ref="SlevomatCodingStandard.PHP.DisallowReference"/>
+    <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
+    <rule ref="SlevomatCodingStandard.PHP.ReferenceSpacing"/>
+    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
+    <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc"/>
+    <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
+    <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+
+    <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
+    <rule ref="SlevomatCodingStandard.Strings.DisallowVariableParsing"/>
+
+    <rule ref="SlevomatCodingStandard.Files.FileLength"/>
+    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+        <properties>
+            <property name="rootNamespaces" type="array">
+                <element key="src" value="Haspadar\Piqule"/>
+            </property>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-style.xml
+++ b/.piqule/phpcs/slevomat-style.xml
@@ -4,7 +4,7 @@
     <rule ref="SlevomatCodingStandard.Commenting.AnnotationName"/>
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
     <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
-    <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing"/>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations"/>

--- a/.piqule/phpcs/slevomat-types.xml
+++ b/.piqule/phpcs/slevomat-types.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: types">
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
+
+</ruleset>

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config;
 
@@ -22,6 +22,8 @@ final readonly class ComposerRootNamespace
         $data = json_decode($contents === false ? '{}' : $contents, true) ?? [];
         $psr4 = $data['autoload']['psr-4'] ?? [];
 
-        return $psr4 !== [] ? rtrim(array_key_first($psr4), '\\') : '';
+        return $psr4 !== []
+            ? rtrim(array_key_first($psr4), '\\')
+            : '';
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -1,8 +1,10 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config;
+
+use Haspadar\Piqule\PiquleException;
 
 /**
  * Read-only access to flat dot-notated configuration keys
@@ -19,8 +21,7 @@ interface Config
      *
      * Missing paths and explicitly empty lists are both represented as an empty list
      *
-     * @throws \Haspadar\Piqule\PiquleException
-     *
+     * @throws PiquleException
      * @return list<scalar>
      */
     public function list(string $name): array;

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config;
 
@@ -32,7 +32,9 @@ use Override;
  */
 final class DefaultConfig implements Config
 {
-    /** @var array<string, scalar|list<scalar>> */
+    /**
+     * @var array<string, scalar|list<scalar>>
+     */
     private readonly array $defaults;
 
     /**
@@ -72,7 +74,7 @@ final class DefaultConfig implements Config
         /** @var array<string, scalar|list<scalar>> $defaults */
         $defaults = array_merge(
             ['dirs.include' => $include, 'dirs.exclude' => $exclude, 'php.version' => $phpVersion],
-            ...array_map(fn($s) => $s->toArray(), $sections),
+            ...array_map(static fn($s) => $s->toArray(), $sections),
         );
         $this->defaults = $defaults;
     }
@@ -100,6 +102,8 @@ final class DefaultConfig implements Config
 
         $value = $this->defaults[$name];
 
-        return is_scalar($value) ? [$value] : $value;
+        return is_scalar($value)
+            ? [$value]
+            : $value;
     }
 }

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -32,9 +32,7 @@ use Override;
  */
 final class DefaultConfig implements Config
 {
-    /**
-     * @var array<string, scalar|list<scalar>>
-     */
+    /** @var array<string, scalar|list<scalar>> */
     private readonly array $defaults;
 
     /**

--- a/src/Config/Dirs/Dirs.php
+++ b/src/Config/Dirs/Dirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 

--- a/src/Config/Dirs/GlobDirs.php
+++ b/src/Config/Dirs/GlobDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 
@@ -18,6 +18,6 @@ final readonly class GlobDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(fn(string $dir): string => $dir . '/*', $this->dirs);
+        return array_map(static fn(string $dir): string => $dir . '/*', $this->dirs);
     }
 }

--- a/src/Config/Dirs/NegatedGlobDirs.php
+++ b/src/Config/Dirs/NegatedGlobDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 
@@ -18,6 +18,6 @@ final readonly class NegatedGlobDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(fn(string $dir): string => '!' . $dir . '/**', $this->dirs);
+        return array_map(static fn(string $dir): string => '!' . $dir . '/**', $this->dirs);
     }
 }

--- a/src/Config/Dirs/ProjectDirs.php
+++ b/src/Config/Dirs/ProjectDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 
@@ -18,6 +18,6 @@ final readonly class ProjectDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(fn(string $dir): string => '../../' . $dir, $this->dirs);
+        return array_map(static fn(string $dir): string => '../../' . $dir, $this->dirs);
     }
 }

--- a/src/Config/Dirs/TrailingGlobDirs.php
+++ b/src/Config/Dirs/TrailingGlobDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 
@@ -18,6 +18,6 @@ final readonly class TrailingGlobDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(fn(string $dir): string => $dir . '/**', $this->dirs);
+        return array_map(static fn(string $dir): string => $dir . '/**', $this->dirs);
     }
 }

--- a/src/Config/Dirs/TrailingSlashDirs.php
+++ b/src/Config/Dirs/TrailingSlashDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 
@@ -18,6 +18,6 @@ final readonly class TrailingSlashDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(fn(string $dir): string => $dir . '/', $this->dirs);
+        return array_map(static fn(string $dir): string => $dir . '/', $this->dirs);
     }
 }

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config;
 
@@ -117,10 +117,7 @@ use Override;
 final readonly class OverrideConfig implements Config
 {
     /** @param OverrideMap $overrides */
-    public function __construct(
-        private Config $defaults,
-        private array $overrides,
-    ) {}
+    public function __construct(private Config $defaults, private array $overrides) {}
 
     #[Override]
     public function has(string $name): bool
@@ -146,14 +143,12 @@ final readonly class OverrideConfig implements Config
     }
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      * @throws PiquleException
-     *
      * @return list<scalar>
      */
-    private function normalizedValue(
-        mixed $value,
-        string $name,
-    ): array {
+    private function normalizedValue(mixed $value, string $name): array
+    {
         if (is_scalar($value)) {
             return [$value];
         }
@@ -172,7 +167,6 @@ final readonly class OverrideConfig implements Config
             }
         }
 
-        /** @var list<scalar> $value */
-        return $value;
+        return array_values(array_filter($value, static fn($item) => is_scalar($item)));
     }
 }

--- a/src/Config/Section/ActionlintSection.php
+++ b/src/Config/Section/ActionlintSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/CiSection.php
+++ b/src/Config/Section/CiSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 
@@ -15,10 +15,7 @@ final readonly class CiSection implements ConfigSection
      * @param list<string> $phpMatrix
      * @param list<string> $phpTestVersion
      */
-    public function __construct(
-        private array $phpMatrix,
-        private array $phpTestVersion,
-    ) {}
+    public function __construct(private array $phpMatrix, private array $phpTestVersion) {}
 
     #[Override]
     public function toArray(): array

--- a/src/Config/Section/ConfigSection.php
+++ b/src/Config/Section/ConfigSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/CoverageSection.php
+++ b/src/Config/Section/CoverageSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/DockerSection.php
+++ b/src/Config/Section/DockerSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/HadolintSection.php
+++ b/src/Config/Section/HadolintSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/InfectionSection.php
+++ b/src/Config/Section/InfectionSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/JsonlintSection.php
+++ b/src/Config/Section/JsonlintSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/MarkdownlintSection.php
+++ b/src/Config/Section/MarkdownlintSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/PhpCsFixerSection.php
+++ b/src/Config/Section/PhpCsFixerSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/PhpCsSection.php
+++ b/src/Config/Section/PhpCsSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/PhpMdSection.php
+++ b/src/Config/Section/PhpMdSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/PhpMetricsSection.php
+++ b/src/Config/Section/PhpMetricsSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 
@@ -15,10 +15,7 @@ final readonly class PhpMetricsSection implements ConfigSection
      * @param list<string> $includes
      * @param list<string> $excludes
      */
-    public function __construct(
-        private array $includes,
-        private array $excludes,
-    ) {}
+    public function __construct(private array $includes, private array $excludes) {}
 
     #[Override]
     public function toArray(): array
@@ -32,13 +29,13 @@ final readonly class PhpMetricsSection implements ConfigSection
             'phpmetrics.extensions' => ['php'],
             'phpmetrics.halstead.max_bugs_per_method' => [0.5],
             'phpmetrics.halstead.max_difficulty_per_method' => [15],
-            'phpmetrics.halstead.max_effort_per_method' => [15000],
-            'phpmetrics.halstead.max_volume_per_method' => [1000],
+            'phpmetrics.halstead.max_effort_per_method' => [15_000],
+            'phpmetrics.halstead.max_volume_per_method' => [1_000],
             'phpmetrics.includes' => $this->includes,
             'phpmetrics.inheritance.max_depth' => [3],
             'phpmetrics.report.html' => ['html'],
             'phpmetrics.report.json' => ['phpmetrics.json'],
-            'phpmetrics.size.max_loc_per_class' => [1000],
+            'phpmetrics.size.max_loc_per_class' => [1_000],
             'phpmetrics.size.max_logical_loc_per_class' => [600],
             'phpmetrics.size.max_logical_loc_per_method' => [20],
             'phpmetrics.structure.max_methods_per_class' => [10],

--- a/src/Config/Section/PhpStanSection.php
+++ b/src/Config/Section/PhpStanSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/PhpUnitSection.php
+++ b/src/Config/Section/PhpUnitSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/PsalmSection.php
+++ b/src/Config/Section/PsalmSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 
@@ -16,10 +16,7 @@ final readonly class PsalmSection implements ConfigSection
      * @param list<string> $includes
      * @param list<string> $excludes
      */
-    public function __construct(
-        private array $includes,
-        private array $excludes,
-    ) {}
+    public function __construct(private array $includes, private array $excludes) {}
 
     #[Override]
     public function toArray(): array

--- a/src/Config/Section/ShellcheckSection.php
+++ b/src/Config/Section/ShellcheckSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/SonarSection.php
+++ b/src/Config/Section/SonarSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/TyposSection.php
+++ b/src/Config/Section/TyposSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/Config/Section/YamllintSection.php
+++ b/src/Config/Section/YamllintSection.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Config\Section;
 

--- a/src/File/ConfiguredFile.php
+++ b/src/File/ConfiguredFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\File;
 
@@ -22,10 +22,7 @@ use Throwable;
  */
 final readonly class ConfiguredFile implements File
 {
-    public function __construct(
-        private File $origin,
-        private Config $config,
-    ) {}
+    public function __construct(private File $origin, private Config $config) {}
 
     #[Override]
     public function name(): string
@@ -68,7 +65,8 @@ final readonly class ConfiguredFile implements File
                     trim($expression),
                     $e->getMessage(),
                 ),
-                previous: $e,
+                0,
+                $e,
             );
         }
     }
@@ -78,9 +76,9 @@ final readonly class ConfiguredFile implements File
     {
         return [
             'config' => fn(string $raw): Action => new ConfigAction($this->config, $raw),
-            'format' => fn(string $raw): Action => new FormatAction($raw),
-            'format_each' => fn(string $raw): Action => new FormatEachAction($raw),
-            'join' => fn(string $raw): Action => new JoinAction($raw),
+            'format' => static fn(string $raw): Action => new FormatAction($raw),
+            'format_each' => static fn(string $raw): Action => new FormatEachAction($raw),
+            'join' => static fn(string $raw): Action => new JoinAction($raw),
         ];
     }
 }

--- a/src/File/File.php
+++ b/src/File/File.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/File/PrefixedFile.php
+++ b/src/File/PrefixedFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\File;
 
@@ -11,21 +11,18 @@ use Override;
  */
 final readonly class PrefixedFile implements File
 {
-    public function __construct(
-        private string $prefix,
-        private File $origin,
-    ) {}
+    public function __construct(private string $prefix, private File $origin) {}
 
-    #[Override]
     /**
      * Builds the target file path by prefixing the original name
      *
      * Examples:
      * - prefix ".git" + name "hooks/pre-push" → ".git/hooks/pre-push"
-     * - prefix ""     + name "config/app.yaml" → "config/app.yaml"
+     * - prefix "" + name "config/app.yaml" → "config/app.yaml"
      *
      * Leading and trailing slashes are normalized
      */
+    #[Override]
     public function name(): string
     {
         $prefix = rtrim($this->prefix, '/');

--- a/src/File/ReplacedFile.php
+++ b/src/File/ReplacedFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/File/TextFile.php
+++ b/src/File/TextFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/Files/CombinedFiles.php
+++ b/src/Files/CombinedFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Files;
 
@@ -12,9 +12,7 @@ use Override;
 final readonly class CombinedFiles implements Files
 {
     /** @param list<Files> $sources */
-    public function __construct(
-        private array $sources,
-    ) {}
+    public function __construct(private array $sources) {}
 
     #[Override]
     public function all(): iterable

--- a/src/Files/EachFile.php
+++ b/src/Files/EachFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Files;
 
@@ -18,10 +18,7 @@ final readonly class EachFile implements Runnable
      * @param Files $files File collection to iterate
      * @param Closure(File): void $action
      */
-    public function __construct(
-        private Files $files,
-        private Closure $action,
-    ) {}
+    public function __construct(private Files $files, private Closure $action) {}
 
     /**
      * Executes the action for every file in the collection

--- a/src/Files/Files.php
+++ b/src/Files/Files.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Files/FilteredFiles.php
+++ b/src/Files/FilteredFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Files;
 
@@ -14,10 +14,7 @@ use Override;
 final readonly class FilteredFiles implements Files
 {
     /** @param Closure(File): bool $predicate */
-    public function __construct(
-        private Files $origin,
-        private Closure $predicate,
-    ) {}
+    public function __construct(private Files $origin, private Closure $predicate) {}
 
     #[Override]
     public function all(): iterable

--- a/src/Files/FolderFiles.php
+++ b/src/Files/FolderFiles.php
@@ -1,10 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Files;
 
 use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Storage\Storage;
 use Override;
 
@@ -17,14 +18,10 @@ final readonly class FolderFiles implements Files
      * @param Storage $storage Source storage to read files from
      * @param string $folder Folder path relative to storage root
      */
-    public function __construct(
-        private Storage $storage,
-        private string $folder,
-    ) {}
+    public function __construct(private Storage $storage, private string $folder) {}
 
     /**
-     * @throws \Haspadar\Piqule\PiquleException
-     *
+     * @throws PiquleException
      * @return iterable<TextFile>
      */
     #[Override]

--- a/src/Files/MappedFiles.php
+++ b/src/Files/MappedFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Files;
 
@@ -14,10 +14,7 @@ use Override;
 final readonly class MappedFiles implements Files
 {
     /** @param Closure(File): File $map */
-    public function __construct(
-        private Files $origin,
-        private Closure $map,
-    ) {}
+    public function __construct(private Files $origin, private Closure $map) {}
 
     #[Override]
     public function all(): iterable

--- a/src/Files/TextFiles.php
+++ b/src/Files/TextFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Files;
 
@@ -13,9 +13,7 @@ use Override;
 final readonly class TextFiles implements Files
 {
     /** @param array<string, string> $files */
-    public function __construct(
-        private array $files,
-    ) {}
+    public function __construct(private array $files) {}
 
     #[Override]
     public function all(): iterable

--- a/src/Formula/Action/Action.php
+++ b/src/Formula/Action/Action.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/ConfigAction.php
+++ b/src/Formula/Action/ConfigAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Action;
 
@@ -8,6 +8,7 @@ use Haspadar\Piqule\Config\Config;
 use Haspadar\Piqule\Formula\Args\Args;
 use Haspadar\Piqule\Formula\Args\ListArgs;
 use Haspadar\Piqule\Formula\Args\StringifiedArgs;
+use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
@@ -15,17 +16,14 @@ use Override;
  */
 final readonly class ConfigAction implements Action
 {
-    public function __construct(
-        private Config $config,
-        private string $key,
-    ) {}
+    public function __construct(private Config $config, private string $key) {}
 
     /**
      * Returns configuration values for the given key
      *
      * Input arguments are ignored because this action acts as a value source
      *
-     * @throws \Haspadar\Piqule\PiquleException
+     * @throws PiquleException
      */
     #[Override]
     public function transformed(Args $args): Args

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Action;
 
@@ -17,9 +17,7 @@ use Throwable;
  */
 final readonly class FormatAction implements Action
 {
-    public function __construct(
-        private string $raw,
-    ) {}
+    public function __construct(private string $raw) {}
 
     /** @throws PiquleException */
     #[Override]
@@ -50,7 +48,8 @@ final readonly class FormatAction implements Action
         } catch (Throwable $e) {
             throw new PiquleException(
                 sprintf('format() failed: %s', $e->getMessage()),
-                previous: $e,
+                0,
+                $e,
             );
         }
 

--- a/src/Formula/Action/FormatEachAction.php
+++ b/src/Formula/Action/FormatEachAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Action;
 
@@ -15,9 +15,7 @@ use Override;
  */
 final readonly class FormatEachAction implements Action
 {
-    public function __construct(
-        private string $raw,
-    ) {}
+    public function __construct(private string $raw) {}
 
     #[Override]
     public function transformed(Args $args): Args

--- a/src/Formula/Action/JoinAction.php
+++ b/src/Formula/Action/JoinAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Action;
 
@@ -14,9 +14,7 @@ use Override;
  */
 final readonly class JoinAction implements Action
 {
-    public function __construct(
-        private string $raw,
-    ) {}
+    public function __construct(private string $raw) {}
 
     #[Override]
     public function transformed(Args $args): Args

--- a/src/Formula/Actions/Actions.php
+++ b/src/Formula/Actions/Actions.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Actions;
 

--- a/src/Formula/Actions/ParsedActions.php
+++ b/src/Formula/Actions/ParsedActions.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Actions;
 
@@ -14,10 +14,7 @@ use Override;
 final readonly class ParsedActions implements Actions
 {
     /** @param array<string, callable(string): Action> $actions */
-    public function __construct(
-        private string $expression,
-        private array  $actions,
-    ) {}
+    public function __construct(private string $expression, private array $actions) {}
 
     /**
      * Parses DSL expression into a sequence of actions
@@ -26,7 +23,6 @@ final readonly class ParsedActions implements Actions
      * in action arguments. Arguments are treated as flat strings.
      *
      * @throws PiquleException
-     *
      * @return list<Action>
      */
     #[Override]
@@ -42,7 +38,7 @@ final readonly class ParsedActions implements Actions
         return array_map(function (array $m): Action {
             $name = $m[1];
 
-            if (!isset($this->actions[$name])) {
+            if (!array_key_exists($name, $this->actions)) {
                 throw new PiquleException(
                     sprintf('Unknown formula action "%s"', $name),
                 );

--- a/src/Formula/Args/Args.php
+++ b/src/Formula/Args/Args.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Args;
 

--- a/src/Formula/Args/ListArgs.php
+++ b/src/Formula/Args/ListArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Args;
 
@@ -12,9 +12,7 @@ use Override;
 final readonly class ListArgs implements Args
 {
     /** @param list<int|float|string|bool> $values */
-    public function __construct(
-        private array $values,
-    ) {}
+    public function __construct(private array $values) {}
 
     /** @return list<int|float|string|bool> */
     #[Override]

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Args;
 
@@ -13,13 +13,10 @@ use Override;
  */
 final readonly class ParsedArgs implements Args
 {
-    public function __construct(
-        private Args $origin,
-    ) {}
+    public function __construct(private Args $origin) {}
 
     /**
      * @throws InvalidArgumentException
-     *
      * @return list<int|float|string|bool>
      */
     #[Override]
@@ -29,8 +26,7 @@ final readonly class ParsedArgs implements Args
         $decoded = $this->decodeJsonList($raw);
         $this->assertScalarList($decoded, $raw);
 
-        /** @var list<int|float|string|bool> $decoded */
-        return $decoded;
+        return array_values(array_filter($decoded, static fn($item) => is_scalar($item)));
     }
 
     /** @throws InvalidArgumentException */
@@ -68,8 +64,8 @@ final readonly class ParsedArgs implements Args
     }
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      * @throws InvalidArgumentException
-     *
      * @return array<array-key, mixed>
      */
     private function decodeJsonList(string $raw): array
@@ -97,14 +93,12 @@ final readonly class ParsedArgs implements Args
     }
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      * @param array<array-key, mixed> $decoded
-     *
      * @throws InvalidArgumentException
      */
-    private function assertScalarList(
-        array $decoded,
-        string $raw,
-    ): void {
+    private function assertScalarList(array $decoded, string $raw): void
+    {
         if (!array_is_list($decoded)) {
             throw new InvalidArgumentException(
                 sprintf('Expected JSON list literal, got "%s"', $raw),

--- a/src/Formula/Args/StringifiedArgs.php
+++ b/src/Formula/Args/StringifiedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Args;
 
@@ -11,17 +11,14 @@ use Override;
  */
 final readonly class StringifiedArgs implements Args
 {
-    public function __construct(
-        private Args $origin,
-    ) {}
+    public function __construct(private Args $origin) {}
 
     /** @return list<string> */
     #[Override]
     public function values(): array
     {
         return array_map(
-            fn(int|float|string|bool $value): string =>
-            $this->stringify($value),
+            fn(int|float|string|bool $value): string => $this->stringify($value),
             $this->origin->values(),
         );
     }

--- a/src/Formula/Args/TrimmedArgs.php
+++ b/src/Formula/Args/TrimmedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Args;
 
@@ -11,9 +11,7 @@ use Override;
  */
 final readonly class TrimmedArgs implements Args
 {
-    public function __construct(
-        private Args $origin,
-    ) {}
+    public function __construct(private Args $origin) {}
 
     /** @return list<int|float|string|bool> */
     #[Override]

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula\Args;
 
@@ -13,17 +13,14 @@ use Override;
  */
 final readonly class UnquotedArgs implements Args
 {
-    public function __construct(
-        private Args $origin,
-    ) {}
+    public function __construct(private Args $origin) {}
 
     /** @return list<int|float|string|bool> */
     #[Override]
     public function values(): array
     {
         return array_map(
-            fn(int|float|string|bool $value) =>
-            is_string($value)
+            fn(int|float|string|bool $value) => is_string($value)
                 ? $this->unquote($value)
                 : $value,
             $this->origin->values(),

--- a/src/Formula/ExecutedFormula.php
+++ b/src/Formula/ExecutedFormula.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula;
 
@@ -14,9 +14,7 @@ use Override;
  */
 final readonly class ExecutedFormula implements Formula
 {
-    public function __construct(
-        private Actions $actions,
-    ) {}
+    public function __construct(private Actions $actions) {}
 
     /** @throws PiquleException */
     #[Override]

--- a/src/Formula/Formula.php
+++ b/src/Formula/Formula.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula;
 

--- a/src/Formula/NormalizedFormula.php
+++ b/src/Formula/NormalizedFormula.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Formula;
 
@@ -11,9 +11,7 @@ use Override;
  */
 final readonly class NormalizedFormula implements Formula
 {
-    public function __construct(
-        private string $expression,
-    ) {}
+    public function __construct(private string $expression) {}
 
     #[Override]
     public function result(): string

--- a/src/Output/Console.php
+++ b/src/Output/Console.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Output;
 

--- a/src/Output/Message.php
+++ b/src/Output/Message.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Output;
 

--- a/src/Output/Output.php
+++ b/src/Output/Output.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Output;
 

--- a/src/PiquleException.php
+++ b/src/PiquleException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule;
 

--- a/src/Runnable.php
+++ b/src/Runnable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule;
 

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -1,11 +1,12 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage;
 
 use Haspadar\Piqule\File\File;
 use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Storage\Reaction\StorageReaction;
 use Override;
 
@@ -26,7 +27,7 @@ final readonly class AppendingStorage implements Storage
      * - Appends contents to an existing file and emits updated() if the marker is absent.
      * - No-ops if the marker is already present in the existing file.
      *
-     * @throws \Haspadar\Piqule\PiquleException
+     * @throws PiquleException
      */
     #[Override]
     public function write(File $file): self

--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -1,10 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage;
 
 use Haspadar\Piqule\File\File;
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Storage\Reaction\StorageReaction;
 use Override;
 
@@ -13,12 +14,9 @@ use Override;
  */
 final readonly class DiffingStorage implements Storage
 {
-    public function __construct(
-        private Storage $origin,
-        private StorageReaction $reaction,
-    ) {}
+    public function __construct(private Storage $origin, private StorageReaction $reaction) {}
 
-    /** @throws \Haspadar\Piqule\PiquleException */
+    /** @throws PiquleException */
     #[Override]
     public function write(File $file): self
     {

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage;
 
@@ -11,14 +11,14 @@ use Override;
 use SplFileInfo;
 use UnexpectedValueException;
 
+use function assert;
+
 /**
  * Filesystem-backed storage rooted at a given directory
  */
 final readonly class DiskStorage implements Storage
 {
-    public function __construct(
-        private string $root,
-    ) {}
+    public function __construct(private string $root) {}
 
     /**
      * Reads and returns the file contents at the given location
@@ -48,7 +48,6 @@ final readonly class DiskStorage implements Storage
      *
      * @throws PiquleException
      * @throws UnexpectedValueException
-     *
      * @return iterable<string>
      */
     #[Override]
@@ -66,7 +65,8 @@ final readonly class DiskStorage implements Storage
         );
 
         foreach ($iterator as $item) {
-            /** @var SplFileInfo $item */
+            assert($item instanceof SplFileInfo);
+
             if ($item->isFile()) {
                 yield ltrim(
                     $location . '/' . $item->getFilename(),

--- a/src/Storage/InMemoryStorage.php
+++ b/src/Storage/InMemoryStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage;
 
@@ -13,14 +13,8 @@ use Override;
  */
 final readonly class InMemoryStorage implements Storage
 {
-    /** @var array<string, File> */
-    private array $entries;
-
     /** @param array<string, File> $entries location => File */
-    public function __construct(array $entries = [])
-    {
-        $this->entries = $entries;
-    }
+    public function __construct(private array $entries = []) {}
 
     #[Override]
     public function read(string $location): string
@@ -57,6 +51,7 @@ final readonly class InMemoryStorage implements Storage
         ]);
     }
 
+    /** @return iterable<string> */
     #[Override]
     public function entries(string $location): iterable
     {
@@ -75,6 +70,7 @@ final readonly class InMemoryStorage implements Storage
             }
 
             $rest = substr($key, strlen($prefix));
+
             if ($rest !== '' && !str_contains($rest, '/')) {
                 $entries[] = $key;
             }

--- a/src/Storage/OnceStorage.php
+++ b/src/Storage/OnceStorage.php
@@ -1,10 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage;
 
 use Haspadar\Piqule\File\File;
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Storage\Reaction\StorageReaction;
 use Override;
 
@@ -13,12 +14,9 @@ use Override;
  */
 final readonly class OnceStorage implements Storage
 {
-    public function __construct(
-        private Storage $origin,
-        private StorageReaction $reaction,
-    ) {}
+    public function __construct(private Storage $origin, private StorageReaction $reaction) {}
 
-    /** @throws \Haspadar\Piqule\PiquleException */
+    /** @throws PiquleException */
     #[Override]
     public function write(File $file): self
     {

--- a/src/Storage/Reaction/ReportingStorageReaction.php
+++ b/src/Storage/Reaction/ReportingStorageReaction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage\Reaction;
 
@@ -12,9 +12,7 @@ use Override;
  */
 final readonly class ReportingStorageReaction implements StorageReaction
 {
-    public function __construct(
-        private Output $output,
-    ) {}
+    public function __construct(private Output $output) {}
 
     #[Override]
     public function created(string $path): void

--- a/src/Storage/Reaction/StorageReaction.php
+++ b/src/Storage/Reaction/StorageReaction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage\Reaction;
 

--- a/src/Storage/Reaction/StorageReactions.php
+++ b/src/Storage/Reaction/StorageReactions.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage\Reaction;
 
@@ -12,9 +12,7 @@ use Override;
 final readonly class StorageReactions implements StorageReaction
 {
     /** @param list<StorageReaction> $reactions */
-    public function __construct(
-        private array $reactions,
-    ) {}
+    public function __construct(private array $reactions) {}
 
     #[Override]
     public function created(string $path): void

--- a/src/Storage/SafePath.php
+++ b/src/Storage/SafePath.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage;
 
@@ -11,9 +11,7 @@ use Haspadar\Piqule\PiquleException;
  */
 final readonly class SafePath
 {
-    public function __construct(
-        private string $root,
-    ) {}
+    public function __construct(private string $root) {}
 
     /** @throws PiquleException */
     public function resolve(string $location): string
@@ -29,7 +27,9 @@ final readonly class SafePath
                 if ($parts === []) {
                     throw new PiquleException("Invalid location: $location");
                 }
+
                 array_pop($parts);
+
                 continue;
             }
 

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Token/CodecovToken.php
+++ b/src/Token/CodecovToken.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/src/Token/InfectionToken.php
+++ b/src/Token/InfectionToken.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/src/Token/Token.php
+++ b/src/Token/Token.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/src/Token/Tokens.php
+++ b/src/Token/Tokens.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/templates/always/.piqule/phpcs/slevomat-style.xml
+++ b/templates/always/.piqule/phpcs/slevomat-style.xml
@@ -4,7 +4,7 @@
     <rule ref="SlevomatCodingStandard.Commenting.AnnotationName"/>
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
     <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
-    <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing"/>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations"/>


### PR DESCRIPTION
- Fixed all Slevomat phpcs violations across 77 src/ files
- Added missing `use` imports for PHPDoc-referenced classes
- Replaced FQCN references in PHPDoc with imported names
- Applied `declare(strict_types = 1)` spacing, `static fn`, trailing commas, and other style fixes
- Regenerated .piqule/ configs from updated templates

Closes #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
* Enhanced code standards enforcement by updating PHP-CS-Fixer and PHPCS configurations with expanded ruleset definitions
* Improved code formatting consistency across the project through standardized declaration and parameter formatting
* Reorganized configuration files for better maintainability and clarity of code quality rules

**Refactor**
* Restructured code checkers configuration to use centralized ruleset includes for easier management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->