### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:f520f14eafbb737e08f0dc094ba532095de2fc72e7123773f36a17ce0ba98b45}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:b5bd4aa8697d220b7c18b20aefefad6c6d765023a20f9d43ee363271bf1c0224}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:f520f14eafbb737e08f0dc094ba532095de2fc72e7123773f36a17ce0ba98b45"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:b5bd4aa8697d220b7c18b20aefefad6c6d765023a20f9d43ee363271bf1c0224"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:f520f14eafbb737e08f0dc094ba532095de2fc72e7123773f36a17ce0ba98b45"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:b5bd4aa8697d220b7c18b20aefefad6c6d765023a20f9d43ee363271bf1c0224"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:b5bd4aa8697d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image references across configuration and build files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->