### PR TITLE
No-Space Style for Declare Strict Types

### DIFF
--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -51,7 +51,7 @@ return (new PhpCsFixer\Config())
 
         // Strict types
         'declare_strict_types' => true,
-        'declare_equal_normalize' => ['space' => 'single'],
+        'declare_equal_normalize' => ['space' => 'none'],
 
         // Final & visibility
         'final_class' => true,

--- a/bin/bootstrap-autoload.php
+++ b/bin/bootstrap-autoload.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 $autoload = file_exists(__DIR__ . '/../vendor/autoload.php')
     ? __DIR__ . '/../vendor/autoload.php'

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 

--- a/src/Config/Dirs/Dirs.php
+++ b/src/Config/Dirs/Dirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 

--- a/src/Config/Dirs/GlobDirs.php
+++ b/src/Config/Dirs/GlobDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 

--- a/src/Config/Dirs/NegatedGlobDirs.php
+++ b/src/Config/Dirs/NegatedGlobDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 

--- a/src/Config/Dirs/ProjectDirs.php
+++ b/src/Config/Dirs/ProjectDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 

--- a/src/Config/Dirs/TrailingGlobDirs.php
+++ b/src/Config/Dirs/TrailingGlobDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 

--- a/src/Config/Dirs/TrailingSlashDirs.php
+++ b/src/Config/Dirs/TrailingSlashDirs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config\Dirs;
 

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 

--- a/src/Config/YamlPathKeys.php
+++ b/src/Config/YamlPathKeys.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 

--- a/src/File/ConfiguredFile.php
+++ b/src/File/ConfiguredFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/File/File.php
+++ b/src/File/File.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/File/PrefixedFile.php
+++ b/src/File/PrefixedFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/File/ReplacedFile.php
+++ b/src/File/ReplacedFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/File/TextFile.php
+++ b/src/File/TextFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\File;
 

--- a/src/Files/CombinedFiles.php
+++ b/src/Files/CombinedFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Files/EachFile.php
+++ b/src/Files/EachFile.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Files/Files.php
+++ b/src/Files/Files.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Files/FilteredFiles.php
+++ b/src/Files/FilteredFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Files/FolderFiles.php
+++ b/src/Files/FolderFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Files/MappedFiles.php
+++ b/src/Files/MappedFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Files/TextFiles.php
+++ b/src/Files/TextFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Files;
 

--- a/src/Formula/Action/Action.php
+++ b/src/Formula/Action/Action.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/ConfigAction.php
+++ b/src/Formula/Action/ConfigAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/FirstAction.php
+++ b/src/Formula/Action/FirstAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/FormatEachAction.php
+++ b/src/Formula/Action/FormatEachAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/IfEmptyAction.php
+++ b/src/Formula/Action/IfEmptyAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/IfNotEmptyAction.php
+++ b/src/Formula/Action/IfNotEmptyAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Action/JoinAction.php
+++ b/src/Formula/Action/JoinAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Action;
 

--- a/src/Formula/Actions/Actions.php
+++ b/src/Formula/Actions/Actions.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Actions;
 

--- a/src/Formula/Actions/ParsedActions.php
+++ b/src/Formula/Actions/ParsedActions.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Actions;
 

--- a/src/Formula/Args/Args.php
+++ b/src/Formula/Args/Args.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Args;
 

--- a/src/Formula/Args/ListArgs.php
+++ b/src/Formula/Args/ListArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Args;
 

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Args;
 

--- a/src/Formula/Args/StringifiedArgs.php
+++ b/src/Formula/Args/StringifiedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Args;
 

--- a/src/Formula/Args/TrimmedArgs.php
+++ b/src/Formula/Args/TrimmedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Args;
 

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula\Args;
 

--- a/src/Formula/ExecutedFormula.php
+++ b/src/Formula/ExecutedFormula.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula;
 

--- a/src/Formula/Formula.php
+++ b/src/Formula/Formula.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula;
 

--- a/src/Formula/NormalizedFormula.php
+++ b/src/Formula/NormalizedFormula.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Formula;
 

--- a/src/Output/Console.php
+++ b/src/Output/Console.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Output;
 

--- a/src/Output/Message.php
+++ b/src/Output/Message.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Output;
 

--- a/src/Output/Output.php
+++ b/src/Output/Output.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Output;
 

--- a/src/PiquleException.php
+++ b/src/PiquleException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule;
 

--- a/src/Runnable.php
+++ b/src/Runnable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule;
 

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Storage/InMemoryStorage.php
+++ b/src/Storage/InMemoryStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Storage/OnceStorage.php
+++ b/src/Storage/OnceStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Storage/Reaction/ReportingStorageReaction.php
+++ b/src/Storage/Reaction/ReportingStorageReaction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage\Reaction;
 

--- a/src/Storage/Reaction/StorageReaction.php
+++ b/src/Storage/Reaction/StorageReaction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage\Reaction;
 

--- a/src/Storage/Reaction/StorageReactions.php
+++ b/src/Storage/Reaction/StorageReactions.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage\Reaction;
 

--- a/src/Storage/SafePath.php
+++ b/src/Storage/SafePath.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Storage;
 

--- a/src/Token/CodecovToken.php
+++ b/src/Token/CodecovToken.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/src/Token/InfectionToken.php
+++ b/src/Token/InfectionToken.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/src/Token/Token.php
+++ b/src/Token/Token.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/src/Token/Tokens.php
+++ b/src/Token/Tokens.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Haspadar\Piqule\Token;
 

--- a/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -51,7 +51,7 @@ return (new PhpCsFixer\Config())
 
         // Strict types
         'declare_strict_types' => true,
-        'declare_equal_normalize' => ['space' => 'single'],
+        'declare_equal_normalize' => ['space' => 'none'],
 
         // Final & visibility
         'final_class' => true,


### PR DESCRIPTION
- Updated php-cs-fixer template to enforce no-space declare_equal_normalize
- Reformatted all source files to use declare(strict_types=1) without spaces

Closes #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized code formatting for PHP `declare(strict_types=1)` statements across the codebase by removing spaces around the equals sign.
  * Updated PHP-CS-Fixer configuration to enforce stricter spacing rules for `declare` statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->