### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:c6b95e0ce23146842969737deb356961c9eb4a9a8d03edd0e353fc19adbd9143}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:bc4d02ea854c114fe21977c9e7d1e146fc196198e1701afc32d937cc6b4f69bd}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:c6b95e0ce23146842969737deb356961c9eb4a9a8d03edd0e353fc19adbd9143"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:bc4d02ea854c114fe21977c9e7d1e146fc196198e1701afc32d937cc6b4f69bd"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:c6b95e0ce23146842969737deb356961c9eb4a9a8d03edd0e353fc19adbd9143"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:bc4d02ea854c114fe21977c9e7d1e146fc196198e1701afc32d937cc6b4f69bd"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:bc4d02ea854c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image reference to the latest version across infrastructure configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->