### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:50a02c1149e00c0367d16cf773612a518ab1bea2fb6b7cc1d4937f4cfd4f923d}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:41e7f4907326d0e56d8eb766b4e033f2fd07b7e794bd015885161d4c7aed4c7c}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:50a02c1149e00c0367d16cf773612a518ab1bea2fb6b7cc1d4937f4cfd4f923d"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:41e7f4907326d0e56d8eb766b4e033f2fd07b7e794bd015885161d4c7aed4c7c"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:50a02c1149e00c0367d16cf773612a518ab1bea2fb6b7cc1d4937f4cfd4f923d"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:41e7f4907326d0e56d8eb766b4e033f2fd07b7e794bd015885161d4c7aed4c7c"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:41e7f4907326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Docker image references in build configuration files. Environment variable overrides remain functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->