### PR TITLE
Strict Psalm With Bin Entry Points Analysis

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -5,6 +5,12 @@ override:
   ci.piqule_bin: bin/piqule
   sonar.organization: haspadar-org
   sonar.projectKey: haspadar_piqule
+  psalm.project.files:
+    - "../../bin/piqule"
+    - "../../bin/piqule-check"
+    - "../../bin/piqule-fix"
+    - "../../bin/piqule-sync"
+    - "../../bin/piqule-tokens-check"
 
 append:
   exclude:

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -101,6 +101,7 @@ defaults:
   psalm.enabled: true
   psalm.error_level: 1
   psalm.project.directories: ["../../src"]
+  psalm.project.files: []
   psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
 
   infection.enabled: true

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -2,10 +2,18 @@
 <psalm
         errorLevel="1"
         xmlns="https://getpsalm.org/schema/config"
-        findUnusedCode="false"
+        findUnusedCode="true"
+        findUnusedBaselineEntry="true"
+        ensureArrayStringOffsetsExist="true"
+        reportMixedIssues="true"
 >
     <projectFiles>
         <directory name="../../src" />
+        <file name="../../bin/piqule" />
+        <file name="../../bin/piqule-check" />
+        <file name="../../bin/piqule-fix" />
+        <file name="../../bin/piqule-sync" />
+        <file name="../../bin/piqule-tokens-check" />
         <ignoreFiles>
             <directory name="../../vendor" />
             <directory name="../../tests" />
@@ -15,5 +23,8 @@
     </projectFiles>
     <issueHandlers>
         <InvalidAttribute errorLevel="suppress" />
+        <UnusedClass errorLevel="suppress" />
+        <PossiblyUnusedMethod errorLevel="suppress" />
+        <UnresolvableInclude errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -23,8 +23,19 @@
     </projectFiles>
     <issueHandlers>
         <InvalidAttribute errorLevel="suppress" />
-        <UnusedClass errorLevel="suppress" />
-        <PossiblyUnusedMethod errorLevel="suppress" />
-        <UnresolvableInclude errorLevel="suppress" />
+        <UnusedClass errorLevel="suppress">
+            <errorLevel type="suppress">
+                <directory name="../../src" />
+            </errorLevel>
+        </UnusedClass>
+        <UnresolvableInclude errorLevel="suppress">
+            <errorLevel type="suppress">
+                <file name="../../bin/piqule" />
+                <file name="../../bin/piqule-check" />
+                <file name="../../bin/piqule-fix" />
+                <file name="../../bin/piqule-sync" />
+                <file name="../../bin/piqule-tokens-check" />
+            </errorLevel>
+        </UnresolvableInclude>
     </issueHandlers>
 </psalm>

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -77,9 +77,9 @@ $total = $requested !== ''
     : count(array_filter($checks, $isEnabled));
 $current = 0;
 
