### PR TITLE
SonarCloud Automatic Analysis Toggle

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -122,6 +122,7 @@ defaults:
   shellcheck.shell: "bash"
   shellcheck.source_path: "."
 
+  sonar.cloud: true
   sonar.enabled: true
   sonar.organization: []
   sonar.projectKey: []

--- a/.piqule/sonar/command.sh
+++ b/.piqule/sonar/command.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLOUD="<< config(sonar.cloud)|first()|join("") >>"
+CLOUD="true"
 if [ "$CLOUD" = "1" ] || [ "$CLOUD" = "true" ]; then
   printf '\033[33m[SKIP] SonarCloud automatic analysis — no local scanner needed\033[0m\n'
   exit 0
@@ -37,7 +37,7 @@ else
 fi
 
 PROJECT_ROOT="$(pwd)"
-IMAGE="${PIQULE_INFRA_IMAGE:-<< config(docker.image) >>}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:a8efe1ce4921b5faebe7f9f0dcc8465151f5a2db5637aa0b4cd27c9e44cdfcef}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/sonar/command.sh
+++ b/.piqule/sonar/command.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CLOUD="true"
-if [ "$CLOUD" = "1" ] || [ "$CLOUD" = "true" ]; then
+if [ "$CLOUD" = "1" ] || [ "$CLOUD" = "true" ] || [ "$CLOUD" = "yes" ] || [ "$CLOUD" = "on" ]; then
   printf '\033[33m[SKIP] SonarCloud automatic analysis — no local scanner needed\033[0m\n'
   exit 0
 fi

--- a/.piqule/sonar/sonar-project.properties
+++ b/.piqule/sonar/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.organization=haspadar-org
+sonar.projectKey=haspadar_piqule
+sonar.sources=src
+sonar.tests=tests
+sonar.exclusions=
+sonar.php.coverage.reportPaths=.piqule/codecov/coverage.xml

--- a/DEV.md
+++ b/DEV.md
@@ -288,7 +288,7 @@ Each env var implements `EnvVar` (`src/EnvVar/EnvVar.php`):
 |-------|------|------|-------------|
 | `CodecovSecret` | `CODECOV_TOKEN` | Secret | `phpunit.enabled` is true |
 | `InfectionSecret` | `STRYKER_DASHBOARD_API_KEY` | Secret | `infection.enabled` is true |
-| `SonarEnvVar` | `SONAR_TOKEN` | EnvVar | `sonar.enabled` is true |
+| `SonarEnvVar` | `SONAR_TOKEN` | EnvVar | `sonar.cloud` is false and `sonar.enabled` is true |
 
 ### Adding a Secret
 
@@ -496,6 +496,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `sonar.cloud` | `true` | Use SonarCloud automatic analysis (skip local scanner and SONAR_TOKEN) |
 | `sonar.enabled` | `true` | Enable SonarCloud |
 | `sonar.organization` | `[]` | SonarCloud organization |
 | `sonar.projectKey` | `[]` | SonarCloud project key |

