### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:a12b741ec6e8c9410b9f54bde9ae5c4d873deb944e724ee6016c9c1daf7e5c09}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:5e9e8dc27e7e68d5284c0c04753fd023a777e6a1b6a130785e08c78a7c3855f0}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:a12b741ec6e8c9410b9f54bde9ae5c4d873deb944e724ee6016c9c1daf7e5c09"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:5e9e8dc27e7e68d5284c0c04753fd023a777e6a1b6a130785e08c78a7c3855f0"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:a12b741ec6e8c9410b9f54bde9ae5c4d873deb944e724ee6016c9c1daf7e5c09"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:5e9e8dc27e7e68d5284c0c04753fd023a777e6a1b6a130785e08c78a7c3855f0"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:5e9e8dc27e7e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container image reference across configuration files to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->