### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:447ce8fcd9d4de3447aedad7ac1c2e5eca421f99185edb4158d31c12bf30defb}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:951b4cf6b905abae4cba3a6e3a6ad42ffb0de78739a0cdeba431e020fabda618}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:447ce8fcd9d4de3447aedad7ac1c2e5eca421f99185edb4158d31c12bf30defb"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:951b4cf6b905abae4cba3a6e3a6ad42ffb0de78739a0cdeba431e020fabda618"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:447ce8fcd9d4de3447aedad7ac1c2e5eca421f99185edb4158d31c12bf30defb"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:951b4cf6b905abae4cba3a6e3a6ad42ffb0de78739a0cdeba431e020fabda618"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:951b4cf6b905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker infrastructure image references across configuration files to improve compatibility and runtime stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->