### PR TITLE
Fix Infinite Digest PR Loop

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,6 +3,7 @@ name: Build Piqule Infra Image
 on:
   push:
     branches: [main]
+    paths: [Dockerfile]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
- Updated build-image workflow to trigger only on Dockerfile changes, not all pushes to main
- Removed 49 orphaned auto-digest branches created by the loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline to execute only when necessary, improving deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->