### PR TITLE
Local SonarCloud Analysis via Sonar-Scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /.idea/
 /*.log
+/.scannerwork/

--- a/DEV.md
+++ b/DEV.md
@@ -107,6 +107,7 @@ Example:
 ### Supported actions
 
 - `config(key)` — loads a list of values from configuration
+- `first()` — extracts the first element from the list; empty input becomes `['']`
 - `format_each(template)` — formats each list item via `sprintf`
 - `join(delimiter)` — reduces the list to a single scalar value; supports escape sequences (`\n`, `\t`, `\r`, `\\`)
 - `if_not_empty()` — guard: empty input (`[]` or `['']`) becomes `[]`, non-empty passes through unchanged
@@ -119,6 +120,7 @@ The DSL operates in stages:
 
 1. `config(...)` produces a list of values
 2. List-level actions:
+   - `first` — picks the first element
    - `format_each`
 3. `join` reduces the list to a single value
 4. Conditional guards (optional, placed after `join`):
@@ -250,6 +252,38 @@ For a full description of every class and the decorator pattern, see [docs/archi
 3. Use the key in a template placeholder: `<< config(my.new.key) >>`
 
 Keys are flat dot-separated names. Accessing an undeclared key throws `PiquleException`.
+
+---
+
+## Tokens
+
+External services (Codecov, Stryker, SonarCloud) require GitHub Secrets for CI integration.
+
+`bin/piqule-tokens-check` verifies that required secrets exist in the repository. It queries `gh secret list` and prints a tip for each missing secret with a link to obtain one. Runs automatically after `piqule sync`, `piqule check` and `piqule fix`.
+
+If `gh` is not installed or not authenticated, the check is silently skipped.
+
+### Token Interface
+
+Each token implements `Token` (`src/Token/Token.php`):
+
+- `secret()` — GitHub Secret name (e.g. `CODECOV_TOKEN`)
+- `url(string $org)` — URL where the user can obtain the token
+- `enabled(Config $config)` — whether the token is needed based on config
+
+### Existing Tokens
+
+| Class | Secret | Enabled when |
+|-------|--------|-------------|
+| `CodecovToken` | `CODECOV_TOKEN` | `phpunit.enabled` is true |
+| `InfectionToken` | `STRYKER_DASHBOARD_API_KEY` | `infection.enabled` is true |
+| `SonarToken` | `SONAR_TOKEN` | `sonar.enabled` is true |
+
+### Adding a Token
+
+1. Create a class in `src/Token/` implementing `Token`
+2. Register it in `bin/piqule-tokens-check` inside the `Tokens` array
+3. Write unit tests
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ARG MARKDOWNLINT_VERSION=0.22.0
 ARG TYPOS_VERSION=1.45.0
 ARG SHELLCHECK_VERSION=0.11.0
 ARG JSONLINT_VERSION=17.0.1
+ARG SONAR_SCANNER_VERSION=8.0.1.6346
 
 FROM ${DEBIAN_IMAGE}
 
@@ -19,6 +20,7 @@ ARG MARKDOWNLINT_VERSION
 ARG TYPOS_VERSION
 ARG SHELLCHECK_VERSION
 ARG JSONLINT_VERSION
+ARG SONAR_SCANNER_VERSION
 
 LABEL org.opencontainers.image.title="Piqule Infra"
 LABEL org.opencontainers.image.description="Infrastructure linters for Piqule"
@@ -108,6 +110,22 @@ RUN set -eux; \
       "markdownlint-cli2@${MARKDOWNLINT_VERSION}" \
       "@prantlf/jsonlint@${JSONLINT_VERSION}"; \
     npm cache clean --force; \
+    \
+    # --------------------------------------------------------\
+    # SonarScanner CLI \
+    # --------------------------------------------------------\
+    SONAR_ARCH="$(uname -m | sed 's/x86_64/linux-x64/' | sed 's/aarch64/linux-aarch64/')"; \
+    curl -sSfL \
+      "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-${SONAR_ARCH}.zip" \
+      -o /tmp/sonar-scanner.zip; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends unzip; \
+    unzip -q /tmp/sonar-scanner.zip -d /opt; \
+    ln -s "/opt/sonar-scanner-${SONAR_SCANNER_VERSION}-${SONAR_ARCH}/bin/sonar-scanner" /usr/local/bin/sonar-scanner; \
+    rm /tmp/sonar-scanner.zip; \
+    apt-get purge -y unzip; \
+    apt-get autoremove -y; \
+    rm -rf /var/lib/apt/lists/*; \
     \
     # --------------------------------------------------------\
     # Non-root runtime \

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Do not edit `.piqule/` or the GitHub workflow file `.github/workflows/piqule.yml
 - PHPMD
 - PHP Metrics
 - PHP_CodeSniffer — with [Slevomat Coding Standard](https://github.com/slevomat/coding-standard) rules (class structure, doc comments, attributes)
-- PHP-CS-Fixer
+- PHP-CS-Fixer — with [kubawerlos/php-cs-fixer-custom-fixers](https://github.com/kubawerlos/php-cs-fixer-custom-fixers)
 - actionlint
 - hadolint
 - shellcheck
@@ -90,7 +90,7 @@ Do not edit `.piqule/` or the GitHub workflow file `.github/workflows/piqule.yml
 - jsonlint
 - yamllint
 - typos
-- SonarQube
+- SonarCloud — requires `SONAR_TOKEN` environment variable ([get token](https://sonarcloud.io/account/security))
 - Pull request size limit
 - Code coverage (Codecov)
 

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -64,6 +64,7 @@ $checks = [
     'php-cs-fixer',
     'phpunit',
     'infection',
+    'sonar',
 ];
 
 $isEnabled = static function(string $key) use ($config): bool {

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -9,6 +9,7 @@ use Haspadar\Piqule\Config\YamlConfig;
 use Haspadar\Piqule\Output\Console;
 use Haspadar\Piqule\Token\CodecovToken;
 use Haspadar\Piqule\Token\InfectionToken;
+use Haspadar\Piqule\Token\SonarToken;
 use Haspadar\Piqule\Token\Tokens;
 
 require_once __DIR__ . '/bootstrap-autoload.php';
@@ -48,6 +49,7 @@ if (file_exists($yamlPath)) {
 $tokens = new Tokens([
     new CodecovToken(),
     new InfectionToken(),
+    new SonarToken(),
 ]);
 
 $enabled = array_filter(

--- a/src/Token/CodecovToken.php
+++ b/src/Token/CodecovToken.php
@@ -36,6 +36,7 @@ final readonly class CodecovToken implements Token
         return filter_var(
             $config->list('phpunit.enabled')[0] ?? true,
             FILTER_VALIDATE_BOOLEAN,
-        );
+            FILTER_NULL_ON_FAILURE,
+        ) ?? true;
     }
 }

--- a/src/Token/CodecovToken.php
+++ b/src/Token/CodecovToken.php
@@ -29,7 +29,13 @@ final readonly class CodecovToken implements Token
     #[Override]
     public function enabled(Config $config): bool
     {
-        return !$config->has('phpunit.enabled')
-            || (bool) ($config->list('phpunit.enabled')[0] ?? true);
+        if (!$config->has('phpunit.enabled')) {
+            return true;
+        }
+
+        return filter_var(
+            $config->list('phpunit.enabled')[0] ?? true,
+            FILTER_VALIDATE_BOOLEAN,
+        );
     }
 }

--- a/src/Token/InfectionToken.php
+++ b/src/Token/InfectionToken.php
@@ -37,6 +37,7 @@ final readonly class InfectionToken implements Token
         return filter_var(
             $config->list('infection.enabled')[0] ?? true,
             FILTER_VALIDATE_BOOLEAN,
-        );
+            FILTER_NULL_ON_FAILURE,
+        ) ?? true;
     }
 }

--- a/src/Token/InfectionToken.php
+++ b/src/Token/InfectionToken.php
@@ -30,7 +30,13 @@ final readonly class InfectionToken implements Token
     #[Override]
     public function enabled(Config $config): bool
     {
-        return !$config->has('infection.enabled')
-            || (bool) ($config->list('infection.enabled')[0] ?? true);
+        if (!$config->has('infection.enabled')) {
+            return true;
+        }
+
+        return filter_var(
+            $config->list('infection.enabled')[0] ?? true,
+            FILTER_VALIDATE_BOOLEAN,
+        );
     }
 }

--- a/src/Token/SonarToken.php
+++ b/src/Token/SonarToken.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Token;
+
+use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\PiquleException;
+use Override;
+
+/**
+ * SonarCloud analysis token
+ */
+final readonly class SonarToken implements Token
+{
+    #[Override]
+    public function secret(): string
+    {
+        return 'SONAR_TOKEN';
+    }
+
+    #[Override]
+    public function url(string $org): string
+    {
+        return 'https://sonarcloud.io/account/security';
+    }
+
+    /** @throws PiquleException */
+    #[Override]
+    public function enabled(Config $config): bool
+    {
+        return !$config->has('sonar.enabled')
+            || (bool) ($config->list('sonar.enabled')[0] ?? true);
+    }
+}

