### PR TITLE
Extract ConfigPaths Value Object

### DIFF
--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\Config\ConfigPaths;
 use Haspadar\Piqule\Config\DefaultConfig;
 use Haspadar\Piqule\Config\YamlConfig;
 
@@ -20,7 +21,7 @@ $projectRoot = $cwd;
 $yamlPath = $projectRoot . '/.piqule.yaml';
 
 try {
-    $defaults = new DefaultConfig(composerJson: $projectRoot . '/composer.json');
+    $defaults = new DefaultConfig(paths: new ConfigPaths($projectRoot . '/composer.json'));
 } catch (Throwable $e) {
     fwrite(STDERR, "Failed to load default config: {$e->getMessage()}\n");
     exit(1);

--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -3,9 +3,10 @@
 
 declare(strict_types=1);
 
+use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\Config\ConfigPaths;
 use Haspadar\Piqule\Config\DefaultConfig;
 use Haspadar\Piqule\Config\YamlConfig;
-use Haspadar\Piqule\Config\Config;
 use Haspadar\Piqule\File\ConfiguredFile;
 use Haspadar\Piqule\File\File;
 use Haspadar\Piqule\File\PrefixedFile;
@@ -39,7 +40,7 @@ try {
     $libraryRoot = $installPath;
 
     $yamlPath = $projectRoot . '/.piqule.yaml';
-    $defaults = new DefaultConfig(composerJson: $projectRoot . '/composer.json');
+    $defaults = new DefaultConfig(paths: new ConfigPaths($projectRoot . '/composer.json'));
 
     if (file_exists($yamlPath)) {
         $config = new YamlConfig($yamlPath, $defaults);

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 use Haspadar\Piqule\Config\Config;
+use Haspadar\Piqule\Config\ConfigPaths;
 use Haspadar\Piqule\Config\DefaultConfig;
 use Haspadar\Piqule\Config\YamlConfig;
 use Haspadar\Piqule\EnvVar\EnvVars;
@@ -21,7 +22,7 @@ $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
 $yamlPath = $projectRoot . '/.piqule.yaml';
 
 try {
-    $defaults = new DefaultConfig(composerJson: $projectRoot . '/composer.json');
+    $defaults = new DefaultConfig(paths: new ConfigPaths($projectRoot . '/composer.json'));
 } catch (Throwable $e) {
     $output->error("Failed to load default config: {$e->getMessage()}");
     exit(1);

--- a/src/Config/ConfigPaths.php
+++ b/src/Config/ConfigPaths.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Config;
+
+/**
+ * Paths used to locate configuration files
+ */
+final readonly class ConfigPaths
+{
+    public function __construct(
+        private string $composerJson = '',
+        private string $configYaml = __DIR__ . '/../../templates/always/.piqule/config.yaml',
+    ) {}
+
+    /** Returns the composer.json file path */
+    public function composerJson(): string
+    {
+        return $this->composerJson;
+    }
+
+    /** Returns the config.yaml file path */
+    public function configYaml(): string
+    {
+        return $this->configYaml;
+    }
+}

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -21,7 +21,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  *     new DefaultConfig();
  *
- *     new DefaultConfig(composerJson: '/path/to/composer.json');
+ *     new DefaultConfig(paths: new ConfigPaths(composerJson: '/path/to/composer.json'));
  */
 final class DefaultConfig implements Config
 {
@@ -37,11 +37,10 @@ final class DefaultConfig implements Config
     public function __construct(
         array $phpSrc = [],
         array $exclude = [],
-        private readonly string $composerJson = '',
-        string $configPath = __DIR__ . '/../../templates/always/.piqule/config.yaml',
+        private readonly ConfigPaths $paths = new ConfigPaths(),
     ) {
         /** @var array<string, mixed> $yaml */
-        $yaml = Yaml::parseFile($configPath);
+        $yaml = Yaml::parseFile($this->paths->configYaml());
 
         if (!array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
             throw new PiquleException('Missing "defaults" section in config.yaml');
@@ -99,9 +98,10 @@ final class DefaultConfig implements Config
         return $this->defaults;
     }
 
+    /** Returns the composer.json file path */
     public function composerJson(): string
     {
-        return $this->composerJson;
+        return $this->paths->composerJson();
     }
 
     /**
@@ -125,7 +125,7 @@ final class DefaultConfig implements Config
             'php_cs_fixer.exclude' => $exclude,
             'phpcs.excludes' => (new GlobDirs($exclude))->toList(),
             'phpcs.files' => $projectIncludes,
-            'phpcs.root_namespace' => (new ComposerRootNamespace($this->composerJson))->toString(),
+            'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
             'phpmd.paths' => $phpSrc,
             'phpmetrics.includes' => $projectIncludes,
             'phpmetrics.excludes' => $exclude,

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -39,10 +39,9 @@ final class DefaultConfig implements Config
         array $exclude = [],
         private readonly ConfigPaths $paths = new ConfigPaths(),
     ) {
-        /** @var array<string, mixed> $yaml */
         $yaml = Yaml::parseFile($this->paths->configYaml());
 
-        if (!array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
+        if (!is_array($yaml) || !array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
             throw new PiquleException('Missing "defaults" section in config.yaml');
         }
 

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -98,10 +98,10 @@ final class DefaultConfig implements Config
         return $this->defaults;
     }
 
-    /** Returns the composer.json file path */
-    public function composerJson(): string
+    /** Returns the configuration paths */
+    public function configPaths(): ConfigPaths
     {
-        return $this->paths->composerJson();
+        return $this->paths;
     }
 
     /**

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -69,7 +69,7 @@ final readonly class YamlConfig implements Config
                 new DefaultConfig(
                     $pathKeys->phpSrc(),
                     $pathKeys->exclude(),
-                    new ConfigPaths($defaults->composerJson()),
+                    $defaults->configPaths(),
                 ),
                 array_diff_key($overrides, array_flip($remaining)),
             ),

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -66,7 +66,11 @@ final readonly class YamlConfig implements Config
 
         $this->config = new AppendConfig(
             new OverrideConfig(
-                new DefaultConfig($pathKeys->phpSrc(), $pathKeys->exclude(), $defaults->composerJson()),
+                new DefaultConfig(
+                    $pathKeys->phpSrc(),
+                    $pathKeys->exclude(),
+                    new ConfigPaths($defaults->composerJson()),
+                ),
                 array_diff_key($overrides, array_flip($remaining)),
             ),
             array_diff_key($appends, array_flip($remaining)),

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Tests\Unit\Config;
 
+use Haspadar\Piqule\Config\ConfigPaths;
 use Haspadar\Piqule\Config\DefaultConfig;
 use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Tests\Fixture\TempFolder;
@@ -140,7 +141,7 @@ final class DefaultConfigTest extends TestCase
             '{"autoload":{"psr-4":{"Acme\\\\":"src/"}}}',
         );
 
-        $namespace = (new DefaultConfig(composerJson: $folder->path() . '/composer.json'))->list('phpcs.root_namespace');
+        $namespace = (new DefaultConfig(paths: new ConfigPaths($folder->path() . '/composer.json')))->list('phpcs.root_namespace');
 
         $folder->close();
 
@@ -160,7 +161,7 @@ final class DefaultConfigTest extends TestCase
         $this->expectExceptionMessage('Missing "defaults" section');
 
         try {
-            new DefaultConfig(configPath: $folder->path() . '/empty.yaml');
+            new DefaultConfig(paths: new ConfigPaths(configYaml: $folder->path() . '/empty.yaml'));
         } finally {
             $folder->close();
         }


### PR DESCRIPTION
- Added ConfigPaths to combine composerJson and configYaml path parameters
- Updated DefaultConfig constructor from four parameters to three
- Updated bin scripts and tests to use ConfigPaths

Part of #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration path handling into a new value object for clearer, consistent initialization across CLI tools.
  * Command-line scripts updated to use the unified path object.
  * Tests updated to reflect the new initialization approach.
  * Improved robustness of default configuration loading.
  * No user-facing behavior changes; existing configuration and defaults remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->