### PR TITLE
Conditional Guard Actions in Formula DSL

### DIFF
--- a/src/File/ConfiguredFile.php
+++ b/src/File/ConfiguredFile.php
@@ -10,6 +10,8 @@ use Haspadar\Piqule\Formula\Action\ConfigAction;
 use Haspadar\Piqule\Formula\Action\FirstAction;
 use Haspadar\Piqule\Formula\Action\FormatAction;
 use Haspadar\Piqule\Formula\Action\FormatEachAction;
+use Haspadar\Piqule\Formula\Action\IfEmptyAction;
+use Haspadar\Piqule\Formula\Action\IfNotEmptyAction;
 use Haspadar\Piqule\Formula\Action\JoinAction;
 use Haspadar\Piqule\Formula\Actions\ParsedActions;
 use Haspadar\Piqule\Formula\ExecutedFormula;
@@ -83,6 +85,14 @@ final readonly class ConfiguredFile implements File
             },
             'format' => static fn(string $raw): Action => new FormatAction($raw),
             'format_each' => static fn(string $raw): Action => new FormatEachAction($raw),
+            'if_empty' => static fn(string $raw): Action => match (trim($raw)) {
+                '' => new IfEmptyAction(),
+                default => throw new PiquleException('Action "if_empty" does not accept arguments'),
+            },
+            'if_not_empty' => static fn(string $raw): Action => match (trim($raw)) {
+                '' => new IfNotEmptyAction(),
+                default => throw new PiquleException('Action "if_not_empty" does not accept arguments'),
+            },
             'join' => static fn(string $raw): Action => new JoinAction($raw),
         ];
     }

--- a/src/Formula/Action/IfEmptyAction.php
+++ b/src/Formula/Action/IfEmptyAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Haspadar\Piqule\Formula\Action;
+
+use Haspadar\Piqule\Formula\Args\Args;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Override;
+
+/**
+ * Passes empty input through, clears non-empty input
+ */
+final readonly class IfEmptyAction implements Action
+{
+    #[Override]
+    public function transformed(Args $args): Args
+    {
+        $values = $args->values();
+
+        if ($values === [] || $values === ['']) {
+            return $args;
+        }
+
+        return new ListArgs([]);
+    }
+}

--- a/src/Formula/Action/IfNotEmptyAction.php
+++ b/src/Formula/Action/IfNotEmptyAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Haspadar\Piqule\Formula\Action;
+
+use Haspadar\Piqule\Formula\Args\Args;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Override;
+
+/**
+ * Passes non-empty input through, clears empty input
+ */
+final readonly class IfNotEmptyAction implements Action
+{
+    #[Override]
+    public function transformed(Args $args): Args
+    {
+        $values = $args->values();
+
+        if ($values === [] || $values === ['']) {
+            return new ListArgs([]);
+        }
+
+        return $args;
+    }
+}

--- a/tests/Unit/File/ConfiguredFileTest.php
+++ b/tests/Unit/File/ConfiguredFileTest.php
@@ -156,6 +156,118 @@ final class ConfiguredFileTest extends TestCase
     }
 
     #[Test]
