### PR TITLE
PHPDoc Summaries and Punctuation for Design Rules

### DIFF
--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -8,7 +8,7 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * Appends values to existing configuration lists without replacing them
+ * Appends values to existing configuration lists without replacing them.
  *
  * Example:
  *
@@ -19,7 +19,11 @@ use Override;
  */
 final readonly class AppendConfig implements Config
 {
-    /** @param array<string, mixed> $appends */
+    /**
+     * Initializes with a base config and values to append.
+     *
+     * @param array<string, mixed> $appends
+     */
     public function __construct(private Config $defaults, private array $appends) {}
 
     #[Override]

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Config;
 
 /**
- * Root namespace from the PSR-4 autoload section of composer.json
+ * Root namespace from the PSR-4 autoload section of composer.json.
  */
 final readonly class ComposerRootNamespace
 {
+    /** Initializes with the composer.json file path. */
     public function __construct(private string $path) {}
 
+    /** Returns the first PSR-4 root namespace as a string. */
     public function toString(): string
     {
         if (!is_file($this->path)) {

--- a/src/Config/Dirs/GlobDirs.php
+++ b/src/Config/Dirs/GlobDirs.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Config\Dirs;
 use Override;
 
 /**
- * Directories suffixed with /* for glob-style exclusion patterns
+ * Directories suffixed with /* for glob-style exclusion patterns.
  */
 final readonly class GlobDirs implements Dirs
 {
-    /** @param list<string> $dirs */
+    /**
+     * Initializes with directory paths to transform.
+     *
+     * @param list<string> $dirs
+     */
     public function __construct(private array $dirs) {}
 
     /** @return list<string> */

--- a/src/Config/Dirs/NegatedGlobDirs.php
+++ b/src/Config/Dirs/NegatedGlobDirs.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Config\Dirs;
 use Override;
 
 /**
- * Directories as negated glob patterns for exclusion (e.g. !vendor/**)
+ * Directories as negated glob patterns for exclusion (e.g. !vendor/**).
  */
 final readonly class NegatedGlobDirs implements Dirs
 {
-    /** @param list<string> $dirs */
+    /**
+     * Initializes with directory paths to negate.
+     *
+     * @param list<string> $dirs
+     */
     public function __construct(private array $dirs) {}
 
     /** @return list<string> */

--- a/src/Config/Dirs/ProjectDirs.php
+++ b/src/Config/Dirs/ProjectDirs.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Config\Dirs;
 use Override;
 
 /**
- * Directories prefixed with ../../ for tools that run inside .piqule/<tool>/
+ * Directories prefixed with ../../ for tools that run inside .piqule/<tool>/.
  */
 final readonly class ProjectDirs implements Dirs
 {
-    /** @param list<string> $dirs */
+    /**
+     * Initializes with directory paths to prefix.
+     *
+     * @param list<string> $dirs
+     */
     public function __construct(private array $dirs) {}
 
     /** @return list<string> */

--- a/src/Config/Dirs/TrailingGlobDirs.php
+++ b/src/Config/Dirs/TrailingGlobDirs.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Config\Dirs;
 use Override;
 
 /**
- * Directories suffixed with /** for recursive glob exclusion patterns
+ * Directories suffixed with /** for recursive glob exclusion patterns.
  */
 final readonly class TrailingGlobDirs implements Dirs
 {
-    /** @param list<string> $dirs */
+    /**
+     * Initializes with directory paths to transform.
+     *
+     * @param list<string> $dirs
+     */
     public function __construct(private array $dirs) {}
 
     /** @return list<string> */

--- a/src/Config/Dirs/TrailingSlashDirs.php
+++ b/src/Config/Dirs/TrailingSlashDirs.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Config\Dirs;
 use Override;
 
 /**
- * Directories suffixed with / to match directory entries explicitly
+ * Directories suffixed with / to match directory entries explicitly.
  */
 final readonly class TrailingSlashDirs implements Dirs
 {
-    /** @param list<string> $dirs */
+    /**
+     * Initializes with directory paths to transform.
+     *
+     * @param list<string> $dirs
+     */
     public function __construct(private array $dirs) {}
 
     /** @return list<string> */

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -7,9 +7,16 @@ namespace Haspadar\Piqule\Config;
 use Haspadar\Piqule\PiquleException;
 use Override;
 
+/**
+ * Replaces specific configuration values while preserving all other defaults.
+ */
 final readonly class OverrideConfig implements Config
 {
-    /** @param array<string, mixed> $overrides */
+    /**
+     * Initializes with a base config and override values.
+     *
+     * @param array<string, mixed> $overrides
+     */
     public function __construct(private Config $defaults, private array $overrides) {}
 
     #[Override]
@@ -36,6 +43,8 @@ final readonly class OverrideConfig implements Config
     }
 
     /**
+     * Converts a raw override value to a validated scalar list.
+     *
      * @throws PiquleException
      * @return list<scalar>
      */

--- a/src/EnvVar/EnvVars.php
+++ b/src/EnvVar/EnvVars.php
@@ -5,14 +5,22 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\EnvVar;
 
 /**
- * Collection of local environment variables
+ * Collection of local environment variables.
  */
 final readonly class EnvVars
 {
-    /** @param list<EnvVar> $items */
+    /**
+     * Initializes with a list of environment variables.
+     *
+     * @param list<EnvVar> $items
+     */
     public function __construct(private array $items) {}
 
-    /** @return list<EnvVar> */
+    /**
+     * Returns all environment variables in this collection.
+     *
+     * @return list<EnvVar>
+     */
     public function items(): array
     {
         return $this->items;

--- a/src/EnvVar/SonarEnvVar.php
+++ b/src/EnvVar/SonarEnvVar.php
@@ -9,7 +9,7 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * SonarCloud scanner token for local analysis
+ * SonarCloud scanner token for local analysis.
  */
 final readonly class SonarEnvVar implements EnvVar
 {
@@ -44,7 +44,11 @@ final readonly class SonarEnvVar implements EnvVar
         ) ?? true;
     }
 
-    /** @throws PiquleException */
+    /**
+     * Checks whether SonarCloud mode is active.
+     *
+     * @throws PiquleException
+     */
     private function cloud(Config $config): bool
     {
         if (!$config->has('sonar.cloud')) {

--- a/src/File/PrefixedFile.php
+++ b/src/File/PrefixedFile.php
@@ -7,21 +7,13 @@ namespace Haspadar\Piqule\File;
 use Override;
 
 /**
- * Prepends a path prefix to the wrapped file's name
+ * Prepends a path prefix to the wrapped file's name.
  */
 final readonly class PrefixedFile implements File
 {
+    /** Initializes with a path prefix and the file to decorate. */
     public function __construct(private string $prefix, private File $origin) {}
 
-    /**
-     * Builds the target file path by prefixing the original name
-     *
-     * Examples:
-     * - prefix ".git" + name "hooks/pre-push" → ".git/hooks/pre-push"
-     * - prefix "" + name "config/app.yaml" → "config/app.yaml"
-     *
-     * Leading and trailing slashes are normalized
-     */
     #[Override]
     public function name(): string
     {

--- a/src/File/ReplacedFile.php
+++ b/src/File/ReplacedFile.php
@@ -7,10 +7,11 @@ namespace Haspadar\Piqule\File;
 use Override;
 
 /**
- * Performs a literal string replacement in the wrapped file's contents
+ * Performs a literal string replacement in the wrapped file's contents.
  */
 final readonly class ReplacedFile implements File
 {
+    /** Initializes with the original file and replacement pair. */
     public function __construct(
         private File $origin,
         private string $search,

--- a/src/File/TextFile.php
+++ b/src/File/TextFile.php
@@ -7,10 +7,11 @@ namespace Haspadar\Piqule\File;
 use Override;
 
 /**
- * An in-memory file with an explicit name, contents, and mode
+ * An in-memory file with an explicit name, contents, and mode.
  */
 final readonly class TextFile implements File
 {
+    /** Initializes with a file name, contents, and optional permission mode. */
     public function __construct(
         private string $name,
         private string $contents,

--- a/src/Files/CombinedFiles.php
+++ b/src/Files/CombinedFiles.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Files;
 use Override;
 
 /**
- * Merges multiple Files sources into a single sequential collection
+ * Merges multiple Files sources into a single sequential collection.
  */
 final readonly class CombinedFiles implements Files
 {
-    /** @param list<Files> $sources */
+    /**
+     * Initializes with multiple file sources to merge.
+     *
+     * @param list<Files> $sources
+     */
     public function __construct(private array $sources) {}
 
     #[Override]

--- a/src/Files/EachFile.php
+++ b/src/Files/EachFile.php
@@ -10,19 +10,18 @@ use Haspadar\Piqule\Runnable;
 use Override;
 
 /**
- * Iterates over all files in a collection and applies a side-effectful action to each
+ * Iterates over all files in a collection and applies a side-effectful action to each.
  */
 final readonly class EachFile implements Runnable
 {
     /**
+     * Initializes with a file collection and an action to apply.
+     *
      * @param Files $files File collection to iterate
      * @param Closure(File): void $action
      */
     public function __construct(private Files $files, private Closure $action) {}
 
-    /**
-     * Executes the action for every file in the collection
-     */
     #[Override]
     public function run(): void
     {

--- a/src/Files/FilteredFiles.php
+++ b/src/Files/FilteredFiles.php
@@ -9,11 +9,15 @@ use Haspadar\Piqule\File\File;
 use Override;
 
 /**
- * Yields only the files from the wrapped collection that satisfy a predicate
+ * Yields only the files from the wrapped collection that satisfy a predicate.
  */
 final readonly class FilteredFiles implements Files
 {
-    /** @param Closure(File): bool $predicate */
+    /**
+     * Initializes with a file collection and a filtering predicate.
+     *
+     * @param Closure(File): bool $predicate
+     */
     public function __construct(private Files $origin, private Closure $predicate) {}
 
     #[Override]

--- a/src/Files/FolderFiles.php
+++ b/src/Files/FolderFiles.php
@@ -10,11 +10,13 @@ use Haspadar\Piqule\Storage\Storage;
 use Override;
 
 /**
- * Reads all files from a given storage folder as a Files collection
+ * Reads all files from a given storage folder as a Files collection.
  */
 final readonly class FolderFiles implements Files
 {
     /**
+     * Initializes with a storage backend and a folder path to read from.
+     *
      * @param Storage $storage Source storage to read files from
      * @param string $folder Folder path relative to storage root
      */

--- a/src/Files/MappedFiles.php
+++ b/src/Files/MappedFiles.php
@@ -9,11 +9,15 @@ use Haspadar\Piqule\File\File;
 use Override;
 
 /**
- * Applies a transformation closure to each file in the wrapped collection
+ * Applies a transformation closure to each file in the wrapped collection.
  */
 final readonly class MappedFiles implements Files
 {
-    /** @param Closure(File): File $map */
+    /**
+     * Initializes with a file collection and a transformation closure.
+     *
+     * @param Closure(File): File $map
+     */
     public function __construct(private Files $origin, private Closure $map) {}
 
     #[Override]

--- a/src/Files/TextFiles.php
+++ b/src/Files/TextFiles.php
@@ -8,11 +8,15 @@ use Haspadar\Piqule\File\TextFile;
 use Override;
 
 /**
- * A Files collection built from a map of path => content strings
+ * A Files collection built from a map of path => content strings.
  */
 final readonly class TextFiles implements Files
 {
-    /** @param array<string, string> $files */
+    /**
+     * Initializes with a map of file paths to their contents.
+     *
+     * @param array<string, string> $files
+     */
     public function __construct(private array $files) {}
 
     #[Override]

--- a/src/Formula/Action/ConfigAction.php
+++ b/src/Formula/Action/ConfigAction.php
@@ -12,19 +12,14 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * Loads values from configuration by key, ignoring any incoming args
+ * Loads values from configuration by key, ignoring any incoming args.
  */
 final readonly class ConfigAction implements Action
 {
+    /** Initializes with a configuration source and a key to look up. */
     public function __construct(private Config $config, private string $key) {}
 
-    /**
-     * Returns configuration values for the given key
-     *
-     * Input arguments are ignored because this action acts as a value source
-     *
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     #[Override]
     public function transformed(Args $args): Args
     {

--- a/src/Formula/Action/FirstAction.php
+++ b/src/Formula/Action/FirstAction.php
@@ -9,7 +9,7 @@ use Haspadar\Piqule\Formula\Args\ListArgs;
 use Override;
 
 /**
- * Returns only the first value from the incoming list
+ * Returns only the first value from the incoming list.
  */
 final readonly class FirstAction implements Action
 {

--- a/src/Formula/Action/IfEmptyAction.php
+++ b/src/Formula/Action/IfEmptyAction.php
@@ -9,7 +9,7 @@ use Haspadar\Piqule\Formula\Args\ListArgs;
 use Override;
 
 /**
- * Passes empty input through, clears non-empty input
+ * Passes empty input through, clears non-empty input.
  */
 final readonly class IfEmptyAction implements Action
 {

--- a/src/Formula/Action/IfNotEmptyAction.php
+++ b/src/Formula/Action/IfNotEmptyAction.php
@@ -9,7 +9,7 @@ use Haspadar\Piqule\Formula\Args\ListArgs;
 use Override;
 
 /**
- * Passes non-empty input through, clears empty input
+ * Passes non-empty input through, clears empty input.
  */
 final readonly class IfNotEmptyAction implements Action
 {

--- a/src/Formula/Action/JoinAction.php
+++ b/src/Formula/Action/JoinAction.php
@@ -10,10 +10,11 @@ use Haspadar\Piqule\Formula\Args\UnquotedArgs;
 use Override;
 
 /**
- * Joins all incoming values into a single string using a delimiter
+ * Joins all incoming values into a single string using a delimiter.
  */
 final readonly class JoinAction implements Action
 {
+    /** Initializes with a raw delimiter string. */
     public function __construct(private string $raw) {}
 
     #[Override]

--- a/src/Formula/Actions/ParsedActions.php
+++ b/src/Formula/Actions/ParsedActions.php
@@ -9,19 +9,18 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * Parses a DSL expression string into an ordered list of Action instances
+ * Parses a DSL expression string into an ordered list of Action instances.
  */
 final readonly class ParsedActions implements Actions
 {
-    /** @param array<string, callable(string): Action> $actions */
+    /**
+     * Initializes with a DSL expression and available action factories.
+     *
+     * @param array<string, callable(string): Action> $actions
+     */
     public function __construct(private string $expression, private array $actions) {}
 
     /**
-     * Parses DSL expression into a sequence of actions
-     *
-     * DSL intentionally does not support nested parentheses
-     * in action arguments. Arguments are treated as flat strings.
-     *
      * @throws PiquleException
      * @return list<Action>
      */

--- a/src/Formula/Args/ListArgs.php
+++ b/src/Formula/Args/ListArgs.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Formula\Args;
 use Override;
 
 /**
- * Args backed by a plain PHP list of scalar values
+ * Args backed by a plain PHP list of scalar values.
  */
 final readonly class ListArgs implements Args
 {
-    /** @param list<int|float|string|bool> $values */
+    /**
+     * Initializes with a plain list of scalar values.
+     *
+     * @param list<int|float|string|bool> $values
+     */
     public function __construct(private array $values) {}
 
     /** @return list<int|float|string|bool> */

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -9,10 +9,11 @@ use JsonException;
 use Override;
 
 /**
- * Decodes a single JSON list literal from the wrapped Args into a typed scalar list
+ * Decodes a single JSON list literal from the wrapped Args into a typed scalar list.
  */
 final readonly class ParsedArgs implements Args
 {
+    /** Initializes with the args containing a JSON list literal. */
     public function __construct(private Args $origin) {}
 
     /**
@@ -29,7 +30,11 @@ final readonly class ParsedArgs implements Args
         return array_values(array_filter($decoded, static fn($item) => is_scalar($item)));
     }
 
-    /** @throws InvalidArgumentException */
+    /**
+     * Extracts the single raw string value from the wrapped args.
+     *
+     * @throws InvalidArgumentException
+     */
     private function singleRawValue(): string
     {
         $values = $this->origin->values();
@@ -64,6 +69,8 @@ final readonly class ParsedArgs implements Args
     }
 
     /**
+     * Decodes a JSON string into an array.
+     *
      * @throws InvalidArgumentException
      * @return array<array-key, mixed>
      */
@@ -92,6 +99,8 @@ final readonly class ParsedArgs implements Args
     }
 
     /**
+     * Validates that the decoded array is a flat list of scalars.
+     *
      * @param array<array-key, mixed> $decoded
      * @throws InvalidArgumentException
      */

--- a/src/Formula/Args/StringifiedArgs.php
+++ b/src/Formula/Args/StringifiedArgs.php
@@ -7,10 +7,11 @@ namespace Haspadar\Piqule\Formula\Args;
 use Override;
 
 /**
- * Converts all scalar values to strings, mapping true/false to "true"/"false"
+ * Converts all scalar values to strings, mapping true/false to "true"/"false".
  */
 final readonly class StringifiedArgs implements Args
 {
+    /** Initializes with the args to stringify. */
     public function __construct(private Args $origin) {}
 
     /** @return list<string> */

--- a/src/Formula/Args/TrimmedArgs.php
+++ b/src/Formula/Args/TrimmedArgs.php
@@ -7,10 +7,11 @@ namespace Haspadar\Piqule\Formula\Args;
 use Override;
 
 /**
- * Trims leading and trailing whitespace from string values; non-strings are passed through unchanged
+ * Trims leading and trailing whitespace from string values; non-strings are passed through unchanged.
  */
 final readonly class TrimmedArgs implements Args
 {
+    /** Initializes with the args to trim. */
     public function __construct(private Args $origin) {}
 
     /** @return list<int|float|string|bool> */

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -7,12 +7,13 @@ namespace Haspadar\Piqule\Formula\Args;
 use Override;
 
 /**
- * Removes matching outer single or double quotes
+ * Removes matching outer single or double quotes.
  *
  * Escape sequences inside the string are not processed
  */
 final readonly class UnquotedArgs implements Args
 {
+    /** Initializes with the args to unquote. */
     public function __construct(private Args $origin) {}
 
     /** @return list<int|float|string|bool> */

--- a/src/Formula/ExecutedFormula.php
+++ b/src/Formula/ExecutedFormula.php
@@ -10,10 +10,11 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * Evaluates a pipeline of actions and returns the resulting scalar string
+ * Evaluates a pipeline of actions and returns the resulting scalar string.
  */
 final readonly class ExecutedFormula implements Formula
 {
+    /** Initializes with a sequence of actions to evaluate. */
     public function __construct(private Actions $actions) {}
 
     /** @throws PiquleException */

--- a/src/Formula/NormalizedFormula.php
+++ b/src/Formula/NormalizedFormula.php
@@ -7,10 +7,11 @@ namespace Haspadar\Piqule\Formula;
 use Override;
 
 /**
- * Normalizes whitespace around pipe separators in a DSL expression
+ * Normalizes whitespace around pipe separators in a DSL expression.
  */
 final readonly class NormalizedFormula implements Formula
 {
+    /** Initializes with a raw DSL expression string. */
     public function __construct(private string $expression) {}
 
     #[Override]

--- a/src/Output/Console.php
+++ b/src/Output/Console.php
@@ -7,7 +7,7 @@ namespace Haspadar\Piqule\Output;
 use Override;
 
 /**
- * Writes colorized messages to STDOUT (info, success) and STDERR (error)
+ * Writes colorized messages to STDOUT (info, success) and STDERR (error).
  */
 final readonly class Console implements Output
 {

--- a/src/Output/Message.php
+++ b/src/Output/Message.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Output;
 
 /**
- * An immutable text message with a plain string body
+ * An immutable text message with a plain string body.
  */
 final readonly class Message
 {
+    /** Initializes with the message text. */
     public function __construct(private string $body) {}
 
+    /** Returns the message text. */
     public function body(): string
     {
         return $this->body;

--- a/src/PiquleException.php
+++ b/src/PiquleException.php
@@ -7,6 +7,6 @@ namespace Haspadar\Piqule;
 use RuntimeException;
 
 /**
- * The only exception type used by Piqule
+ * The only exception type used by Piqule.
  */
 final class PiquleException extends RuntimeException {}

--- a/src/Secret/CodecovSecret.php
+++ b/src/Secret/CodecovSecret.php
@@ -9,7 +9,7 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * Codecov coverage upload token
+ * Codecov coverage upload token.
  */
 final readonly class CodecovSecret implements Secret
 {

--- a/src/Secret/InfectionSecret.php
+++ b/src/Secret/InfectionSecret.php
@@ -9,7 +9,7 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * Stryker mutation testing dashboard token
+ * Stryker mutation testing dashboard token.
  */
 final readonly class InfectionSecret implements Secret
 {

--- a/src/Secret/Secrets.php
+++ b/src/Secret/Secrets.php
@@ -5,14 +5,22 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Secret;
 
 /**
- * Collection of CI secrets
+ * Collection of CI secrets.
  */
 final readonly class Secrets
 {
-    /** @param list<Secret> $items */
+    /**
+     * Initializes with a list of CI secrets.
+     *
+     * @param list<Secret> $items
+     */
     public function __construct(private array $items) {}
 
-    /** @return list<Secret> */
+    /**
+     * Returns all secrets in this collection.
+     *
+     * @return list<Secret>
+     */
     public function items(): array
     {
         return $this->items;

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -11,24 +11,18 @@ use Haspadar\Piqule\Storage\Reaction\StorageReaction;
 use Override;
 
 /**
- * Appends file contents to an existing file unless the marker string is already present
+ * Appends file contents to an existing file unless the marker string is already present.
  */
 final readonly class AppendingStorage implements Storage
 {
+    /** Initializes with underlying storage, a reaction, and a duplicate marker. */
     public function __construct(
         private Storage $origin,
         private StorageReaction $reaction,
         private string $marker,
     ) {}
 
-    /**
-     * Writes the file to storage with append semantics:
-     * - Creates a new file and emits created() if the file does not exist yet.
-     * - Appends contents to an existing file and emits updated() if the marker is absent.
-     * - No-ops if the marker is already present in the existing file.
-     *
-     * @throws PiquleException
-     */
+    /** @throws PiquleException */
     #[Override]
     public function write(File $file): self
     {

--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -10,10 +10,11 @@ use Haspadar\Piqule\Storage\Reaction\StorageReaction;
 use Override;
 
 /**
- * Writes a file only when its contents or mode differ from what is already stored
+ * Writes a file only when its contents or mode differ from what is already stored.
  */
 final readonly class DiffingStorage implements Storage
 {
+    /** Initializes with underlying storage and a change reaction. */
     public function __construct(private Storage $origin, private StorageReaction $reaction) {}
 
     /** @throws PiquleException */

--- a/src/Storage/OnceStorage.php
+++ b/src/Storage/OnceStorage.php
@@ -10,10 +10,11 @@ use Haspadar\Piqule\Storage\Reaction\StorageReaction;
 use Override;
 
 /**
- * Writes a file only if it does not already exist in the underlying storage
+ * Writes a file only if it does not already exist in the underlying storage.
  */
 final readonly class OnceStorage implements Storage
 {
+    /** Initializes with underlying storage and a creation reaction. */
     public function __construct(private Storage $origin, private StorageReaction $reaction) {}
 
     /** @throws PiquleException */

--- a/src/Storage/Reaction/ReportingStorageReaction.php
+++ b/src/Storage/Reaction/ReportingStorageReaction.php
@@ -8,10 +8,11 @@ use Haspadar\Piqule\Output\Output;
 use Override;
 
 /**
- * Reports created and updated storage events to an Output channel
+ * Reports created and updated storage events to an Output channel.
  */
 final readonly class ReportingStorageReaction implements StorageReaction
 {
+    /** Initializes with the output channel for reporting. */
     public function __construct(private Output $output) {}
 
     #[Override]

--- a/src/Storage/Reaction/StorageReactions.php
+++ b/src/Storage/Reaction/StorageReactions.php
@@ -7,11 +7,15 @@ namespace Haspadar\Piqule\Storage\Reaction;
 use Override;
 
 /**
- * Composite StorageReaction that broadcasts events to a list of reactions
+ * Composite StorageReaction that broadcasts events to a list of reactions.
  */
 final readonly class StorageReactions implements StorageReaction
 {
-    /** @param list<StorageReaction> $reactions */
+    /**
+     * Initializes with a list of reactions to broadcast to.
+     *
+     * @param list<StorageReaction> $reactions
+     */
     public function __construct(private array $reactions) {}
 
     #[Override]

--- a/src/Storage/SafePath.php
+++ b/src/Storage/SafePath.php
@@ -7,13 +7,18 @@ namespace Haspadar\Piqule\Storage;
 use Haspadar\Piqule\PiquleException;
 
 /**
- * Resolves a relative location to an absolute path within a storage root, preventing path traversal
+ * Resolves a relative location to an absolute path within a storage root, preventing path traversal.
  */
 final readonly class SafePath
 {
+    /** Initializes with the storage root directory. */
     public function __construct(private string $root) {}
 
-    /** @throws PiquleException */
+    /**
+     * Returns the safe absolute path for a relative location.
+     *
+     * @throws PiquleException
+     */
     public function resolve(string $location): string
     {
         $parts = [];


### PR DESCRIPTION
- Added PHPDoc summaries to all public classes and interfaces
- Fixed punctuation to comply with phpdocPunctuation rule

Part of #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized PHPDoc comments across configuration, file handling, formula processing, output, storage, and secrets modules.
  * Enhanced constructor and method documentation with consistent formatting and detailed descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->