### PR TITLE
Ensure dependencies label exists before creating digest PR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -83,6 +83,7 @@ jobs:
             git add "${FILES[@]}"
             git commit -m "Update infra image digest to ${NEW_DIGEST:0:19}"
             git push -u origin "$BRANCH"
+            gh label create "dependencies" --color 0075ca 2>/dev/null || true
             PR_URL=$(gh pr create \
               --base main \
               --head "$BRANCH" \


### PR DESCRIPTION
## Summary

- Prevent `gh pr create --label dependencies` from failing if the label doesn't exist yet

## Test plan

- [ ] Verify `gh label create` is idempotent (exits 0 when label already exists)
- [ ] Verify digest PR creation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated digest update workflow to enhance label management during pull request creation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->