--- a/src/Token/SonarToken.php
+++ b/src/Token/SonarToken.php
@@ -36,6 +36,7 @@ final readonly class SonarToken implements Token
         return filter_var(
             $config->list('sonar.enabled')[0] ?? true,
             FILTER_VALIDATE_BOOLEAN,
-        );
+            FILTER_NULL_ON_FAILURE,
+        ) ?? true;
     }
 }

--- a/src/Token/SonarToken.php
+++ b/src/Token/SonarToken.php
@@ -29,7 +29,13 @@ final readonly class SonarToken implements Token
     #[Override]
     public function enabled(Config $config): bool
     {
-        return !$config->has('sonar.enabled')
-            || (bool) ($config->list('sonar.enabled')[0] ?? true);
+        if (!$config->has('sonar.enabled')) {
+            return true;
+        }
+
+        return filter_var(
+            $config->list('sonar.enabled')[0] ?? true,
+            FILTER_VALIDATE_BOOLEAN,
+        );
     }
 }

--- a/templates/always/.piqule/sonar/command.sh
+++ b/templates/always/.piqule/sonar/command.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROPS=".piqule/sonar/sonar-project.properties"
+
+if [ ! -f "$PROPS" ]; then
+  echo "SonarCloud config not found: $PROPS" >&2
+  exit 1
+fi
+
+if [ -z "${SONAR_TOKEN:-}" ]; then
+  echo -e "\033[33m[TIP] Set SONAR_TOKEN to enable SonarCloud analysis\033[0m"
+  echo -e "\033[33m      Get token at: https://sonarcloud.io/account/security\033[0m"
+  echo -e "\033[33m      ● export SONAR_TOKEN=<your-token>     (bash/zsh)\033[0m"
+  echo -e "\033[33m      ● set -Ux SONAR_TOKEN <your-token>    (fish)\033[0m"
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is not installed or not in PATH" >&2
+  exit 1
+fi
+
+PROJECT_ROOT="$(pwd)"
+IMAGE="${PIQULE_INFRA_IMAGE:-<< config(docker.image) >>}"
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -e SONAR_TOKEN="$SONAR_TOKEN" \
+  -e HOME=/tmp \
+  -v "$PROJECT_ROOT:/project" \
+  -w /project \
+  "$IMAGE" \
+  sonar-scanner -Dproject.settings="$PROPS" -Dsonar.qualitygate.wait=true