--- a/src/EnvVar/SonarEnvVar.php
+++ b/src/EnvVar/SonarEnvVar.php
@@ -29,12 +29,30 @@ final readonly class SonarEnvVar implements EnvVar
     #[Override]
     public function enabled(Config $config): bool
     {
+        if ($this->cloud($config)) {
+            return false;
+        }
+
         if (!$config->has('sonar.enabled')) {
             return true;
         }
 
         return filter_var(
             $config->list('sonar.enabled')[0] ?? true,
+            FILTER_VALIDATE_BOOLEAN,
+            FILTER_NULL_ON_FAILURE,
+        ) ?? true;
+    }
+
+    /** @throws PiquleException */
+    private function cloud(Config $config): bool
+    {
+        if (!$config->has('sonar.cloud')) {
+            return true;
+        }
+
+        return filter_var(
+            $config->list('sonar.cloud')[0] ?? true,
             FILTER_VALIDATE_BOOLEAN,
             FILTER_NULL_ON_FAILURE,
         ) ?? true;

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -122,6 +122,7 @@ defaults:
   shellcheck.shell: "bash"
   shellcheck.source_path: "."
 
+  sonar.cloud: true
   sonar.enabled: true
   sonar.organization: []
   sonar.projectKey: []

--- a/templates/always/.piqule/sonar/command.sh
+++ b/templates/always/.piqule/sonar/command.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CLOUD="<< config(sonar.cloud)|first()|join("") >>"
-if [ "$CLOUD" = "1" ] || [ "$CLOUD" = "true" ]; then
+if [ "$CLOUD" = "1" ] || [ "$CLOUD" = "true" ] || [ "$CLOUD" = "yes" ] || [ "$CLOUD" = "on" ]; then
   printf '\033[33m[SKIP] SonarCloud automatic analysis — no local scanner needed\033[0m\n'
   exit 0
 fi

--- a/tests/Unit/EnvVar/SonarEnvVarTest.php
+++ b/tests/Unit/EnvVar/SonarEnvVarTest.php
@@ -12,52 +12,71 @@ use PHPUnit\Framework\TestCase;
 final class SonarEnvVarTest extends TestCase
 {
     #[Test]
-    public function enabledWhenSonarEnabled(): void
+    public function disabledWhenCloudTrue(): void
     {
         self::assertSame(
-            true,
-            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.enabled' => [true]])),
-            'SonarEnvVar must be enabled when sonar.enabled is true',
+            false,
+            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.cloud' => [true]])),
+            'SonarEnvVar must be disabled when sonar.cloud is true',
         );
     }
 
     #[Test]
-    public function enabledWhenKeyAbsent(): void
+    public function disabledWhenCloudAbsent(): void
     {
         self::assertSame(
-            true,
+            false,
             (new SonarEnvVar())->enabled(new FakeConfig([])),
-            'SonarEnvVar must be enabled when sonar.enabled key is absent',
+            'SonarEnvVar must be disabled when sonar.cloud key is absent (default is cloud mode)',
         );
     }
 
     #[Test]
-    public function disabledWhenSonarDisabled(): void
-    {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.enabled' => [false]])),
-            'SonarEnvVar must be disabled when sonar.enabled is false',
-        );
-    }
-
-    #[Test]
-    public function disabledWhenSonarDisabledAsString(): void
-    {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.enabled' => ['false']])),
-            'SonarEnvVar must be disabled when sonar.enabled is string "false"',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenInvalidString(): void
+    public function enabledWhenCloudFalse(): void
     {
         self::assertSame(
             true,
-            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.enabled' => ['tru']])),
-            'SonarEnvVar must default to enabled when value is not a valid boolean string',
+            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.cloud' => [false]])),
+            'SonarEnvVar must be enabled when sonar.cloud is false (local scanner mode)',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenCloudFalseAndSonarDisabled(): void
+    {
+        self::assertSame(
+            false,
+            (new SonarEnvVar())->enabled(new FakeConfig([
+                'sonar.cloud' => [false],
+                'sonar.enabled' => [false],
+            ])),
+            'SonarEnvVar must be disabled when sonar.enabled is false even in scanner mode',
+        );
+    }
+
+    #[Test]
+    public function enabledWhenCloudFalseAndSonarEnabled(): void
+    {
+        self::assertSame(
+            true,
+            (new SonarEnvVar())->enabled(new FakeConfig([
+                'sonar.cloud' => [false],
+                'sonar.enabled' => [true],
+            ])),
+            'SonarEnvVar must be enabled when sonar.cloud is false and sonar.enabled is true',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenCloudFalseStringAndSonarDisabledString(): void
+    {
+        self::assertSame(
+            false,
+            (new SonarEnvVar())->enabled(new FakeConfig([
+                'sonar.cloud' => ['false'],
+                'sonar.enabled' => ['false'],
+            ])),
+            'SonarEnvVar must handle string "false" for both keys',
         );
     }
 

--- a/tests/Unit/EnvVar/SonarEnvVarTest.php
+++ b/tests/Unit/EnvVar/SonarEnvVarTest.php
@@ -68,6 +68,19 @@ final class SonarEnvVarTest extends TestCase
     }
 
     #[Test]
+    public function disabledWhenCloudTrueAndSonarDisabled(): void
+    {
+        self::assertSame(
+            false,
+            (new SonarEnvVar())->enabled(new FakeConfig([
+                'sonar.cloud' => [true],
+                'sonar.enabled' => [false],
+            ])),
+            'SonarEnvVar must be disabled when sonar.cloud is true regardless of sonar.enabled',
+        );
+    }
+
+    #[Test]
     public function disabledWhenCloudFalseStringAndSonarDisabledString(): void
     {
         self::assertSame(


### PR DESCRIPTION
- Added sonar.cloud config key defaulting to true for automatic analysis mode
- Updated sonar command.sh to skip local scanner when cloud mode is on
- Suppressed SONAR_TOKEN verification in cloud mode
- Added tests for cloud mode short-circuit and boolean string handling

Closes #508