### PR TITLE
#504: Parallel check execution with --full flag and timing

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -14,7 +14,8 @@ defaults:
   exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
 
-  check.default: "fast"
+  check.full: false
+  check.parallel: true
   check.slow: ["infection", "sonar"]
 
   ci.piqule_bin: "vendor/bin/piqule"

--- a/DEV.md
+++ b/DEV.md
@@ -303,9 +303,9 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `check.default` | `"fast"` | Default group for `piqule check` without arguments (`fast` or `full`) |
+| `check.full` | `false` | Include slow checks by default (`-f`/`--full` to force, `-F`/`--no-full` to disable) |
 | `check.parallel` | `true` | Run checks concurrently by default (`-p`/`--parallel` to force, `-P`/`--no-parallel` to disable) |
-| `check.slow` | `["infection", "sonar"]` | Checks excluded from `fast` group |
+| `check.slow` | `["infection", "sonar"]` | Checks excluded unless `--full` is passed or `check.full` is `true` |
 
 ### CI
 

--- a/DEV.md
+++ b/DEV.md
@@ -259,7 +259,7 @@ Keys are flat dot-separated names. Accessing an undeclared key throws `PiquleExc
 
 External services (Codecov, Stryker, SonarCloud) require GitHub Secrets for CI integration.
 
-`bin/piqule-tokens-check` verifies that required secrets exist in the repository. It queries `gh secret list` and prints a tip for each missing secret with a link to obtain one. Runs automatically after `piqule sync`, `piqule check` and `piqule fix`.
+`bin/piqule-tokens-check` verifies that required secrets exist in the repository. It queries `gh secret list` and prints a tip for each missing secret with a link to obtain one. Tokens available as local environment variables are not reported as missing. Runs automatically after `piqule sync`, `piqule check` and `piqule fix`.
 
 If `gh` is not installed or not authenticated, the check is silently skipped.
 
@@ -304,6 +304,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | Key | Default | Description |
 |-----|---------|-------------|
 | `check.default` | `"fast"` | Default group for `piqule check` without arguments (`fast` or `full`) |
+| `check.parallel` | `true` | Run checks concurrently by default (`-p`/`--parallel` to force, `-P`/`--no-parallel` to disable) |
 | `check.slow` | `["infection", "sonar"]` | Checks excluded from `fast` group |
 
 ### CI

--- a/DEV.md
+++ b/DEV.md
@@ -259,7 +259,7 @@ Keys are flat dot-separated names. Accessing an undeclared key throws `PiquleExc
 
 External services (Codecov, Stryker, SonarCloud) require GitHub Secrets for CI integration.
 
-`bin/piqule-tokens-check` verifies that required secrets exist in the repository. It queries `gh secret list` and prints a tip for each missing secret with a link to obtain one. Tokens available as local environment variables are not reported as missing. Runs automatically after `piqule sync`, `piqule check` and `piqule fix`.
+`bin/piqule-tokens-check` verifies that required secrets exist in the repository. It queries `gh secret list` and prints a tip for each missing secret with a link to obtain one. Tokens available as non-empty local environment variables are not reported as missing (empty values like `SONAR_TOKEN=` are still flagged). Runs automatically after `piqule sync`, `piqule check` and `piqule fix`.
 
 If `gh` is not installed or not authenticated, the check is silently skipped.
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Do not edit `.piqule/` or the GitHub workflow file `.github/workflows/piqule.yml
 ## Commands
 
 - `piqule sync` — generate configuration from templates
-- `piqule check` — run checks using default group (`check.default`, defaults to `fast`)
-- `piqule check fast` — run all checks except slow ones (`check.slow`: infection, sonar)
-- `piqule check full` — run all checks including slow ones
+- `piqule check` — run all checks except slow ones (`check.slow`: infection, sonar)
 - `piqule check <tool>` — run specific tool
+- `-f`, `--full` — include slow checks (default: `check.full`)
+- `-F`, `--no-full` — exclude slow checks
 - `-p`, `--parallel` — run checks concurrently (default: `check.parallel`)
 - `-P`, `--no-parallel` — force sequential execution
 - `-v`, `--verbose` — show full output from each check

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Do not edit `.piqule/` or the GitHub workflow file `.github/workflows/piqule.yml
 ## Commands
 
 - `piqule sync` — generate configuration from templates
