### PR TITLE
Remove class and file length limits from phpcs

### DIFF
--- a/.piqule/phpcs/slevomat-classes.xml
+++ b/.piqule/phpcs/slevomat-classes.xml
@@ -4,7 +4,6 @@
     <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassKeywordOrder"/>
-    <rule ref="SlevomatCodingStandard.Classes.ClassLength"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
         <properties>

--- a/.piqule/phpcs/slevomat-style.xml
+++ b/.piqule/phpcs/slevomat-style.xml
@@ -28,7 +28,6 @@
     <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
     <rule ref="SlevomatCodingStandard.Strings.DisallowVariableParsing"/>
 
-    <rule ref="SlevomatCodingStandard.Files.FileLength"/>
     <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
         <properties>
             <property name="rootNamespaces" type="array">

--- a/templates/always/.piqule/phpcs/slevomat-classes.xml
+++ b/templates/always/.piqule/phpcs/slevomat-classes.xml
@@ -4,7 +4,6 @@
     <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassKeywordOrder"/>
-    <rule ref="SlevomatCodingStandard.Classes.ClassLength"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
         <properties>

--- a/templates/always/.piqule/phpcs/slevomat-style.xml
+++ b/templates/always/.piqule/phpcs/slevomat-style.xml
@@ -28,7 +28,6 @@
     <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
     <rule ref="SlevomatCodingStandard.Strings.DisallowVariableParsing"/>
 
-    <rule ref="SlevomatCodingStandard.Files.FileLength"/>
     <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
         <properties>
             <property name="rootNamespaces" type="array">


### PR DESCRIPTION
- Removed `ClassLength` rule — class size limits are enforced by PHPStan custom rules
- Removed `FileLength` rule — file size limits are enforced by PHPStan custom rules

Closes #462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP code style validation configuration to remove class and file length checks from the development ruleset across both main and template configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->