### PR TITLE
YAML Configuration Support with Override and Append Sections

### DIFF
--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -3,9 +3,8 @@
 
 declare(strict_types=1);
 
-use Haspadar\Piqule\Config\ComposerRootNamespace;
 use Haspadar\Piqule\Config\DefaultConfig;
-use Haspadar\Piqule\Config\OverrideConfig;
+use Haspadar\Piqule\Config\YamlConfig;
 use Haspadar\Piqule\Config\Config;
 use Haspadar\Piqule\File\ConfiguredFile;
 use Haspadar\Piqule\File\File;
@@ -34,15 +33,13 @@ try {
     $libraryRoot = Composer\InstalledVersions::getInstallPath('haspadar/piqule')
         ?: throw new PiquleException('Cannot determine piqule install path');
 
-    $config = file_exists($projectRoot . '/.piqule.php')
-        ? require $projectRoot . '/.piqule.php'
-        : new OverrideConfig(new DefaultConfig(), []);
+    $defaults = new DefaultConfig(composerJson: $projectRoot . '/composer.json');
 
-    if ($config->list('phpcs.root_namespace') === ['']) {
-        $config = new OverrideConfig($config, [
-            'phpcs.root_namespace' => (new ComposerRootNamespace($projectRoot . '/composer.json'))->toString(),
-        ]);
-    }
+    $config = match (true) {
+        file_exists($projectRoot . '/.piqule.yaml') => new YamlConfig($projectRoot . '/.piqule.yaml', $defaults),
+        file_exists($projectRoot . '/.piqule.php')  => require $projectRoot . '/.piqule.php',
+        default                                      => $defaults,
+    };
 
     $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
     $disk = new DiskStorage($projectRoot);

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "phpunit/phpunit": "^12.0",
         "squizlabs/php_codesniffer": "^4.0",
         "symfony/process": "^7.0",
+        "symfony/yaml": "^7.4",
         "vimeo/psalm": "^6.14"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "880b40c9355b7990c40ef6bb5269032c",
+    "content-hash": "ab70256952e4fcfc3a8ec44513a2b7db",
     "packages": [
         {
             "name": "amphp/amp",
@@ -7774,6 +7774,82 @@
                 }
             ],
             "time": "2025-09-11T10:15:23+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "thecodingmachine/safe",

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Haspadar\Piqule\Config;
+
+use Haspadar\Piqule\PiquleException;
+use Override;
+
+/**
+ * Appends values to existing configuration lists without replacing them
+ *
+ * Example:
+ *
+ *     new AppendConfig(new DefaultConfig(), [
+ *         'phpstan.neon_includes' => ['../../rules.neon'],
+ *         'exclude' => ['legacy'],
+ *     ]);
+ */
+final readonly class AppendConfig implements Config
+{
+    /** @param array<string, list<scalar>> $appends */
+    public function __construct(private Config $defaults, private array $appends) {}
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return $this->defaults->has($name);
+    }
+
+    /**
+     * Returns the default list with appended values merged in
+     *
+     * @throws PiquleException
+     * @return list<scalar>
+     */
+    #[Override]
+    public function list(string $name): array
+    {
+        if (!$this->defaults->has($name)) {
+            throw new PiquleException(
+                sprintf('Unknown config key "%s"', $name),
+            );
+        }
+
+        if (!array_key_exists($name, $this->appends)) {
+            return $this->defaults->list($name);
+        }
+
+        return [...$this->defaults->list($name), ...$this->appends[$name]];
+    }
+
+    #[Override]
+    public function toArray(): array
+    {
+        $result = $this->defaults->toArray();
+
+        foreach (array_keys($result) as $key) {
+            $result[$key] = $this->list($key);
+        }
+
+        return $result;
+    }
+}

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -50,6 +50,9 @@ final readonly class AppendConfig implements Config
         return [...$this->defaults->list($name), ...$this->appends[$name]];
     }
 
+    /**
+     * @throws PiquleException
+     */
     #[Override]
     public function toArray(): array
     {

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -50,9 +50,7 @@ final readonly class AppendConfig implements Config
         return [...$this->defaults->list($name), ...$this->appends[$name]];
     }
 