-$green = static fn(string $s) => "\033[32m{$s}\033[0m\n";
-$blue = static fn(string $s) => "\033[34m{$s}\033[0m\n";
-$red = static fn(string $s) => "\033[31m{$s}\033[0m\n";
+$green = static fn(string $s): string => "\033[32m{$s}\033[0m\n";
+$blue = static fn(string $s): string => "\033[34m{$s}\033[0m\n";
+$red = static fn(string $s): string => "\033[31m{$s}\033[0m\n";
 
 $runCheck = static function(string $key) use ($projectRoot, $isEnabled, $green, $blue, $red, $total, &$current,): bool {
     $command = "{$projectRoot}/.piqule/{$key}/command.sh";

--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -30,17 +30,30 @@ try {
     $projectRoot = getcwd()
         ?: throw new PiquleException('Cannot determine current working directory');
 
-    $libraryRoot = Composer\InstalledVersions::getInstallPath('haspadar/piqule')
-        ?: throw new PiquleException('Cannot determine piqule install path');
+    $installPath = Composer\InstalledVersions::getInstallPath('haspadar/piqule');
+
+    if ($installPath === null || $installPath === '') {
+        throw new PiquleException('Cannot determine piqule install path');
+    }
+
+    $libraryRoot = $installPath;
 
     $yamlPath = $projectRoot . '/.piqule.yaml';
     $defaults = new DefaultConfig(composerJson: $projectRoot . '/composer.json');
 
-    $config = match (true) {
-        file_exists($yamlPath)                     => new YamlConfig($yamlPath, $defaults),
-        file_exists($projectRoot . '/.piqule.php') => require $projectRoot . '/.piqule.php',
-        default                                    => $defaults,
-    };
+    if (file_exists($yamlPath)) {
+        $config = new YamlConfig($yamlPath, $defaults);
+    } elseif (file_exists($projectRoot . '/.piqule.php')) {
+        $loaded = require $projectRoot . '/.piqule.php';
+
+        if (!$loaded instanceof Config) {
+            throw new PiquleException('.piqule.php must return an instance of Config');
+        }
+
+        $config = $loaded;
+    } else {
+        $config = $defaults;
+    }
 
     $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
     $disk = new DiskStorage($projectRoot);

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -17,9 +17,18 @@ $output = new Console();
 
 $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
 
-$config = file_exists($projectRoot . '/.piqule.php')
-    ? require $projectRoot . '/.piqule.php'
-    : new OverrideConfig(new DefaultConfig(), []);
+if (file_exists($projectRoot . '/.piqule.php')) {
+    $loaded = require $projectRoot . '/.piqule.php';
+
+    if (!$loaded instanceof Config) {
+        $output->error('.piqule.php must return an instance of Config');
+        exit(1);
+    }
+
+    $config = $loaded;
+} else {
+    $config = new OverrideConfig(new DefaultConfig(), []);
+}
 
 $tokens = new Tokens([
     new CodecovToken(),
@@ -59,9 +68,11 @@ if ($secretsStatus !== 0) {
 $decoded = json_decode(implode('', $secretsJson), true) ?? [];
 $existing = array_column($decoded, 'name');
 
+$repoOut = [];
 exec('gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null', $repoOut, $repoStatus);
 
-$repo = $repoStatus === 0 ? trim($repoOut[0] ?? '') : '';
+$repoLines = array_values(array_filter($repoOut, 'is_string'));
+$repo = $repoStatus === 0 && $repoLines !== [] ? trim($repoLines[0]) : '';
 $org = $repo !== '' ? explode('/', $repo)[0] : '';
 
 foreach ($enabled as $token) {

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 use Haspadar\Piqule\Config\Config;
 use Haspadar\Piqule\Config\DefaultConfig;
-use Haspadar\Piqule\Config\OverrideConfig;
+use Haspadar\Piqule\Config\YamlConfig;
 use Haspadar\Piqule\Output\Console;
 use Haspadar\Piqule\Token\CodecovToken;
 use Haspadar\Piqule\Token\InfectionToken;
@@ -16,8 +16,23 @@ require_once __DIR__ . '/bootstrap-autoload.php';
 $output = new Console();
 
 $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
+$yamlPath = $projectRoot . '/.piqule.yaml';
 
-if (file_exists($projectRoot . '/.piqule.php')) {
+try {
+    $defaults = new DefaultConfig(composerJson: $projectRoot . '/composer.json');
+} catch (Throwable $e) {
+    $output->error("Failed to load default config: {$e->getMessage()}");
+    exit(1);
+}
+
+if (file_exists($yamlPath)) {
+    try {
+        $config = new YamlConfig($yamlPath, $defaults);
+    } catch (Throwable $e) {
+        $output->error("Failed to load .piqule.yaml: {$e->getMessage()}");
+        exit(1);
+    }
+} elseif (file_exists($projectRoot . '/.piqule.php')) {
     $loaded = require $projectRoot . '/.piqule.php';
 
     if (!$loaded instanceof Config) {
@@ -27,7 +42,7 @@ if (file_exists($projectRoot . '/.piqule.php')) {
 
     $config = $loaded;
 } else {
-    $config = new OverrideConfig(new DefaultConfig(), []);
+    $config = $defaults;
 }
 
 $tokens = new Tokens([

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -38,9 +38,10 @@ final class DefaultConfig implements Config
         array $phpSrc = [],
         array $exclude = [],
         private readonly string $composerJson = '',
+        string $configPath = __DIR__ . '/../../templates/always/.piqule/config.yaml',
     ) {
         /** @var array<string, mixed> $yaml */
-        $yaml = Yaml::parseFile(__DIR__ . '/../../templates/always/.piqule/config.yaml');
+        $yaml = Yaml::parseFile($configPath);
 
         if (!array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
             throw new PiquleException('Missing "defaults" section in config.yaml');

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -42,7 +42,7 @@ final class DefaultConfig implements Config
         /** @var array<string, mixed> $yaml */
         $yaml = Yaml::parseFile(__DIR__ . '/../../templates/always/.piqule/config.yaml');
 
-        if (!isset($yaml['defaults']) || !is_array($yaml['defaults'])) {
+        if (!array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
             throw new PiquleException('Missing "defaults" section in config.yaml');
         }
 

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -9,6 +9,7 @@ use Haspadar\Piqule\Config\Dirs\NegatedGlobDirs;
 use Haspadar\Piqule\Config\Dirs\ProjectDirs;
 use Haspadar\Piqule\Config\Dirs\TrailingGlobDirs;
 use Haspadar\Piqule\Config\Dirs\TrailingSlashDirs;
+use Haspadar\Piqule\PiquleException;
 use Override;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -31,6 +32,7 @@ final class DefaultConfig implements Config
      * @param list<string> $phpSrc
      * @param list<string> $exclude
      * @throws ParseException
+     * @throws PiquleException
      */
     public function __construct(
         array $phpSrc = [],
@@ -40,18 +42,22 @@ final class DefaultConfig implements Config
         /** @var array<string, mixed> $yaml */
         $yaml = Yaml::parseFile(__DIR__ . '/../../templates/always/.piqule/config.yaml');
 
+        if (!isset($yaml['defaults']) || !is_array($yaml['defaults'])) {
+            throw new PiquleException('Missing "defaults" section in config.yaml');
+        }
+
         /** @var array<string, mixed> $base */
         $base = $yaml['defaults'];
 
         /** @var list<string> $resolvedPhpSrc */
         $resolvedPhpSrc = $phpSrc !== []
             ? $phpSrc
-            : $base['php.src'];
+            : ($base['php.src'] ?? []);
 
         /** @var list<string> $resolvedExclude */
         $resolvedExclude = $exclude !== []
             ? $exclude
-            : $base['exclude'];
+            : ($base['exclude'] ?? []);
 
         /** @var array<string, scalar|list<scalar>> $defaults */
         $defaults = array_merge($base, $this->dynamic($resolvedPhpSrc, $resolvedExclude));

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -78,6 +78,7 @@ use Override;
  *   'phpunit.testsuites.unit'?: list<string>,
  *   'psalm.error_level'?: list<int|float>,
  *   'psalm.project.directories'?: list<string>,
+ *   'psalm.project.files'?: list<string>,
  *   'psalm.project.ignore'?: list<string>,
  *   'shellcheck.exclude'?: list<string>,
  *   'shellcheck.external_sources'?: bool,

--- a/src/Config/YamlPathKeys.php
+++ b/src/Config/YamlPathKeys.php
@@ -35,13 +35,11 @@ final readonly class YamlPathKeys
 
         if (array_key_exists('exclude', $appends) && is_array($appends['exclude'])) {
             $extra = $this->toStringList(array_values($appends['exclude']), 'append.exclude');
-            /** @var list<string> $exclude */
             $exclude = array_values(array_unique(array_merge($exclude, $extra)));
         }
 
         if (array_key_exists('php.src', $appends) && is_array($appends['php.src'])) {
             $extra = $this->toStringList(array_values($appends['php.src']), 'append.php.src');
-            /** @var list<string> $phpSrc */
             $phpSrc = array_values(array_unique(array_merge($phpSrc, $extra)));
         }
 

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -41,7 +41,7 @@ final readonly class FormatAction implements Action
         $templateValues = $templateArgs->values();
         $template = (string) ($templateValues[0] ?? '');
 
-        $scalar = (new StringifiedArgs($args))->values()[0];
+        $scalar = (new StringifiedArgs($args))->values()[0] ?? '';
 
         try {
             $result = sprintf($template, $scalar);

--- a/src/Formula/Action/FormatEachAction.php
+++ b/src/Formula/Action/FormatEachAction.php
@@ -22,7 +22,7 @@ final readonly class FormatEachAction implements Action
     {
         $templateArgs = new UnquotedArgs(new ListArgs([$this->raw]));
         $templateValues = $templateArgs->values();
-        $template = (string) $templateValues[0];
+        $template = (string) ($templateValues[0] ?? '');
 
         return new ListArgs(
             array_map(

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -101,6 +101,7 @@ defaults:
   psalm.enabled: true
   psalm.error_level: 1
   psalm.project.directories: ["../../src"]
+  psalm.project.files: []
   psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
 
   infection.enabled: true

--- a/templates/always/.piqule/psalm/psalm.xml
+++ b/templates/always/.piqule/psalm/psalm.xml
@@ -16,8 +16,15 @@
     </projectFiles>
     <issueHandlers>
         <InvalidAttribute errorLevel="suppress" />
-        <UnusedClass errorLevel="suppress" />
-        <PossiblyUnusedMethod errorLevel="suppress" />
-        <UnresolvableInclude errorLevel="suppress" />
+        <UnusedClass errorLevel="suppress">
+            <errorLevel type="suppress">
+<< config(psalm.project.directories)|format_each('                <directory name="%s" />')|join("\n") >>
+            </errorLevel>
+        </UnusedClass>
+        <UnresolvableInclude errorLevel="suppress">
+            <errorLevel type="suppress">
+<< config(psalm.project.files)|format_each('                <file name="%s" />')|join("\n") >>
+            </errorLevel>
+        </UnresolvableInclude>
     </issueHandlers>
 </psalm>

--- a/templates/always/.piqule/psalm/psalm.xml
+++ b/templates/always/.piqule/psalm/psalm.xml
@@ -2,15 +2,22 @@
 <psalm
         errorLevel="<< config(psalm.error_level)|join("") >>"
         xmlns="https://getpsalm.org/schema/config"
-        findUnusedCode="false"
+        findUnusedCode="true"
+        findUnusedBaselineEntry="true"
+        ensureArrayStringOffsetsExist="true"
+        reportMixedIssues="true"
 >
     <projectFiles>
 << config(psalm.project.directories)|format_each('        <directory name="%s" />')|join("\n") >>
+<< config(psalm.project.files)|format_each('        <file name="%s" />')|join("\n") >>
         <ignoreFiles>
 << config(psalm.project.ignore)|format_each('            <directory name="%s" />')|join("\n") >>
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
         <InvalidAttribute errorLevel="suppress" />
+        <UnusedClass errorLevel="suppress" />
+        <PossiblyUnusedMethod errorLevel="suppress" />
+        <UnresolvableInclude errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Unit\Config;
 
 use Haspadar\Piqule\Config\DefaultConfig;
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Tests\Fixture\TempFolder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -148,5 +149,20 @@ final class DefaultConfigTest extends TestCase
             $namespace,
             'DefaultConfig must extract root namespace from composer.json psr-4 section',
         );
+    }
+
+    #[Test]
+    public function throwsWhenConfigYamlHasNoDefaultsSection(): void
+    {
+        $folder = (new TempFolder())->withFile('empty.yaml', 'root: true');
+
+        $this->expectException(PiquleException::class);
+        $this->expectExceptionMessage('Missing "defaults" section');
+
+        try {
+            new DefaultConfig(configPath: $folder->path() . '/empty.yaml');
+        } finally {
+            $folder->close();
+        }
     }
 }


### PR DESCRIPTION
- Added strict Psalm checks: findUnusedCode, ensureArrayStringOffsetsExist, reportMixedIssues
- Added psalm.project.files config key to support extensionless PHP scripts
- Fixed type safety in bin/ scripts: require return type verification, exec output handling
- Removed unnecessary @var annotations Psalm can infer

Closes #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled unused-code detection and stricter array-offset/mixed-issue checks in static analysis; analysis now includes executable scripts as explicit project files.

* **Bug Fixes**
  * Stronger configuration validation and clearer runtime errors for missing/invalid configs; safer config-loading fallbacks.

* **Refactor**
  * Improved type safety and null-safety: added explicit return types and safer handling of missing/optional inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->