### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:7311388ff9f19a6adb7728f6a2f13f16d5f0e398570b9786232b26159d5a80db}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:66958601b8cecc1f43720ae324d7b38ee0d3eac3dd646bac572343091a42f60e}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7311388ff9f19a6adb7728f6a2f13f16d5f0e398570b9786232b26159d5a80db"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:66958601b8cecc1f43720ae324d7b38ee0d3eac3dd646bac572343091a42f60e"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7311388ff9f19a6adb7728f6a2f13f16d5f0e398570b9786232b26159d5a80db"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:66958601b8cecc1f43720ae324d7b38ee0d3eac3dd646bac572343091a42f60e"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:66958601b8ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker infrastructure image references in build scripts and configuration files to use newer pinned digest versions, ensuring consistent infrastructure components across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->