-- `piqule check` — run all checks except slow ones (`check.slow`: infection, sonar)
+- `piqule check` — run checks, excluding slow ones by default (`check.slow`: infection, sonar)
 - `piqule check <tool>` — run specific tool
 - `-f`, `--full` — include slow checks (default: `check.full`)
 - `-F`, `--no-full` — exclude slow checks

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Do not edit `.piqule/` or the GitHub workflow file `.github/workflows/piqule.yml
 - `piqule check fast` — run all checks except slow ones (`check.slow`: infection, sonar)
 - `piqule check full` — run all checks including slow ones
 - `piqule check <tool>` — run specific tool
+- `-p`, `--parallel` — run checks concurrently (default: `check.parallel`)
+- `-P`, `--no-parallel` — force sequential execution
+- `-v`, `--verbose` — show full output from each check
 - `piqule fix` — run auto-fixable tools
 - `piqule fix <tool>` — run specific fixer
 

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -349,3 +349,4 @@ if ($failed) {
 }
 
 echo "\n" . ($green)(sprintf('[OK]   %-' . $titleWidth . 's', 'All checks passed')) . ($green)($totalElapsed) . "\n";
+exit(0);

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -199,10 +199,12 @@ if (!$parallel) {
     exit(0);
 }
 
-$runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $gray, &$current): ?array {
+$runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $red, $gray, &$current): ?array {
     $command = "{$projectRoot}/.piqule/{$key}/command.sh";
 
     if (!file_exists($command)) {
+        echo ($red)("Unknown check: {$key}") . "\n";
+
         return null;
     }
 
@@ -218,6 +220,8 @@ $runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $gr
     $stderr = tmpfile();
 
     if ($stdout === false || $stderr === false) {
+        echo ($red)("Failed to create temp files for: {$key}") . "\n";
+
         return null;
     }
 
@@ -228,15 +232,34 @@ $runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $gr
     );
 
     if (!is_resource($proc)) {
+        echo ($red)("Failed to start: {$key}") . "\n";
+
         return null;
     }
 
     return ['proc' => $proc, 'stdout' => $stdout, 'stderr' => $stderr, 'key' => $key, 'start' => microtime(true), 'num' => $current];
 };
 
-$running = [];
+$dependsOn = [
+    'sonar' => ['phpunit'],
+    'infection' => ['phpunit'],
+];
+
+$independent = [];
+$dependent = [];
 
 foreach ($checks as $key) {
+    if (array_key_exists($key, $dependsOn)) {
+        $dependent[$key] = $dependsOn[$key];
+    } else {
+        $independent[] = $key;
+    }
+}
+
+$running = [];
+$failed = false;
+
+foreach ($independent as $key) {
     $handle = $runCheckAsync($key);
 
     if ($handle !== null) {
@@ -245,57 +268,76 @@ foreach ($checks as $key) {
     }
 }
 
-$failed = false;
-$pending = $running;
+$awaitAll = static function(array $handles) use ($green, $red, $formatTime, $titleWidth, $verbose, &$failed): void {
+    /** @var array<int, array{proc: resource, stdout: resource, stderr: resource, key: string, start: float, num: int}> $pending */
+    $pending = $handles;
 
-while ($pending !== []) {
-    foreach ($pending as $i => $handle) {
-        $info = proc_get_status($handle['proc']);
+    while ($pending !== []) {
+        foreach ($pending as $i => $handle) {
+            $info = proc_get_status($handle['proc']);
 
-        if ($info['running']) {
-            continue;
-        }
-
-        $elapsed = sprintf('%5s', $formatTime(microtime(true) - $handle['start']));
-        $status = $info['exitcode'];
-
-        if ($status === -1) {
-            $status = proc_close($handle['proc']);
-        } else {
-            proc_close($handle['proc']);
-        }
-
-        rewind($handle['stdout']);
-        $out = stream_get_contents($handle['stdout']);
-        fclose($handle['stdout']);
-
-        rewind($handle['stderr']);
-        $err = stream_get_contents($handle['stderr']);
-        fclose($handle['stderr']);
-
-        if ($status !== 0 || $verbose) {
-            if ($out !== '' && $out !== false) {
-                echo $out;
+            if ($info['running']) {
+                continue;
             }
 
-            if ($err !== '' && $err !== false) {
-                fwrite(STDERR, $err);
+            $elapsed = sprintf('%5s', $formatTime(microtime(true) - $handle['start']));
+            $status = $info['exitcode'];
+
+            if ($status === -1) {
+                $status = proc_close($handle['proc']);
+            } else {
+                proc_close($handle['proc']);
             }
+
+            rewind($handle['stdout']);
+            $out = stream_get_contents($handle['stdout']);
+            fclose($handle['stdout']);
+
+            rewind($handle['stderr']);
+            $err = stream_get_contents($handle['stderr']);
+            fclose($handle['stderr']);
+
+            if ($status !== 0 || $verbose) {
+                if ($out !== '' && $out !== false) {
+                    echo $out;
+                }
+
+                if ($err !== '' && $err !== false) {
+                    fwrite(STDERR, $err);
+                }
+            }
+
+            if ($status !== 0) {
+                echo ($red)(sprintf('[FAIL] %-' . $titleWidth . 's', $handle['key'])) . ($red)($elapsed) . "\n";
+                $failed = true;
+            } else {
+                echo ($green)(sprintf('[OK]   %-' . $titleWidth . 's', $handle['key'])) . ($green)($elapsed) . "\n";
+            }
+
+            unset($pending[$i]);
         }
 
-        if ($status !== 0) {
-            echo ($red)(sprintf('[FAIL] %-' . $titleWidth . 's', $handle['key'])) . ($red)($elapsed) . "\n";
-            $failed = true;
-        } else {
-            echo ($green)(sprintf('[OK]   %-' . $titleWidth . 's', $handle['key'])) . ($green)($elapsed) . "\n";
+        if ($pending !== []) {
+            usleep(50000);
         }
+    }
+};
 
-        unset($pending[$i]);
+$awaitAll($running);
+
+if (!$failed && $dependent !== []) {
+    $depRunning = [];
+
+    foreach (array_keys($dependent) as $key) {
+        $handle = $runCheckAsync($key);
+
+        if ($handle !== null) {
+            echo ($gray)(sprintf('[RUN]  %-' . $titleWidth . 's', $key)) . ($gray)(sprintf('%5s', "{$handle['num']}/{$total}")) . "\n";
+            $depRunning[] = $handle;
+        }
     }
 
-    if ($pending !== []) {
-        usleep(50000);
-    }
+    $awaitAll($depRunning);
 }
 
 $totalElapsed = sprintf('%5s', $formatTime(microtime(true) - $totalStart));

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -46,7 +46,18 @@ if (file_exists($yamlPath)) {
     $config = $defaults;
 }
 
-$requested = $argv[1] ?? '';
+$flags = ['-v', '--verbose', '-p', '--parallel', '-P', '--no-parallel'];
+$verbose = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
+$parallelFlag = in_array('-p', $argv, true) || in_array('--parallel', $argv, true);
+$noParallelFlag = in_array('-P', $argv, true) || in_array('--no-parallel', $argv, true);
+$parallelDefault = filter_var(
+    $config->list('check.parallel')[0] ?? false,
+    FILTER_VALIDATE_BOOLEAN,
+    FILTER_NULL_ON_FAILURE,
+) ?? false;
+$parallel = $noParallelFlag ? false : ($parallelFlag || $parallelDefault);
+$args = array_values(array_filter($argv, static fn(string $a): bool => !in_array($a, $flags, true)));
+$requested = $args[1] ?? '';
 
 $checks = [
     'actionlint',
@@ -105,45 +116,69 @@ $total = $requested !== ''
     : count(array_filter($checks, $isEnabled));
 $current = 0;
 
-$green = static fn(string $s): string => "\033[32m{$s}\033[0m\n";
-$blue = static fn(string $s): string => "\033[34m{$s}\033[0m\n";
-$red = static fn(string $s): string => "\033[31m{$s}\033[0m\n";
+$titleWidth = 20;
+$green = static fn(string $s): string => "\033[32m{$s}\033[0m";
+$red = static fn(string $s): string => "\033[31m{$s}\033[0m";
+$gray = static fn(string $s): string => "\033[90m{$s}\033[0m";
+$formatTime = static function(float $seconds): string {
+    if ($seconds < 60) {
+        return sprintf('%.1fs', $seconds);
+    }
 
-$runCheck = static function(string $key) use ($projectRoot, $isEnabled, $green, $blue, $red, $total, &$current,): bool {
+    $total = (int)$seconds;
+
+    return sprintf('%dm%02ds', intdiv($total, 60), $total % 60);
+};
+
+$totalStart = microtime(true);
+
+$runCheck = static function(string $key) use ($projectRoot, $isEnabled, $green, $red, $gray, $formatTime, $titleWidth, $total, &$current, $verbose): bool {
     $command = "{$projectRoot}/.piqule/{$key}/command.sh";
 
     if (!file_exists($command)) {
-        echo ($red)("Unknown check: {$key}");
+        echo ($red)("Unknown check: {$key}") . "\n";
 
         return false;
     }
 
     if (!$isEnabled($key)) {
-        echo ($blue)("[SKIP] {$key}");
+        echo ($gray)("[SKIP] {$key}") . "\n";
 
         return true;
     }
 
     $current++;
 
-    $titleWidth = 18;
-
     if ($total > 1) {
-        echo ($blue)(sprintf('[RUN]  %-' . $titleWidth . 's (%d/%d)', $key, $current, $total));
+        echo ($gray)(sprintf('[RUN]  %-' . $titleWidth . 's', $key)) . ($gray)(sprintf('%5s', "{$current}/{$total}")) . "\n";
     } else {
-        echo ($blue)("[RUN]  {$key}");
+        echo ($gray)("[RUN]  {$key}") . "\n";
     }
 
-    passthru('bash ' . escapeshellarg($command), $status);
+    $output = [];
+    $start = microtime(true);
+
+    if ($verbose) {
+        passthru('bash ' . escapeshellarg($command), $status);
+    } else {
+        exec('bash ' . escapeshellarg($command) . ' 2>&1', $output, $status);
+    }
+
+    $elapsed = sprintf('%5s', $formatTime(microtime(true) - $start));
 
     if ($status !== 0) {
-        echo ($red)("[FAIL] {$key}");
+        if ($output !== []) {
+            /** @var list<string> $lines */
+            $lines = $output;
+            echo implode("\n", $lines) . "\n";
+        }
+
+        echo ($red)(sprintf('[FAIL] %-' . $titleWidth . 's', $key)) . ($red)($elapsed) . "\n";
 
         return false;
     }
 
-    echo ($green)("[OK]   {$key}");
-    echo "\n";
+    echo ($green)(sprintf('[OK]   %-' . $titleWidth . 's', $key)) . ($green)($elapsed) . "\n";
 
     return true;
 };
@@ -152,10 +187,122 @@ if ($requested !== '') {
     exit($runCheck($requested) ? 0 : 1);
 }
 
+if (!$parallel) {
+    foreach ($checks as $key) {
+        if (!$runCheck($key)) {
+            exit(1);
+        }
+    }
+
+    $totalElapsed = sprintf('%5s', $formatTime(microtime(true) - $totalStart));
+    echo "\n" . ($green)(sprintf('[OK]   %-' . $titleWidth . 's', 'All checks passed')) . ($green)($totalElapsed) . "\n";
+    exit(0);
+}
+
+$runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $gray, &$current): ?array {
+    $command = "{$projectRoot}/.piqule/{$key}/command.sh";
+
+    if (!file_exists($command)) {
+        return null;
+    }
+
+    if (!$isEnabled($key)) {
+        echo ($gray)("[SKIP] {$key}") . "\n";
+
+        return null;
+    }
+
+    $current++;
+
+    $stdout = tmpfile();
+    $stderr = tmpfile();
+
+    if ($stdout === false || $stderr === false) {
+        return null;
+    }
+
+    $proc = proc_open(
+        'bash ' . escapeshellarg($command),
+        [1 => $stdout, 2 => $stderr],
+        $pipes,
+    );
+
+    if (!is_resource($proc)) {
+        return null;
+    }
+
+    return ['proc' => $proc, 'stdout' => $stdout, 'stderr' => $stderr, 'key' => $key, 'start' => microtime(true), 'num' => $current];
+};
+
+$running = [];
+
 foreach ($checks as $key) {
-    if (!$runCheck($key)) {
-        exit(1);
+    $handle = $runCheckAsync($key);
+
+    if ($handle !== null) {
+        echo ($gray)(sprintf('[RUN]  %-' . $titleWidth . 's', $key)) . ($gray)(sprintf('%5s', "{$handle['num']}/{$total}")) . "\n";
+        $running[] = $handle;
     }
 }
 
-echo ($green)('All checks passed');
+$failed = false;
+$pending = $running;
+
+while ($pending !== []) {
+    foreach ($pending as $i => $handle) {
+        $info = proc_get_status($handle['proc']);
+
+        if ($info['running']) {
+            continue;
+        }
+
+        $elapsed = sprintf('%5s', $formatTime(microtime(true) - $handle['start']));
+        $status = $info['exitcode'];
+
+        if ($status === -1) {
+            $status = proc_close($handle['proc']);
+        } else {
+            proc_close($handle['proc']);
+        }
+
+        rewind($handle['stdout']);
+        $out = stream_get_contents($handle['stdout']);
+        fclose($handle['stdout']);
+
+        rewind($handle['stderr']);
+        $err = stream_get_contents($handle['stderr']);
+        fclose($handle['stderr']);
+
+        if ($status !== 0 || $verbose) {
+            if ($out !== '' && $out !== false) {
+                echo $out;
+            }
+
+            if ($err !== '' && $err !== false) {
+                fwrite(STDERR, $err);
+            }
+        }
+
+        if ($status !== 0) {
+            echo ($red)(sprintf('[FAIL] %-' . $titleWidth . 's', $handle['key'])) . ($red)($elapsed) . "\n";
+            $failed = true;
+        } else {
+            echo ($green)(sprintf('[OK]   %-' . $titleWidth . 's', $handle['key'])) . ($green)($elapsed) . "\n";
+        }
+
+        unset($pending[$i]);
+    }
+
+    if ($pending !== []) {
+        usleep(50000);
+    }
+}
+
+$totalElapsed = sprintf('%5s', $formatTime(microtime(true) - $totalStart));
+
+if ($failed) {
+    echo "\n" . ($red)(sprintf('[FAIL] %-' . $titleWidth . 's', 'Checks failed')) . ($red)($totalElapsed) . "\n";
+    exit(1);
+}
+
+echo "\n" . ($green)(sprintf('[OK]   %-' . $titleWidth . 's', 'All checks passed')) . ($green)($totalElapsed) . "\n";

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -185,6 +185,8 @@ if ($requested !== '') {
 if (!$parallel) {
     foreach ($checks as $key) {
         if (!$runCheck($key)) {
+            $totalElapsed = sprintf('%5s', $formatTime(microtime(true) - $totalStart));
+            echo "\n" . ($red)(sprintf('[FAIL] %-' . $titleWidth . 's', 'Checks failed')) . ($red)($totalElapsed) . "\n";
             exit(1);
         }
     }
@@ -194,11 +196,14 @@ if (!$parallel) {
     exit(0);
 }
 
-$runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $red, $gray, &$current): ?array {
+$failed = false;
+
+$runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $red, $gray, &$current, &$failed): ?array {
     $command = "{$projectRoot}/.piqule/{$key}/command.sh";
 
     if (!file_exists($command)) {
         echo ($red)("Unknown check: {$key}") . "\n";
+        $failed = true;
 
         return null;
     }
@@ -216,6 +221,7 @@ $runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $re
 
     if ($stdout === false || $stderr === false) {
         echo ($red)("Failed to create temp files for: {$key}") . "\n";
+        $failed = true;
 
         return null;
     }
@@ -228,6 +234,7 @@ $runCheckAsync = static function(string $key) use ($projectRoot, $isEnabled, $re
 
     if (!is_resource($proc)) {
         echo ($red)("Failed to start: {$key}") . "\n";
+        $failed = true;
 
         return null;
     }
@@ -252,7 +259,6 @@ foreach ($checks as $key) {
 }
 
 $running = [];
-$failed = false;
 
 foreach ($independent as $key) {
     $handle = $runCheckAsync($key);

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -46,16 +46,24 @@ if (file_exists($yamlPath)) {
     $config = $defaults;
 }
 
-$flags = ['-v', '--verbose', '-p', '--parallel', '-P', '--no-parallel'];
+$flags = ['-v', '--verbose', '-p', '--parallel', '-P', '--no-parallel', '-f', '--full', '-F', '--no-full'];
 $verbose = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
 $parallelFlag = in_array('-p', $argv, true) || in_array('--parallel', $argv, true);
 $noParallelFlag = in_array('-P', $argv, true) || in_array('--no-parallel', $argv, true);
+$fullFlag = in_array('-f', $argv, true) || in_array('--full', $argv, true);
+$noFullFlag = in_array('-F', $argv, true) || in_array('--no-full', $argv, true);
 $parallelDefault = filter_var(
     $config->list('check.parallel')[0] ?? false,
     FILTER_VALIDATE_BOOLEAN,
     FILTER_NULL_ON_FAILURE,
 ) ?? false;
+$fullDefault = filter_var(
+    $config->list('check.full')[0] ?? false,
+    FILTER_VALIDATE_BOOLEAN,
+    FILTER_NULL_ON_FAILURE,
+) ?? false;
 $parallel = $noParallelFlag ? false : ($parallelFlag || $parallelDefault);
+$full = $noFullFlag ? false : ($fullFlag || $fullDefault);
 $args = array_values(array_filter($argv, static fn(string $a): bool => !in_array($a, $flags, true)));
 $requested = $args[1] ?? '';
 
@@ -83,26 +91,13 @@ $slowChecks = array_map(
     $config->list('check.slow'),
 );
 
-$groups = ['fast', 'full'];
-
-if ($requested === '' || in_array($requested, $groups, true)) {
-    $group = $requested !== '' ? $requested : (string)($config->list('check.default')[0] ?? 'fast');
-
-    if (!in_array($group, $groups, true)) {
-        fwrite(STDERR, "Invalid check.default value: {$group}. Must be one of: " . implode(', ', $groups) . "\n");
-        exit(1);
-    }
-
-    if ($group === 'fast') {
-        $checks = array_values(
-            array_filter(
-                $checks,
-                static fn(string $key): bool => !in_array($key, $slowChecks, true),
-            ),
-        );
-    }
-
-    $requested = '';
+if ($requested === '' && !$full) {
+    $checks = array_values(
+        array_filter(
+            $checks,
+            static fn(string $key): bool => !in_array($key, $slowChecks, true),
+        ),
+    );
 }
 
 $isEnabled = static function(string $key) use ($config): bool {

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -97,7 +97,9 @@ foreach ($enabled as $token) {
         continue;
     }
 
-    if (getenv($token->secret()) !== false) {
+    $env = getenv($token->secret());
+
+    if ($env !== false && $env !== '') {
         continue;
     }
 

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -97,6 +97,10 @@ foreach ($enabled as $token) {
         continue;
     }
 
+    if (getenv($token->secret()) !== false) {
+        continue;
+    }
+
     $output->info(sprintf('[TOKEN] %s is missing. Get it at: %s', $token->secret(), $token->url($org)));
     if ($repo !== '') {
         $output->info(sprintf('[TOKEN] Add it at: https://github.com/%s/settings/secrets/actions/new', $repo));

--- a/bin/piqule-verify
+++ b/bin/piqule-verify
@@ -25,7 +25,7 @@ CURRENT="$(find "$TEMPLATES_DIR/always" "$TEMPLATES_DIR/git" -type f \
   | awk '{print $1}')"
 
 if [ "$CURRENT" != "$(cat "$PINNED")" ]; then
-  echo -e "\033[31mTemplates have changed. Run: piqule sync\033[0m"
+  echo -e "\033[31mTemplates have changed. Run: piqule sync\033[0m\n"
 else
-  echo -e "\033[32mTemplates are up to date\033[0m"
+  echo -e "\033[90mTemplates are up to date\033[0m\n"
 fi

--- a/bin/piqule-verify
+++ b/bin/piqule-verify
@@ -25,7 +25,7 @@ CURRENT="$(find "$TEMPLATES_DIR/always" "$TEMPLATES_DIR/git" -type f \
   | awk '{print $1}')"
 
 if [ "$CURRENT" != "$(cat "$PINNED")" ]; then
-  echo -e "\033[31mTemplates have changed. Run: piqule sync\033[0m\n"
+  printf "\033[31mTemplates have changed. Run: piqule sync\033[0m\n\n"
 else
-  echo -e "\033[90mTemplates are up to date\033[0m\n"
+  printf "\033[90mTemplates are up to date\033[0m\n\n"
 fi

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -14,7 +14,7 @@ defaults:
   exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
 
-  check.default: "fast"
+  check.full: false
   check.parallel: true
   check.slow: ["infection", "sonar"]
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -15,6 +15,7 @@ defaults:
   php.versions: ["8.3"]
 
   check.default: "fast"
+  check.parallel: true
   check.slow: ["infection", "sonar"]
 
   ci.piqule_bin: "vendor/bin/piqule"

--- a/templates/git/hooks/pre-push-piqule
+++ b/templates/git/hooks/pre-push-piqule
@@ -2,12 +2,12 @@
 set -e
 
 if [ -x "vendor/bin/piqule" ]; then
-  vendor/bin/piqule check full
+  vendor/bin/piqule check
   exit $?
 fi
 
 if command -v composer >/dev/null 2>&1; then
-  composer exec -- piqule check full
+  composer exec -- piqule check
   exit $?
 fi
 


### PR DESCRIPTION
## Summary

- Add parallel execution mode (`--parallel`/`-p`, on by default) with per-tool and total timing display
- Replace positional `fast`/`full` groups with `--full`/`-f` and `--no-full`/`-F` flags
- Suppress tool output unless `-v` or check fails; dependent checks (sonar, infection) run after phpunit
- Fix token warning: skip when env var is set, treat empty value as missing

Closes #504

## Test plan

- [ ] `piqule check` runs fast checks in parallel with timing
- [ ] `piqule check -f` includes slow checks (infection, sonar)
- [ ] `piqule check -F` excludes slow checks even if `check.full: true`
- [ ] `piqule check -P` forces sequential execution
- [ ] `piqule check -v` shows full output from each check
- [ ] Failed check output is shown without `-v`
- [ ] `SONAR_TOKEN=test piqule check` — no `[TOKEN]` warning
- [ ] `SONAR_TOKEN= piqule check` — warning shown (empty value)
- [ ] `piqule check <tool>` runs single tool as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI flags to control check execution: `--full`/`--no-full` for slow checks, `--parallel`/`--no-parallel` for execution mode, and `--verbose` for detailed output.
  * Parallel check execution is now enabled by default with elapsed timing displayed for each check.
  * Enhanced token validation to check local environment variables.

* **Chores**
  * Updated default configuration with new `check.full` and `check.parallel` keys; slow checks now excluded by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->