-    /**
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     #[Override]
     public function toArray(): array
     {

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -19,7 +19,7 @@ use Override;
  */
 final readonly class AppendConfig implements Config
 {
-    /** @param array<string, list<scalar>> $appends */
+    /** @param array<string, mixed> $appends */
     public function __construct(private Config $defaults, private array $appends) {}
 
     #[Override]
@@ -47,7 +47,24 @@ final readonly class AppendConfig implements Config
             return $this->defaults->list($name);
         }
 
-        return [...$this->defaults->list($name), ...$this->appends[$name]];
+        $appends = $this->appends[$name];
+
+        if (!is_array($appends) || !array_is_list($appends)) {
+            throw new PiquleException(
+                sprintf('Append "%s" must be a list<scalar>', $name),
+            );
+        }
+
+        foreach ($appends as $item) {
+            if (!is_scalar($item)) {
+                throw new PiquleException(
+                    sprintf('Append "%s" must contain only scalars', $name),
+                );
+            }
+        }
+
+        /** @var list<scalar> $appends */
+        return [...$this->defaults->list($name), ...$appends];
     }
 
     /** @throws PiquleException */

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -26,6 +26,9 @@ interface Config
      */
     public function list(string $name): array;
 
-    /** @return array<string, scalar|list<scalar>> */
+    /**
+     * @throws PiquleException
+     * @return array<string, scalar|list<scalar>>
+     */
     public function toArray(): array;
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -25,4 +25,7 @@ interface Config
      * @return list<scalar>
      */
     public function list(string $name): array;
+
+    /** @return array<string, scalar|list<scalar>> */
+    public function toArray(): array;
 }

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -42,10 +42,13 @@ final class DefaultConfig implements Config
     public function __construct(
         array $include = ['src'],
         array $exclude = ['vendor', 'tests', '.git'],
+        string $composerJson = '',
     ) {
         $phpVersion = ['8.3'];
         $projectIncludes = (new ProjectDirs($include))->toList();
         $globExcludes = (new GlobDirs($exclude))->toList();
+
+        $rootNamespace = (new ComposerRootNamespace($composerJson))->toString();
 
         $sections = [
             new CiSection($phpVersion, $phpVersion),
@@ -59,7 +62,7 @@ final class DefaultConfig implements Config
             new TyposSection($exclude),
             new YamllintSection($exclude),
             new PhpCsFixerSection($exclude),
-            new PhpCsSection($projectIncludes, $globExcludes),
+            new PhpCsSection($projectIncludes, $globExcludes, $rootNamespace),
             new PhpMdSection($include),
             new PhpMetricsSection($projectIncludes, $exclude),
             new PhpStanSection($projectIncludes),
@@ -103,5 +106,11 @@ final class DefaultConfig implements Config
         return is_scalar($value)
             ? [$value]
             : $value;
+    }
+
+    #[Override]
+    public function toArray(): array
+    {
+        return $this->defaults;
     }
 }

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -169,6 +169,9 @@ final readonly class OverrideConfig implements Config
         return array_values(array_filter($value, static fn($item) => is_scalar($item)));
     }
 
+    /**
+     * @throws PiquleException
+     */
     #[Override]
     public function toArray(): array
     {

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -116,7 +116,7 @@ use Override;
  */
 final readonly class OverrideConfig implements Config
 {
-    /** @param OverrideMap $overrides */
+    /** @param array<string, mixed> $overrides */
     public function __construct(private Config $defaults, private array $overrides) {}
 
     #[Override]
@@ -167,5 +167,17 @@ final readonly class OverrideConfig implements Config
         }
 
         return array_values(array_filter($value, static fn($item) => is_scalar($item)));
+    }
+
+    #[Override]
+    public function toArray(): array
+    {
+        $result = $this->defaults->toArray();
+
+        foreach (array_keys($result) as $key) {
+            $result[$key] = $this->list($key);
+        }
+
+        return $result;
     }
 }

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -169,9 +169,7 @@ final readonly class OverrideConfig implements Config
         return array_values(array_filter($value, static fn($item) => is_scalar($item)));
     }
 