--- a/templates/always/.piqule/sonar/sonar-project.properties
+++ b/templates/always/.piqule/sonar/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.organization=<< config(sonar.organization)|join(",") >>
+sonar.projectKey=<< config(sonar.projectKey)|join(",") >>
+sonar.sources=<< config(sonar.sources)|join(",") >>
+sonar.tests=<< config(sonar.tests)|join(",") >>
+sonar.exclusions=<< config(sonar.exclusions)|join(",") >>
+sonar.php.coverage.reportPaths=<< config(sonar.php.coverage.reportPaths)|join(",") >>

--- a/tests/Unit/Token/SonarTokenTest.php
+++ b/tests/Unit/Token/SonarTokenTest.php
@@ -52,6 +52,16 @@ final class SonarTokenTest extends TestCase
     }
 
     #[Test]
+    public function enabledWhenInvalidString(): void
+    {
+        self::assertSame(
+            true,
+            (new SonarToken())->enabled(new FakeConfig(['sonar.enabled' => ['tru']])),
+            'SonarToken must default to enabled when value is not a valid boolean string',
+        );
+    }
+
+    #[Test]
     public function returnsCorrectSecret(): void
     {
         self::assertSame(

--- a/tests/Unit/Token/SonarTokenTest.php
+++ b/tests/Unit/Token/SonarTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Token;
+
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use Haspadar\Piqule\Token\SonarToken;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SonarTokenTest extends TestCase
+{
+    #[Test]
+    public function enabledWhenSonarEnabled(): void
+    {
+        self::assertSame(
+            true,
+            (new SonarToken())->enabled(new FakeConfig(['sonar.enabled' => [true]])),
+            'SonarToken must be enabled when sonar.enabled is true',
+        );
+    }
+
+    #[Test]
+    public function enabledWhenKeyAbsent(): void
+    {
+        self::assertSame(
+            true,
+            (new SonarToken())->enabled(new FakeConfig([])),
+            'SonarToken must be enabled when sonar.enabled key is absent',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenSonarDisabled(): void
+    {
+        self::assertSame(
+            false,
+            (new SonarToken())->enabled(new FakeConfig(['sonar.enabled' => [false]])),
+            'SonarToken must be disabled when sonar.enabled is false',
+        );
+    }
+
+    #[Test]
+    public function returnsCorrectSecret(): void
+    {
+        self::assertSame(
+            'SONAR_TOKEN',
+            (new SonarToken())->secret(),
+            'SonarToken secret must be SONAR_TOKEN',
+        );
+    }
+
+    #[Test]
+    public function returnsUrl(): void
+    {
+        self::assertSame(
+            'https://sonarcloud.io/account/security',
+            (new SonarToken())->url('acme'),
+            'SonarToken url must point to SonarCloud security page',
+        );
+    }
+}

--- a/tests/Unit/Token/SonarTokenTest.php
+++ b/tests/Unit/Token/SonarTokenTest.php
@@ -42,6 +42,16 @@ final class SonarTokenTest extends TestCase
     }
 
     #[Test]
+    public function disabledWhenSonarDisabledAsString(): void
+    {
+        self::assertSame(
+            false,
+            (new SonarToken())->enabled(new FakeConfig(['sonar.enabled' => ['false']])),
+            'SonarToken must be disabled when sonar.enabled is string "false"',
+        );
+    }
+
+    #[Test]
     public function returnsCorrectSecret(): void
     {
         self::assertSame(


### PR DESCRIPTION
- Added sonar check to run SonarCloud analysis locally via piqule check sonar
- Added SonarToken to verify SONAR_TOKEN GitHub secret via piqule-tokens-check
- Added sonar-scanner CLI to piqule-infra Docker image
- Updated DEV.md and README.md with sonar token and check documentation

Closes #491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SonarCloud analysis support and integrated Sonar into checks and token verification

* **Documentation**
  * Added DSL list action `first()` and updated Tokens/Checks and README references for SonarCloud and PHP-CS-Fixer

* **Chores**
  * Enabled SonarScanner in the build image, added Sonar project templates, and ignored scanner output directory

* **Tests**
  * Added unit tests for Sonar token behavior

* **Bug Fixes**
  * Improved token enablement parsing to default-enable when unset and handle boolean-like strings robustly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->