### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:8eba01cfff094116c95f5320cfdcd993cc5bf95b0edbb80c92aa1af7ad650b2e}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:7fa94073432e586103b40d91c5c9470c25aea5a999f595ba477d4438a0a18723}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:8eba01cfff094116c95f5320cfdcd993cc5bf95b0edbb80c92aa1af7ad650b2e"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7fa94073432e586103b40d91c5c9470c25aea5a999f595ba477d4438a0a18723"
 
   actionlint.enabled: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,7 +26,7 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:8eba01cfff094116c95f5320cfdcd993cc5bf95b0edbb80c92aa1af7ad650b2e"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:7fa94073432e586103b40d91c5c9470c25aea5a999f595ba477d4438a0a18723"
 
   actionlint.enabled: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:7fa94073432e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal Docker infrastructure dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->