### PR TITLE
Conditional Psalm Issue Handlers

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -103,6 +103,7 @@ defaults:
   psalm.project.directories: ["../../src"]
   psalm.project.files: []
   psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
+  psalm.suppress.possibly_unused: []
 
   infection.enabled: true
   infection.php_options: "-d memory_limit=1G"

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -28,6 +28,7 @@
                 <directory name="../../src" />
             </errorLevel>
         </UnusedClass>
+
         <UnresolvableInclude errorLevel="suppress">
             <errorLevel type="suppress">
                 <file name="../../bin/piqule" />

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -17,6 +17,14 @@ use Throwable;
  */
 final readonly class FormatAction implements Action
 {
+    /** @var array<string, string> */
+    private const array ESCAPE_REPLACEMENTS = [
+        '\\\\' => '\\',
+        '\\n' => "\n",
+        '\\r' => "\r",
+        '\\t' => "\t",
+    ];
+
     public function __construct(private string $raw) {}
 
     /** @throws PiquleException */
@@ -56,14 +64,6 @@ final readonly class FormatAction implements Action
 
     private function normalize(string $value): string
     {
-        return strtr(
-            $value,
-            [
-                '\\\\' => '\\',
-                '\\n' => "\n",
-                '\\r' => "\r",
-                '\\t' => "\t",
-            ],
-        );
+        return strtr($value, self::ESCAPE_REPLACEMENTS);
     }
 }

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -17,7 +17,6 @@ use Throwable;
  */
 final readonly class FormatAction implements Action
 {
-    /** @var array<string, string> */
     private const array ESCAPE_REPLACEMENTS = [
         '\\\\' => '\\',
         '\\n' => "\n",

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -26,9 +26,7 @@ final readonly class FormatAction implements Action
         $values = $args->values();
 
         if ($values === []) {
-            throw new PiquleException(
-                'Cannot format empty value',
-            );
+            return new ListArgs([]);
         }
 
         if (count($values) > 1) {
@@ -39,7 +37,7 @@ final readonly class FormatAction implements Action
 
         $templateArgs = new UnquotedArgs(new ListArgs([$this->raw]));
         $templateValues = $templateArgs->values();
-        $template = (string) ($templateValues[0] ?? '');
+        $template = $this->normalize((string) ($templateValues[0] ?? ''));
 
         $scalar = (new StringifiedArgs($args))->values()[0] ?? '';
 
@@ -54,5 +52,18 @@ final readonly class FormatAction implements Action
         }
 
         return new ListArgs([$result]);
+    }
+
+    private function normalize(string $value): string
+    {
+        return strtr(
+            $value,
+            [
+                '\\\\' => '\\',
+                '\\n' => "\n",
+                '\\r' => "\r",
+                '\\t' => "\t",
+            ],
+        );
     }
 }

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -103,6 +103,7 @@ defaults:
   psalm.project.directories: ["../../src"]
   psalm.project.files: []
   psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
+  psalm.suppress.possibly_unused: []
 
   infection.enabled: true
   infection.php_options: "-d memory_limit=1G"

--- a/templates/always/.piqule/psalm/psalm.xml
+++ b/templates/always/.piqule/psalm/psalm.xml
@@ -21,10 +21,7 @@
 << config(psalm.project.directories)|format_each('                <directory name="%s" />')|join("\n") >>
             </errorLevel>
         </UnusedClass>
-        <UnresolvableInclude errorLevel="suppress">
-            <errorLevel type="suppress">
-<< config(psalm.project.files)|format_each('                <file name="%s" />')|join("\n") >>
-            </errorLevel>
-        </UnresolvableInclude>
+<< config(psalm.suppress.possibly_unused)|format_each('                <directory name="%s" />')|join("\n")|if_not_empty()|format('        <PossiblyUnusedMethod errorLevel="suppress">\n            <errorLevel type="suppress">\n%s\n            </errorLevel>\n        </PossiblyUnusedMethod>') >>
+<< config(psalm.project.files)|format_each('                <file name="%s" />')|join("\n")|if_not_empty()|format('        <UnresolvableInclude errorLevel="suppress">\n            <errorLevel type="suppress">\n%s\n            </errorLevel>\n        </UnresolvableInclude>') >>
     </issueHandlers>
 </psalm>