+    public function rendersContentWhenIfNotEmptyReceivesNonEmptyInput(): void
+    {
+        $config = new OverrideConfig(
+            new DefaultConfig(),
+            ['php.versions' => ['8.3', '8.4']],
+        );
+
+        self::assertThat(
+            new ConfiguredFile(
+                new TextFile(
+                    'file',
+                    '<< config(php.versions)|format_each("%s")|join(",")|if_not_empty()|format("[%s]") >>',
+                ),
+                $config,
+            ),
+            new HasFileContents('[8.3,8.4]'),
+            'if_not_empty must pass non-empty value through to format',
+        );
+    }
+
+    #[Test]
+    public function rendersEmptyWhenIfNotEmptyReceivesEmptyInput(): void
+    {
+        $config = new OverrideConfig(
+            new DefaultConfig(),
+            ['psalm.project.files' => []],
+        );
+
+        self::assertThat(
+            new ConfiguredFile(
+                new TextFile(
+                    'file',
+                    'before|<< config(psalm.project.files)|format_each("%s")|join(",")|if_not_empty() >>|after',
+                ),
+                $config,
+            ),
+            new HasFileContents('before||after'),
+            'if_not_empty must produce empty string for empty config list',
+        );
+    }
+
+    #[Test]
+    public function rendersContentWhenIfEmptyReceivesEmptyInput(): void
+    {
+        $config = new OverrideConfig(
+            new DefaultConfig(),
+            ['psalm.project.files' => []],
+        );
+
+        self::assertThat(
+            new ConfiguredFile(
+                new TextFile(
+                    'file',
+                    '<< config(psalm.project.files)|join(",")|if_empty()|format("none") >>',
+                ),
+                $config,
+            ),
+            new HasFileContents('none'),
+            'if_empty must pass empty value through to format',
+        );
+    }
+
+    #[Test]
+    public function rendersEmptyWhenIfEmptyReceivesNonEmptyInput(): void
+    {
+        $config = new OverrideConfig(
+            new DefaultConfig(),
+            ['php.versions' => ['8.3']],
+        );
+
+        self::assertThat(
+            new ConfiguredFile(
+                new TextFile(
+                    'file',
+                    'x<< config(php.versions)|join(",")|if_empty() >>y',
+                ),
+                $config,
+            ),
+            new HasFileContents('xy'),
+            'if_empty must produce empty string for non-empty config list',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenIfNotEmptyReceivesArguments(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new ConfiguredFile(
+            new TextFile(
+                'file',
+                '<< config(shellcheck.shell)|if_not_empty(something) >>',
+            ),
+            new OverrideConfig(new DefaultConfig(), []),
+        ))->contents();
+    }
+
+    #[Test]
+    public function throwsWhenIfEmptyReceivesArguments(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new ConfiguredFile(
+            new TextFile(
+                'file',
+                '<< config(shellcheck.shell)|if_empty(something) >>',
+            ),
+            new OverrideConfig(new DefaultConfig(), []),
+        ))->contents();
+    }
+
+    #[Test]
     public function preservesOriginMode(): void
     {
         $file = new ConfiguredFile(

--- a/tests/Unit/File/ConfiguredFileTest.php
+++ b/tests/Unit/File/ConfiguredFileTest.php
@@ -243,6 +243,7 @@ final class ConfiguredFileTest extends TestCase
     public function throwsWhenIfNotEmptyReceivesArguments(): void
     {
         $this->expectException(PiquleException::class);
+        $this->expectExceptionMessage('Action "if_not_empty" does not accept arguments');
 
         (new ConfiguredFile(
             new TextFile(
@@ -257,6 +258,7 @@ final class ConfiguredFileTest extends TestCase
     public function throwsWhenIfEmptyReceivesArguments(): void
     {
         $this->expectException(PiquleException::class);
+        $this->expectExceptionMessage('Action "if_empty" does not accept arguments');
 
         (new ConfiguredFile(
             new TextFile(

--- a/tests/Unit/Formula/Action/IfEmptyActionTest.php
+++ b/tests/Unit/Formula/Action/IfEmptyActionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Action;
+
+use Haspadar\Piqule\Formula\Action\IfEmptyAction;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsValues;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class IfEmptyActionTest extends TestCase
+{
+    #[Test]
+    public function passesEmptyListThrough(): void
+    {
+        self::assertThat(
+            (new IfEmptyAction())->transformed(new ListArgs([])),
+            new HasArgsValues([]),
+            'IfEmptyAction must pass empty list through unchanged',
+        );
+    }
+
+    #[Test]
+    public function passesSingleEmptyStringThrough(): void
+    {
+        self::assertThat(
+            (new IfEmptyAction())->transformed(new ListArgs([''])),
+            new HasArgsValues(['']),
+            'IfEmptyAction must pass single empty string through unchanged',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenInputIsNonEmpty(): void
+    {
+        self::assertThat(
+            (new IfEmptyAction())->transformed(new ListArgs(['hello'])),
+            new HasArgsValues([]),
+            'IfEmptyAction must return empty list for non-empty input',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenInputIsNumeric(): void
+    {
+        self::assertThat(
+            (new IfEmptyAction())->transformed(new ListArgs([42])),
+            new HasArgsValues([]),
+            'IfEmptyAction must return empty list for numeric input',
+        );
+    }
+}

--- a/tests/Unit/Formula/Action/IfEmptyActionTest.php
+++ b/tests/Unit/Formula/Action/IfEmptyActionTest.php
@@ -51,4 +51,24 @@ final class IfEmptyActionTest extends TestCase
             'IfEmptyAction must return empty list for numeric input',
         );
     }
+
+    #[Test]
+    public function returnsEmptyListWhenInputIsNumericZero(): void
+    {
+        self::assertThat(
+            (new IfEmptyAction())->transformed(new ListArgs([0])),
+            new HasArgsValues([]),
+            'IfEmptyAction must return empty list for numeric zero',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenInputIsBooleanFalse(): void
+    {
+        self::assertThat(
+            (new IfEmptyAction())->transformed(new ListArgs([false])),
+            new HasArgsValues([]),
+            'IfEmptyAction must return empty list for boolean false',
+        );
+    }
 }

--- a/tests/Unit/Formula/Action/IfNotEmptyActionTest.php
+++ b/tests/Unit/Formula/Action/IfNotEmptyActionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Action;
+
+use Haspadar\Piqule\Formula\Action\IfNotEmptyAction;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsValues;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class IfNotEmptyActionTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyListWhenInputIsEmpty(): void
+    {
+        self::assertThat(
+            (new IfNotEmptyAction())->transformed(new ListArgs([])),
+            new HasArgsValues([]),
+            'IfNotEmptyAction must return empty list for empty input',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenInputIsSingleEmptyString(): void
+    {
+        self::assertThat(
+            (new IfNotEmptyAction())->transformed(new ListArgs([''])),
+            new HasArgsValues([]),
+            'IfNotEmptyAction must return empty list for single empty string',
+        );
+    }
+
+    #[Test]
+    public function passesNonEmptyValueThrough(): void
+    {
+        self::assertThat(
+            (new IfNotEmptyAction())->transformed(new ListArgs(['hello'])),
+            new HasArgsValues(['hello']),
+            'IfNotEmptyAction must pass non-empty value through unchanged',
+        );
+    }
+
+    #[Test]
+    public function passesNumericValueThrough(): void
+    {
+        self::assertThat(
+            (new IfNotEmptyAction())->transformed(new ListArgs([0])),
+            new HasArgsValues([0]),
+            'IfNotEmptyAction must treat numeric zero as non-empty',
+        );
+    }
+
+    #[Test]
+    public function passesBooleanFalseThrough(): void
+    {
+        self::assertThat(
+            (new IfNotEmptyAction())->transformed(new ListArgs([false])),
+            new HasArgsValues([false]),
+            'IfNotEmptyAction must treat boolean false as non-empty',
+        );
+    }
+
+    #[Test]
+    public function passesMultipleValuesThrough(): void
+    {
+        self::assertThat(
+            (new IfNotEmptyAction())->transformed(new ListArgs(['a', 'b'])),
+            new HasArgsValues(['a', 'b']),
+            'IfNotEmptyAction must pass multiple values through unchanged',
+        );
+    }
+}

--- a/tests/Unit/Formula/Action/IfNotEmptyActionTest.php
+++ b/tests/Unit/Formula/Action/IfNotEmptyActionTest.php
@@ -71,4 +71,14 @@ final class IfNotEmptyActionTest extends TestCase
             'IfNotEmptyAction must pass multiple values through unchanged',
         );
     }
+
+    #[Test]
+    public function passesMultipleEmptyStringsThrough(): void
+    {
+        self::assertThat(
+            (new IfNotEmptyAction())->transformed(new ListArgs(['', ''])),
+            new HasArgsValues(['', '']),
+            'IfNotEmptyAction must treat multiple empty strings as non-empty',
+        );
+    }
 }


### PR DESCRIPTION
- Added `if_not_empty()` action to skip pipeline when input is empty list or single empty string
- Added `if_empty()` action as inverse guard to skip pipeline when input is present
- Updated ConfiguredFile to register both actions in the DSL pipeline

Closes #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two DSL actions for conditional placeholder replacement: if_empty (applies when input is empty) and if_not_empty (applies when input is non-empty).
  * Both actions trim and enforce that no arguments are provided; supplying an argument is rejected.

* **Tests**
  * Added comprehensive unit tests covering empty, non-empty, numeric, boolean and error cases for both actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->