### PR TITLE
Auto-Update Infra Image Digest After Build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           NEW_DIGEST="${{ steps.build.outputs.digest }}"
           CONFIG="templates/always/.piqule/config.yaml"
-          OLD_DIGEST=$(grep -o 'sha256:[a-f0-9]*' "$CONFIG")
+          OLD_DIGEST=$(grep -o 'sha256:[a-f0-9]*' "$CONFIG" | head -1)
           if [ "$OLD_DIGEST" != "$NEW_DIGEST" ]; then
             sed -i "s|$OLD_DIGEST|$NEW_DIGEST|" "$CONFIG"
             git config user.name "github-actions[bot]"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -38,9 +38,27 @@ jobs:
       # Build and push infra image
       # ------------------------------------------------------------
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+        id: build
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/piqule-infra:latest
+
+      # ------------------------------------------------------------
+      # Update pinned digest in config template when image changes
+      # ------------------------------------------------------------
+      - name: Update image digest in config
+        run: |
+          NEW_DIGEST="${{ steps.build.outputs.digest }}"
+          CONFIG="templates/always/.piqule/config.yaml"
+          OLD_DIGEST=$(grep -o 'sha256:[a-f0-9]*' "$CONFIG")
+          if [ "$OLD_DIGEST" != "$NEW_DIGEST" ]; then
+            sed -i "s|$OLD_DIGEST|$NEW_DIGEST|" "$CONFIG"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add "$CONFIG"
+            git commit -m "Update infra image digest to ${NEW_DIGEST:0:19} [skip ci]"
+            git push
+          fi

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -62,6 +62,14 @@ jobs:
             ".piqule/_docker.sh"
           )
           OLD_DIGEST=$(grep -o 'sha256:[a-f0-9]*' "${FILES[0]}" | head -1)
+          if [ -z "$OLD_DIGEST" ]; then
+            echo "::error::Could not extract existing digest from ${FILES[0]}"
+            exit 1
+          fi
+          if [ -z "$NEW_DIGEST" ]; then
+            echo "::error::Build step did not produce a digest"
+            exit 1
+          fi
           if [ "$OLD_DIGEST" != "$NEW_DIGEST" ]; then
             for file in "${FILES[@]}"; do
               sed -i "s|$OLD_DIGEST|$NEW_DIGEST|" "$file"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write
@@ -52,13 +56,19 @@ jobs:
       - name: Update image digest in config
         run: |
           NEW_DIGEST="${{ steps.build.outputs.digest }}"
-          CONFIG="templates/always/.piqule/config.yaml"
-          OLD_DIGEST=$(grep -o 'sha256:[a-f0-9]*' "$CONFIG" | head -1)
+          FILES=(
+            "templates/always/.piqule/config.yaml"
+            ".piqule/config.yaml"
+            ".piqule/_docker.sh"
+          )
+          OLD_DIGEST=$(grep -o 'sha256:[a-f0-9]*' "${FILES[0]}" | head -1)
           if [ "$OLD_DIGEST" != "$NEW_DIGEST" ]; then
-            sed -i "s|$OLD_DIGEST|$NEW_DIGEST|" "$CONFIG"
+            for file in "${FILES[@]}"; do
+              sed -i "s|$OLD_DIGEST|$NEW_DIGEST|" "$file"
+            done
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add "$CONFIG"
+            git add "${FILES[@]}"
             git commit -m "Update infra image digest to ${NEW_DIGEST:0:19} [skip ci]"
             git push
           fi

--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:a7d41e9fef08156778df6f9172145970a617962bee9e17f1484ebc9b41f6ac29}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:7b22c9bd07f39b7f2848af9b92eadf3bcf5bc69256766d574099eab24c0adfe8}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -25,7 +25,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:a7d41e9fef08156778df6f9172145970a617962bee9e17f1484ebc9b41f6ac29"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7b22c9bd07f39b7f2848af9b92eadf3bcf5bc69256766d574099eab24c0adfe8"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -25,7 +25,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:a7d41e9fef08156778df6f9172145970a617962bee9e17f1484ebc9b41f6ac29"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7b22c9bd07f39b7f2848af9b92eadf3bcf5bc69256766d574099eab24c0adfe8"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
- Updated pinned infra image digest to include sonar-scanner
- Added auto-commit step in build-image workflow to update digest when image changes

Closes #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow improved: concurrent runs cancel duplicates and workflow permissions tightened; build now exposes image digest and will auto-update pinned image digests when they change, committing the updated references to the repository to keep tooling images current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->