### PR TITLE
Auto-Generate Coverage Report for SonarCloud Analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 /*.log
 /.scannerwork/
+/.piqule/codecov/

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -37,7 +37,7 @@ fi
 
 COVERAGE_FILE=".piqule/codecov/coverage.xml"
 
-if php -m 2>/dev/null | grep -qi xdebug; then
+if php -r 'exit(extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
   mkdir -p "$(dirname "$COVERAGE_FILE")"
   ARGS+=(--coverage-clover="$COVERAGE_FILE")
   XDEBUG_MODE=coverage

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -35,5 +35,16 @@ if [ -n "$SEED" ]; then
   ARGS+=(--random-order-seed="$SEED")
 fi
 
+COVERAGE_FILE=".piqule/codecov/coverage.xml"
+
+if php -m 2>/dev/null | grep -qi xdebug; then
+  mkdir -p "$(dirname "$COVERAGE_FILE")"
+  ARGS+=(--coverage-clover="$COVERAGE_FILE")
+  XDEBUG_MODE=coverage
+else
+  XDEBUG_MODE=off
+fi
+
 PHP_OPTIONS="<< config(phpunit.php_options) >>"
+export XDEBUG_MODE
 php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"

--- a/templates/always/.piqule/sonar/command.sh
+++ b/templates/always/.piqule/sonar/command.sh
@@ -9,16 +9,24 @@ if [ ! -f "$PROPS" ]; then
 fi
 
 if [ -z "${SONAR_TOKEN:-}" ]; then
-  echo -e "\033[33m[TIP] Set SONAR_TOKEN to enable SonarCloud analysis\033[0m"
-  echo -e "\033[33m      Get token at: https://sonarcloud.io/account/security\033[0m"
-  echo -e "\033[33m      ● export SONAR_TOKEN=<your-token>     (bash/zsh)\033[0m"
-  echo -e "\033[33m      ● set -Ux SONAR_TOKEN <your-token>    (fish)\033[0m"
+  printf '\033[33m[TIP] Set SONAR_TOKEN to enable SonarCloud analysis\033[0m\n'
+  printf '\033[33m      Get token at: https://sonarcloud.io/account/security\033[0m\n'
+  printf '\033[33m      ● export SONAR_TOKEN=<your-token>     (bash/zsh)\033[0m\n'
+  printf '\033[33m      ● set -Ux SONAR_TOKEN <your-token>    (fish)\033[0m\n'
   exit 0
 fi
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "Error: docker is not installed or not in PATH" >&2
   exit 1
+fi
+
+COVERAGE_FILE=".piqule/codecov/coverage.xml"
+if [ -f "$COVERAGE_FILE" ]; then
+  sed "s|$(pwd)/||g" "$COVERAGE_FILE" > "${COVERAGE_FILE}.tmp" \
+    && mv "${COVERAGE_FILE}.tmp" "$COVERAGE_FILE"
+else
+  printf '\033[33m[TIP] Run piqule check phpunit first to include coverage in SonarCloud analysis\033[0m\n'
 fi
 
 PROJECT_ROOT="$(pwd)"

--- a/templates/always/.piqule/sonar/command.sh
+++ b/templates/always/.piqule/sonar/command.sh
@@ -23,7 +23,8 @@ fi
 
 COVERAGE_FILE=".piqule/codecov/coverage.xml"
 if [ -f "$COVERAGE_FILE" ]; then
-  sed "s|$(pwd)/||g" "$COVERAGE_FILE" > "${COVERAGE_FILE}.tmp" \
+  ESCAPED_PWD=$(printf '%s' "$(pwd)" | sed 's/[&/\]/\\&/g')
+  sed "s|${ESCAPED_PWD}/||g" "$COVERAGE_FILE" > "${COVERAGE_FILE}.tmp" \
     && mv "${COVERAGE_FILE}.tmp" "$COVERAGE_FILE"
 else
   printf '\033[33m[TIP] Run piqule check phpunit first to include coverage in SonarCloud analysis\033[0m\n'


### PR DESCRIPTION
- Added automatic Clover XML coverage generation in phpunit command when Xdebug is available
- Added absolute-to-relative path conversion in sonar command for Docker compatibility
- Updated .gitignore to exclude generated coverage directory

Closes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test coverage collection: runtime detection and automatic coverage mode configuration for PHP tests, plus a fixed coverage output location.
  * Enhanced code quality scan prep: normalizes coverage file paths before analysis and provides clearer guidance when coverage is missing.
  * Updated version control exclusions to ignore generated coverage artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->