### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:7ce01d8f3533fa3bbf3f5b33e2452905f7b325cd291b7d6fd174848372feea1e}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:9d1f25143571a426ded0f453a442b31fe07137bb6e66d7054ce6601615d645ce}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7ce01d8f3533fa3bbf3f5b33e2452905f7b325cd291b7d6fd174848372feea1e"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:9d1f25143571a426ded0f453a442b31fe07137bb6e66d7054ce6601615d645ce"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7ce01d8f3533fa3bbf3f5b33e2452905f7b325cd291b7d6fd174848372feea1e"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:9d1f25143571a426ded0f453a442b31fe07137bb6e66d7054ce6601615d645ce"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:9d1f25143571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker infrastructure image to a newer version across configuration and template files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->