### PR TITLE
Remove redundant or overly strict phpcs rules

### DIFF
--- a/.piqule/phpcs/slevomat-flow.xml
+++ b/.piqule/phpcs/slevomat-flow.xml
@@ -5,7 +5,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>

--- a/.piqule/phpcs/slevomat-functions.xml
+++ b/.piqule/phpcs/slevomat-functions.xml
@@ -27,7 +27,6 @@
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
 
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
-    <rule ref="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators"/>
     <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
     <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
     <rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>

--- a/.piqule/phpcs/slevomat-style.xml
+++ b/.piqule/phpcs/slevomat-style.xml
@@ -9,7 +9,6 @@
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments"/>
-    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>

--- a/.piqule/phpcs/slevomat-types.xml
+++ b/.piqule/phpcs/slevomat-types.xml
@@ -3,7 +3,6 @@
 
     <rule ref="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat"/>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -143,7 +143,6 @@ final readonly class OverrideConfig implements Config
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      * @throws PiquleException
      * @return list<scalar>
      */

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -64,7 +64,6 @@ final readonly class ParsedArgs implements Args
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      * @throws InvalidArgumentException
      * @return array<array-key, mixed>
      */
@@ -93,7 +92,6 @@ final readonly class ParsedArgs implements Args
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      * @param array<array-key, mixed> $decoded
      * @throws InvalidArgumentException
      */

--- a/templates/always/.piqule/phpcs/slevomat-flow.xml
+++ b/templates/always/.piqule/phpcs/slevomat-flow.xml
@@ -5,7 +5,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>

--- a/templates/always/.piqule/phpcs/slevomat-functions.xml
+++ b/templates/always/.piqule/phpcs/slevomat-functions.xml
@@ -27,7 +27,6 @@
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
 
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
-    <rule ref="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators"/>
     <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
     <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
     <rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>

--- a/templates/always/.piqule/phpcs/slevomat-style.xml
+++ b/templates/always/.piqule/phpcs/slevomat-style.xml
@@ -9,7 +9,6 @@
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments"/>
-    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>

--- a/templates/always/.piqule/phpcs/slevomat-types.xml
+++ b/templates/always/.piqule/phpcs/slevomat-types.xml
@@ -3,7 +3,6 @@
 
     <rule ref="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat"/>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>


### PR DESCRIPTION
- Removed `DisallowMixedTypeHint` — PHPStan level 9 handles `mixed` enforcement
- Removed `DisallowNullSafeObjectOperator` — `?->` operator is now allowed
- Removed `InlineDocCommentDeclaration` — type inference is handled by PHPStan/Psalm
- Removed `DisallowIncrementAndDecrementOperators` — `++`/`--` operators are now allowed
- Removed obsolete `@phpcsSuppress` annotations from src/

Closes #460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP code quality linting configurations by removing various coding standard rules from ruleset definitions across project and template directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->