-    /**
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     #[Override]
     public function toArray(): array
     {

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -76,6 +76,9 @@ final readonly class YamlConfig implements Config
         return $this->config->list($name);
     }
 
+    /**
+     * @throws PiquleException
+     */
     #[Override]
     public function toArray(): array
     {

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -6,6 +6,7 @@ namespace Haspadar\Piqule\Config;
 
 use Haspadar\Piqule\PiquleException;
 use Override;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -32,8 +33,15 @@ final readonly class YamlConfig implements Config
     /** @throws PiquleException */
     public function __construct(string $path, Config $defaults)
     {
-        /** @var array{override?: array<string, scalar>, append?: array<string, list<scalar>>}|null $data */
-        $data = Yaml::parseFile($path);
+        try {
+            $data = Yaml::parseFile($path);
+        } catch (ParseException $e) {
+            throw new PiquleException(
+                sprintf('Failed to parse "%s": %s', $path, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
 
         if (!is_array($data)) {
             throw new PiquleException(
@@ -41,10 +49,10 @@ final readonly class YamlConfig implements Config
             );
         }
 
-        /** @var array<string, scalar|list<scalar>> $overrides */
-        $overrides = $data['override'] ?? [];
+        /** @var array<string, mixed> $overrides */
+        $overrides = isset($data['override']) && is_array($data['override']) ? $data['override'] : [];
         /** @var array<string, list<scalar>> $appends */
-        $appends = $data['append'] ?? [];
+        $appends = isset($data['append']) && is_array($data['append']) ? $data['append'] : [];
 
         $this->config = new AppendConfig(
             new OverrideConfig($defaults, $overrides),

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Haspadar\Piqule\Config;
+
+use Haspadar\Piqule\PiquleException;
+use Override;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Loads project configuration from a .piqule.yaml file
+ *
+ * Supports two sections:
+ * - override: replaces default values
+ * - append: adds values to existing lists
+ *
+ * Example .piqule.yaml:
+ *
+ *     override:
+ *         phpstan.level: 8
+ *     append:
+ *         phpstan.neon_includes:
+ *             - ../../rules.neon
+ *         exclude:
+ *             - legacy
+ */
+final readonly class YamlConfig implements Config
+{
+    private Config $config;
+
+    /** @throws PiquleException */
+    public function __construct(string $path, Config $defaults)
+    {
+        /** @var array{override?: array<string, scalar>, append?: array<string, list<scalar>>}|null $data */
+        $data = Yaml::parseFile($path);
+
+        if (!is_array($data)) {
+            throw new PiquleException(
+                sprintf('Invalid configuration file "%s": expected a mapping', $path),
+            );
+        }
+
+        /** @var array<string, scalar|list<scalar>> $overrides */
+        $overrides = $data['override'] ?? [];
+        /** @var array<string, list<scalar>> $appends */
+        $appends = $data['append'] ?? [];
+
+        $this->config = new AppendConfig(
+            new OverrideConfig($defaults, $overrides),
+            $appends,
+        );
+    }
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return $this->config->has($name);
+    }
+
+    /**
+     * @throws PiquleException
+     * @return list<scalar>
+     */
+    #[Override]
+    public function list(string $name): array
+    {
+        return $this->config->list($name);
+    }
+
+    #[Override]
+    public function toArray(): array
+    {
+        return $this->config->toArray();
+    }
+}

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -53,7 +53,7 @@ final readonly class YamlConfig implements Config
         $overrides = isset($data['override']) && is_array($data['override'])
             ? $data['override']
             : [];
-        /** @var array<string, list<scalar>> $appends */
+        /** @var array<string, mixed> $appends */
         $appends = isset($data['append']) && is_array($data['append'])
             ? $data['append']
             : [];

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -50,9 +50,13 @@ final readonly class YamlConfig implements Config
         }
 
         /** @var array<string, mixed> $overrides */
-        $overrides = isset($data['override']) && is_array($data['override']) ? $data['override'] : [];
+        $overrides = isset($data['override']) && is_array($data['override'])
+            ? $data['override']
+            : [];
         /** @var array<string, list<scalar>> $appends */
-        $appends = isset($data['append']) && is_array($data['append']) ? $data['append'] : [];
+        $appends = isset($data['append']) && is_array($data['append'])
+            ? $data['append']
+            : [];
 
         $this->config = new AppendConfig(
             new OverrideConfig($defaults, $overrides),
@@ -76,9 +80,7 @@ final readonly class YamlConfig implements Config
         return $this->config->list($name);
     }
 
-    /**
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     #[Override]
     public function toArray(): array
     {

--- a/tests/Fake/Config/FakeConfig.php
+++ b/tests/Fake/Config/FakeConfig.php
@@ -26,4 +26,9 @@ final class FakeConfig implements Config
 
         return $this->data[$name];
     }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
 }

--- a/tests/Unit/Config/AppendConfigTest.php
+++ b/tests/Unit/Config/AppendConfigTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Config;
+
+use Haspadar\Piqule\Config\AppendConfig;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AppendConfigTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueWhenKeyIsDeclaredInDefaults(): void
+    {
+        self::assertTrue(
+            (new AppendConfig(
+                new FakeConfig(['phpstan.neon_includes' => []]),
+                [],
+            ))->has('phpstan.neon_includes'),
+            'AppendConfig must report a key as present if it exists in defaults',
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenKeyIsNotDeclaredInDefaults(): void
+    {
+        self::assertFalse(
+            (new AppendConfig(
+                new FakeConfig(['phpstan.neon_includes' => []]),
+                [],
+            ))->has('unknown.key'),
+            'AppendConfig must report an undeclared key as absent',
+        );
+    }
+
+    #[Test]
+    public function returnsDefaultListWhenNoAppendsForKey(): void
+    {
+        self::assertSame(
+            ['../../rules.neon'],
+            (new AppendConfig(
+                new FakeConfig(['phpstan.neon_includes' => ['../../rules.neon']]),
+                [],
+            ))->list('phpstan.neon_includes'),
+            'AppendConfig must return the default list unchanged when no appends are defined for the key',
+        );
+    }
+
+    #[Test]
+    public function appendsValuesToDefaultList(): void
+    {
+        self::assertSame(
+            ['../../rules.neon', '../../extra.neon'],
+            (new AppendConfig(
+                new FakeConfig(['phpstan.neon_includes' => ['../../rules.neon']]),
+                ['phpstan.neon_includes' => ['../../extra.neon']],
+            ))->list('phpstan.neon_includes'),
+            'AppendConfig must merge appended values after the default list',
+        );
+    }
+
+    #[Test]
+    public function appendsMultipleValuesToEmptyDefaultList(): void
+    {
+        self::assertSame(
+            ['legacy', 'generated'],
+            (new AppendConfig(
+                new FakeConfig(['dirs.exclude' => []]),
+                ['dirs.exclude' => ['legacy', 'generated']],
+            ))->list('dirs.exclude'),
+            'AppendConfig must append to an empty default list',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenListCalledForUndeclaredKey(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendConfig(
+            new FakeConfig([]),
+            [],
+        ))->list('phpstan.neon_includes');
+    }
+
+    #[Test]
+    public function toArrayReturnsAllKeysWithAppendsApplied(): void
+    {
+        self::assertSame(
+            [
+                'phpstan.neon_includes' => ['../../rules.neon', '../../extra.neon'],
+                'dirs.exclude' => ['vendor', 'tests'],
+            ],
+            (new AppendConfig(
+                new FakeConfig([
+                    'phpstan.neon_includes' => ['../../rules.neon'],
+                    'dirs.exclude' => ['vendor', 'tests'],
+                ]),
+                ['phpstan.neon_includes' => ['../../extra.neon']],
+            ))->toArray(),
+            'toArray must return all keys with appended values merged in',
+        );
+    }
+
+    #[Test]
+    public function toArrayReturnsAllKeysUnchangedWhenNoAppends(): void
+    {
+        self::assertSame(
+            ['phpstan.level' => ['8'], 'phpstan.paths' => ['src']],
+            (new AppendConfig(
+                new FakeConfig(['phpstan.level' => ['8'], 'phpstan.paths' => ['src']]),
+                [],
+            ))->toArray(),
+            'toArray must return all keys unchanged when no appends are defined',
+        );
+    }
+}

--- a/tests/Unit/Config/AppendConfigTest.php
+++ b/tests/Unit/Config/AppendConfigTest.php
@@ -106,6 +106,39 @@ final class AppendConfigTest extends TestCase
     }
 
     #[Test]
+    public function throwsWhenAppendValueIsAssociativeArray(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendConfig(
+            new FakeConfig(['phpstan.neon_includes' => []]),
+            ['phpstan.neon_includes' => ['key' => 'value']],
+        ))->list('phpstan.neon_includes');
+    }
+
+    #[Test]
+    public function throwsWhenAppendValueIsScalar(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendConfig(
+            new FakeConfig(['phpstan.neon_includes' => []]),
+            ['phpstan.neon_includes' => '../../rules.neon'],
+        ))->list('phpstan.neon_includes');
+    }
+
+    #[Test]
+    public function throwsWhenAppendListContainsNonScalar(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendConfig(
+            new FakeConfig(['phpstan.neon_includes' => []]),
+            ['phpstan.neon_includes' => [['nested']]],
+        ))->list('phpstan.neon_includes');
+    }
+
+    #[Test]
     public function toArrayReturnsAllKeysUnchangedWhenNoAppends(): void
     {
         self::assertSame(

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -117,4 +117,38 @@ final class DefaultConfigTest extends TestCase
             'php.version must default to 8.3',
         );
     }
+
+    #[Test]
+    public function returnsToArrayWithAllDeclaredKeys(): void
+    {
+        $array = (new DefaultConfig())->toArray();
+
+        self::assertArrayHasKey(
+            'phpstan.level',
+            $array,
+            'toArray must include all declared default keys',
+        );
+    }
+
+    #[Test]
+    public function usesRootNamespaceFromComposerJson(): void
+    {
+        $folder = sys_get_temp_dir() . '/piqule-test-' . uniqid('', true);
+        mkdir($folder, 0o755);
+        file_put_contents(
+            $folder . '/composer.json',
+            '{"autoload":{"psr-4":{"Acme\\\\":"src/"}}}',
+        );
+
+        $namespace = (new DefaultConfig(composerJson: $folder . '/composer.json'))->list('phpcs.root_namespace');
+
+        array_map('unlink', glob($folder . '/*') ?: []);
+        rmdir($folder);
+
+        self::assertSame(
+            ['Acme'],
+            $namespace,
+            'DefaultConfig must extract root namespace from composer.json psr-4 section',
+        );
+    }
 }

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Unit\Config;
 
 use Haspadar\Piqule\Config\DefaultConfig;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -133,17 +134,14 @@ final class DefaultConfigTest extends TestCase
     #[Test]
     public function usesRootNamespaceFromComposerJson(): void
     {
-        $folder = sys_get_temp_dir() . '/piqule-test-' . uniqid('', true);
-        mkdir($folder, 0o755);
-        file_put_contents(
-            $folder . '/composer.json',
+        $folder = (new TempFolder())->withFile(
+            'composer.json',
             '{"autoload":{"psr-4":{"Acme\\\\":"src/"}}}',
         );
 
-        $namespace = (new DefaultConfig(composerJson: $folder . '/composer.json'))->list('phpcs.root_namespace');
+        $namespace = (new DefaultConfig(composerJson: $folder->path() . '/composer.json'))->list('phpcs.root_namespace');
 
-        array_map('unlink', glob($folder . '/*') ?: []);
-        rmdir($folder);
+        $folder->close();
 
         self::assertSame(
             ['Acme'],

--- a/tests/Unit/Config/OverrideConfigTest.php
+++ b/tests/Unit/Config/OverrideConfigTest.php
@@ -132,4 +132,17 @@ final class OverrideConfigTest extends TestCase
             ['jsonlint.mode' => new stdClass()],
         ))->list('jsonlint.mode');
     }
+
+    #[Test]
+    public function toArrayReturnsAllKeysWithOverridesApplied(): void
+    {
+        self::assertSame(
+            ['phpstan.level' => [9], 'phpstan.paths' => ['src']],
+            (new OverrideConfig(
+                new FakeConfig(['phpstan.level' => ['8'], 'phpstan.paths' => ['src']]),
+                ['phpstan.level' => 9],
+            ))->toArray(),
+            'toArray must return all keys with overrides applied',
+        );
+    }
 }

--- a/tests/Unit/Config/YamlConfigTest.php
+++ b/tests/Unit/Config/YamlConfigTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Config;
+
+use Haspadar\Piqule\Config\YamlConfig;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class YamlConfigTest extends TestCase
+{
+    private TempFolder $folder;
+
+    protected function setUp(): void
+    {
+        $this->folder = new TempFolder();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->folder->close();
+    }
+
+    #[Test]
+    public function throwsWhenFileContainsInvalidYaml(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile('.piqule.yaml', ": invalid: yaml: :")->path() . '/.piqule.yaml';
+
+        new YamlConfig($path, new FakeConfig([]));
+    }
+
+    #[Test]
+    public function throwsWhenFileContainsScalarYaml(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile('.piqule.yaml', "just a string\n")->path() . '/.piqule.yaml';
+
+        new YamlConfig($path, new FakeConfig([]));
+    }
+
+    #[Test]
+    public function returnsDelegatedHasWhenNoOverrides(): void
+    {
+        $path = $this->folder->withFile('.piqule.yaml', "override: {}\n")->path() . '/.piqule.yaml';
+
+        $config = new YamlConfig($path, new FakeConfig(['phpstan.level' => ['8']]));
+
+        self::assertTrue(
+            $config->has('phpstan.level'),
+            'YamlConfig must delegate has() to defaults when no overrides are present',
+        );
+    }
+
+    #[Test]
+    public function returnsDefaultValueWhenNoOverridesOrAppends(): void
+    {
+        $path = $this->folder->withFile('.piqule.yaml', "{}\n")->path() . '/.piqule.yaml';
+
+        $config = new YamlConfig($path, new FakeConfig(['phpstan.level' => ['8']]));
+
+        self::assertSame(
+            ['8'],
+            $config->list('phpstan.level'),
+            'YamlConfig must return the default value when no overrides or appends are specified',
+        );
+    }
+
+    #[Test]
+    public function returnsOverriddenValueWhenOverrideSectionPresent(): void
+    {
+        $yaml = "override:\n    phpstan.level: 9\n";
+        $path = $this->folder->withFile('.piqule.yaml', $yaml)->path() . '/.piqule.yaml';
+
+        $config = new YamlConfig($path, new FakeConfig(['phpstan.level' => ['8']]));
+
+        self::assertSame(
+            [9],
+            $config->list('phpstan.level'),
+            'YamlConfig must return the overridden value when override section is present',
+        );
+    }
+
+    #[Test]
+    public function returnsAppendedValuesWhenAppendSectionPresent(): void
+    {
+        $yaml = "append:\n    phpstan.neon_includes:\n        - ../../rules.neon\n";
+        $path = $this->folder->withFile('.piqule.yaml', $yaml)->path() . '/.piqule.yaml';
+
+        $config = new YamlConfig($path, new FakeConfig(['phpstan.neon_includes' => []]));
+
+        self::assertSame(
+            ['../../rules.neon'],
+            $config->list('phpstan.neon_includes'),
+            'YamlConfig must append values from the append section to the default list',
+        );
+    }
+
+    #[Test]
+    public function appendsToExistingDefaultList(): void
+    {
+        $yaml = "append:\n    phpstan.neon_includes:\n        - ../../extra.neon\n";
+        $path = $this->folder->withFile('.piqule.yaml', $yaml)->path() . '/.piqule.yaml';
+
+        $config = new YamlConfig($path, new FakeConfig(['phpstan.neon_includes' => ['../../base.neon']]));
+
+        self::assertSame(
+            ['../../base.neon', '../../extra.neon'],
+            $config->list('phpstan.neon_includes'),
+            'YamlConfig must preserve default values and append new ones after them',
+        );
+    }
+
+    #[Test]
+    public function toArrayReturnsAllKeysWithOverridesAndAppendsApplied(): void
+    {
+        $yaml = "override:\n    phpstan.level: 9\nappend:\n    phpstan.neon_includes:\n        - ../../rules.neon\n";
+        $path = $this->folder->withFile('.piqule.yaml', $yaml)->path() . '/.piqule.yaml';
+
+        $config = new YamlConfig(
+            $path,
+            new FakeConfig([
+                'phpstan.level' => ['8'],
+                'phpstan.neon_includes' => [],
+            ]),
+        );
+
+        self::assertSame(
+            [
+                'phpstan.level' => [9],
+                'phpstan.neon_includes' => ['../../rules.neon'],
+            ],
+            $config->toArray(),
+            'toArray must return all keys with both overrides and appends applied',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenListCalledForUndeclaredKey(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile('.piqule.yaml', "{}\n")->path() . '/.piqule.yaml';
+
+        (new YamlConfig($path, new FakeConfig([])))->list('phpstan.level');
+    }
+}

--- a/tests/Unit/Config/YamlConfigTest.php
+++ b/tests/Unit/Config/YamlConfigTest.php
@@ -32,7 +32,7 @@ final class YamlConfigTest extends TestCase
 
         $path = $this->folder->withFile('.piqule.yaml', ": invalid: yaml: :")->path() . '/.piqule.yaml';
 
-        new YamlConfig($path, new FakeConfig([])); // NOSONAR
+        (new YamlConfig($path, new FakeConfig([])))->has('');
     }
 
     #[Test]
@@ -42,7 +42,7 @@ final class YamlConfigTest extends TestCase
 
         $path = $this->folder->withFile('.piqule.yaml', "just a string\n")->path() . '/.piqule.yaml';
 
-        new YamlConfig($path, new FakeConfig([])); // NOSONAR
+        (new YamlConfig($path, new FakeConfig([])))->has('');
     }
 
     #[Test]

--- a/tests/Unit/Config/YamlConfigTest.php
+++ b/tests/Unit/Config/YamlConfigTest.php
@@ -32,7 +32,7 @@ final class YamlConfigTest extends TestCase
 
         $path = $this->folder->withFile('.piqule.yaml', ": invalid: yaml: :")->path() . '/.piqule.yaml';
 
-        new YamlConfig($path, new FakeConfig([]));
+        new YamlConfig($path, new FakeConfig([])); // NOSONAR
     }
 
     #[Test]
@@ -42,7 +42,7 @@ final class YamlConfigTest extends TestCase
 
         $path = $this->folder->withFile('.piqule.yaml', "just a string\n")->path() . '/.piqule.yaml';
 
-        new YamlConfig($path, new FakeConfig([]));
+        new YamlConfig($path, new FakeConfig([])); // NOSONAR
     }
 
     #[Test]


### PR DESCRIPTION
- Added `symfony/yaml` dependency for YAML config parsing
- Added `AppendConfig` decorator for merging values into default lists
- Added `YamlConfig` to load `.piqule.yaml` with `override`/`append` sections
- Updated `Config` interface and all implementations with `toArray()`
- Refactored `DefaultConfig` to resolve `phpcs.root_namespace` from `composer.json` directly

Part of #471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YAML-based configuration (.piqule.yaml) with fallback to PHP config
  * Support for override and append sections and a bulk config export API

* **Tests**
  * Added unit tests covering append, override, default, and YAML config behaviors

* **Chores**
  * Added a YAML parsing dependency for configuration file support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->