--- a/tests/Unit/Formula/Action/FormatActionTest.php
+++ b/tests/Unit/Formula/Action/FormatActionTest.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Tests\Unit\Formula\Action;
 use Haspadar\Piqule\Formula\Action\FormatAction;
 use Haspadar\Piqule\Formula\Args\ListArgs;
 use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsValues;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -26,12 +27,13 @@ final class FormatActionTest extends TestCase
     }
 
     #[Test]
-    public function throwsWhenInputIsEmpty(): void
+    public function returnsEmptyListWhenInputIsEmpty(): void
     {
-        $this->expectException(PiquleException::class);
-
-        (new FormatAction('%s'))
-            ->transformed(new ListArgs([]));
+        self::assertThat(
+            (new FormatAction('%s'))->transformed(new ListArgs([])),
+            new HasArgsValues([]),
+            'FormatAction must pass empty list through unchanged',
+        );
     }
 
     #[Test]
@@ -41,6 +43,19 @@ final class FormatActionTest extends TestCase
 
         (new FormatAction('%s'))
             ->transformed(new ListArgs(['a', 'b']));
+    }
+
+    #[Test]
+    public function normalizesEscapeSequencesInTemplate(): void
+    {
+        $result = (new FormatAction('a\\n%s'))
+            ->transformed(new ListArgs(['b']));
+
+        self::assertSame(
+            ["a\nb"],
+            $result->values(),
+            'FormatAction must normalize \\n to real newline in template',
+        );
     }
 
     #[Test]

--- a/tests/Unit/Formula/Action/FormatActionTest.php
+++ b/tests/Unit/Formula/Action/FormatActionTest.php
@@ -46,7 +46,7 @@ final class FormatActionTest extends TestCase
     }
 
     #[Test]
-    public function normalizesEscapeSequencesInTemplate(): void
+    public function normalizesNewlineInTemplate(): void
     {
         $result = (new FormatAction('a\\n%s'))
             ->transformed(new ListArgs(['b']));
@@ -55,6 +55,45 @@ final class FormatActionTest extends TestCase
             ["a\nb"],
             $result->values(),
             'FormatAction must normalize \\n to real newline in template',
+        );
+    }
+
+    #[Test]
+    public function normalizesCarriageReturnInTemplate(): void
+    {
+        $result = (new FormatAction('a\\r%s'))
+            ->transformed(new ListArgs(['b']));
+
+        self::assertSame(
+            ["a\rb"],
+            $result->values(),
+            'FormatAction must normalize \\r to real carriage return in template',
+        );
+    }
+
+    #[Test]
+    public function normalizesTabInTemplate(): void
+    {
+        $result = (new FormatAction('a\\t%s'))
+            ->transformed(new ListArgs(['b']));
+
+        self::assertSame(
+            ["a\tb"],
+            $result->values(),
+            'FormatAction must normalize \\t to real tab in template',
+        );
+    }
+
+    #[Test]
+    public function normalizesEscapedBackslashInTemplate(): void
+    {
+        $result = (new FormatAction('a\\\\%s'))
+            ->transformed(new ListArgs(['b']));
+
+        self::assertSame(
+            ['a\\b'],
+            $result->values(),
+            'FormatAction must normalize \\\\\\\\ to single backslash in template',
         );
     }
 


### PR DESCRIPTION
- Added `psalm.suppress.possibly_unused` config key for optional PossiblyUnusedMethod suppression
- Updated Psalm template to render PossiblyUnusedMethod and UnresolvableInclude conditionally via `if_not_empty()`
- Updated `FormatAction` to pass empty input through instead of throwing, enabling conditional pipelines

Closes #485
Closes #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Formatting empty values no longer throws an error; now returns an empty result gracefully.

* **New Features**
  * Added escape sequence normalization in templates (`\n`, `\r`, `\t` now render correctly).

* **Chores**
  * Updated Psalm configuration defaults for enhanced code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->