### PR TITLE
Fast and Full Check Groups

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -14,6 +14,9 @@ defaults:
   exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
 
+  check.default: "fast"
+  check.slow: ["infection", "sonar"]
+
   ci.piqule_bin: "vendor/bin/piqule"
   ci.pr.max_lines_changed: 250
 

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -35,5 +35,16 @@ if [ -n "$SEED" ]; then
   ARGS+=(--random-order-seed="$SEED")
 fi
 
+COVERAGE_FILE=".piqule/codecov/coverage.xml"
+
+if php -r 'exit(extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
+  mkdir -p "$(dirname "$COVERAGE_FILE")"
+  ARGS+=(--coverage-clover="$COVERAGE_FILE")
+  XDEBUG_MODE=coverage
+else
+  XDEBUG_MODE=off
+fi
+
 PHP_OPTIONS="-d memory_limit=1G"
+export XDEBUG_MODE
 php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"

--- a/DEV.md
+++ b/DEV.md
@@ -299,6 +299,13 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | `exclude` | `["vendor", "tests", ".git"]` | Excluded directories — cascades to all tools |
 | `php.versions` | `["8.3"]` | PHP versions for CI matrix |
 
+### Check Groups
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `check.default` | `"fast"` | Default group for `piqule check` without arguments (`fast` or `full`) |
+| `check.slow` | `["infection", "sonar"]` | Checks excluded from `fast` group |
+
 ### CI
 
 | Key | Default | Description |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Do not edit `.piqule/` or the GitHub workflow file `.github/workflows/piqule.yml
 ## Commands
 
 - `piqule sync` — generate configuration from templates
-- `piqule check` — run all checks
+- `piqule check` — run checks using default group (`check.default`, defaults to `fast`)
+- `piqule check fast` — run all checks except slow ones (`check.slow`: infection, sonar)
+- `piqule check full` — run all checks including slow ones
 - `piqule check <tool>` — run specific tool
 - `piqule fix` — run auto-fixable tools
 - `piqule fix <tool>` — run specific fixer

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -67,10 +67,9 @@ $checks = [
     'sonar',
 ];
 
-/** @var list<string> $slowChecks */
 $slowChecks = array_map(
     'strval',
-    (array)($config->list('check.slow')),
+    $config->list('check.slow'),
 );
 
 $groups = ['fast', 'full'];

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -77,6 +77,11 @@ $groups = ['fast', 'full'];
 if ($requested === '' || in_array($requested, $groups, true)) {
     $group = $requested !== '' ? $requested : (string)($config->list('check.default')[0] ?? 'fast');
 
+    if (!in_array($group, $groups, true)) {
+        fwrite(STDERR, "Invalid check.default value: {$group}. Must be one of: " . implode(', ', $groups) . "\n");
+        exit(1);
+    }
+
     if ($group === 'fast') {
         $checks = array_values(
             array_filter(

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -67,6 +67,29 @@ $checks = [
     'sonar',
 ];
 
+/** @var list<string> $slowChecks */
+$slowChecks = array_map(
+    'strval',
+    (array)($config->list('check.slow')),
+);
+
+$groups = ['fast', 'full'];
+
+if ($requested === '' || in_array($requested, $groups, true)) {
+    $group = $requested !== '' ? $requested : (string)($config->list('check.default')[0] ?? 'fast');
+
+    if ($group === 'fast') {
+        $checks = array_values(
+            array_filter(
+                $checks,
+                static fn(string $key): bool => !in_array($key, $slowChecks, true),
+            ),
+        );
+    }
+
+    $requested = '';
+}
+
 $isEnabled = static function(string $key) use ($config): bool {
     $enabledKey = "{$key}.enabled";
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -14,6 +14,9 @@ defaults:
   exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
 
+  check.default: "fast"
+  check.slow: ["infection", "sonar"]
+
   ci.piqule_bin: "vendor/bin/piqule"
   ci.pr.max_lines_changed: 250
 

--- a/templates/git/hooks/pre-push-piqule
+++ b/templates/git/hooks/pre-push-piqule
@@ -2,12 +2,12 @@
 set -e
 
 if [ -x "vendor/bin/piqule" ]; then
-  vendor/bin/piqule check
+  vendor/bin/piqule check full
   exit $?
 fi
 
 if command -v composer >/dev/null 2>&1; then
-  composer exec -- piqule check
+  composer exec -- piqule check full
   exit $?
 fi
 


### PR DESCRIPTION
- Added `check.default` and `check.slow` config keys to split checks into fast and full groups
- Updated pre-push hook to run full checks explicitly
- Updated generated files after coverage template merge

Closes #493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added check groups: `piqule check fast` (default) excludes slow checks; `piqule check full` runs all checks.
  * New default settings: default group set to `fast` and slow checks include `infection` and `sonar`.
  * PHPUnit now enables code-coverage reporting when Xdebug is available.
  * Pre-push hook now runs full checks by default.

* **Documentation**
  * Updated docs to describe group-based check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->