### PR TITLE
#466: Require short class names in PHPDoc via use statements

### DIFF
--- a/.piqule/phpcs/slevomat-namespaces.xml
+++ b/.piqule/phpcs/slevomat-namespaces.xml
@@ -6,7 +6,11 @@
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>

--- a/templates/always/.piqule/phpcs/slevomat-namespaces.xml
+++ b/templates/always/.piqule/phpcs/slevomat-namespaces.xml
@@ -6,7 +6,11 @@
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>


### PR DESCRIPTION
- Extended `ReferenceUsedNamesOnly` with `searchAnnotations: true` to enforce short class names in PHPDoc annotations
- Fully qualified class names in `@throws`, `@param`, `@return` and other annotations now trigger a phpcs error

Closes #466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality rule configuration to include annotation scanning when validating namespace references, enhancing code standard compliance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->