### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:b62b14e57bf700258aa73705fdeefb55a9d5caebaa10fb1558527828ab8b2b2a}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:f878eead886ebb78ec0dd1ff89afa2234aad4328baaa9fbadb0d9617b467f45e}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:b62b14e57bf700258aa73705fdeefb55a9d5caebaa10fb1558527828ab8b2b2a"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:f878eead886ebb78ec0dd1ff89afa2234aad4328baaa9fbadb0d9617b467f45e"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:b62b14e57bf700258aa73705fdeefb55a9d5caebaa10fb1558527828ab8b2b2a"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:f878eead886ebb78ec0dd1ff89afa2234aad4328baaa9fbadb0d9617b467f45e"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:f878eead886e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configurations across tooling and project templates to use a new infrastructure image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->