### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:1316888201fbd26fb802bb879d7a1c0b3364dac42c6078b8f6047533f6813944}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:51bc8e293021026d3e7b93f1d3a7f4a0f5b119cb7e0755ea3ddb95384eaffaac}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:1316888201fbd26fb802bb879d7a1c0b3364dac42c6078b8f6047533f6813944"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:51bc8e293021026d3e7b93f1d3a7f4a0f5b119cb7e0755ea3ddb95384eaffaac"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:1316888201fbd26fb802bb879d7a1c0b3364dac42c6078b8f6047533f6813944"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:51bc8e293021026d3e7b93f1d3a7f4a0f5b119cb7e0755ea3ddb95384eaffaac"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:51bc8e293021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure container image to the latest version across all configuration files and build templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->