### PR TITLE
Lazy Constructors for Config Classes

### DIFF
--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -25,58 +25,30 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class DefaultConfig implements Config
 {
-    /** @var array<string, scalar|list<scalar>> */
-    private readonly array $defaults;
+    /** @var array<string, scalar|list<scalar>>|null */
+    private ?array $cache;
 
     /**
+     * Initializes with source directories, exclusions, and config paths
+     *
      * @param list<string> $phpSrc
      * @param list<string> $exclude
-     * @throws ParseException
-     * @throws PiquleException
      */
     public function __construct(
-        array $phpSrc = [],
-        array $exclude = [],
+        private readonly array $phpSrc = [],
+        private readonly array $exclude = [],
         private readonly ConfigPaths $paths = new ConfigPaths(),
     ) {
-        $yaml = Yaml::parseFile($this->paths->configYaml());
-
-        if (!is_array($yaml) || !array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
-            throw new PiquleException('Missing "defaults" section in config.yaml');
-        }
-
-        /** @var array<string, mixed> $base */
-        $base = $yaml['defaults'];
-
-        /** @var list<string> $resolvedPhpSrc */
-        $resolvedPhpSrc = $phpSrc !== []
-            ? $phpSrc
-            : ($base['php.src'] ?? []);
-
-        /** @var list<string> $resolvedExclude */
-        $resolvedExclude = $exclude !== []
-            ? $exclude
-            : ($base['exclude'] ?? []);
-
-        /** @var array<string, scalar|list<scalar>> $defaults */
-        $defaults = array_merge($base, $this->dynamic($resolvedPhpSrc, $resolvedExclude));
-        $this->defaults = $defaults;
+        $this->cache = null;
     }
 
-    /**
-     * Checks whether a configuration key exists in built-in defaults
-     */
     #[Override]
     public function has(string $name): bool
     {
-        return array_key_exists($name, $this->defaults);
+        return array_key_exists($name, $this->defaults());
     }
 
-    /**
-     * Returns the configuration value as a list
-     *
-     * @return list<int|float|string|bool>
-     */
+    /** @return list<int|float|string|bool> */
     #[Override]
     public function list(string $name): array
     {
@@ -84,7 +56,7 @@ final class DefaultConfig implements Config
             return [];
         }
 
-        $value = $this->defaults[$name];
+        $value = $this->defaults()[$name];
 
         return is_scalar($value)
             ? [$value]
@@ -94,13 +66,60 @@ final class DefaultConfig implements Config
     #[Override]
     public function toArray(): array
     {
-        return $this->defaults;
+        return $this->defaults();
     }
 
     /** Returns the configuration paths */
     public function configPaths(): ConfigPaths
     {
         return $this->paths;
+    }
+
+    /**
+     * Parses YAML and computes all defaults with dynamic path derivations
+     *
+     * @throws PiquleException
+     * @return array<string, scalar|list<scalar>>
+     */
+    private function defaults(): array
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        try {
+            /** @var array<string, mixed> $yaml */
+            $yaml = Yaml::parseFile($this->paths->configYaml());
+        } catch (ParseException $e) {
+            throw new PiquleException(
+                sprintf('Failed to parse config "%s": %s', $this->paths->configYaml(), $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        if (!is_array($yaml) || !array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
+            throw new PiquleException('Missing "defaults" section in config.yaml');
+        }
+
+        /** @var array<string, mixed> $base */
+        $base = $yaml['defaults'];
+
+        /** @var list<string> $resolvedPhpSrc */
+        $resolvedPhpSrc = $this->phpSrc !== []
+            ? $this->phpSrc
+            : ($base['php.src'] ?? []);
+
+        /** @var list<string> $resolvedExclude */
+        $resolvedExclude = $this->exclude !== []
+            ? $this->exclude
+            : ($base['exclude'] ?? []);
+
+        /** @var array<string, scalar|list<scalar>> $defaults */
+        $defaults = array_merge($base, $this->dynamic($resolvedPhpSrc, $resolvedExclude));
+        $this->cache = $defaults;
+
+        return $defaults;
     }
 
     /**

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -88,7 +88,6 @@ final class DefaultConfig implements Config
         }
 
         try {
-            /** @var array<string, mixed> $yaml */
             $yaml = Yaml::parseFile($this->paths->configYaml());
         } catch (ParseException $e) {
             throw new PiquleException(

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -26,21 +26,54 @@ use Symfony\Component\Yaml\Yaml;
  *         exclude:
  *             - legacy
  */
-final readonly class YamlConfig implements Config
+final class YamlConfig implements Config
 {
-    private Config $config;
+    private ?Config $cache;
 
     /**
-     * @throws PiquleException
-     * @throws YamlParseException
+     * Initializes with a YAML file path and default configuration
      */
-    public function __construct(string $path, DefaultConfig $defaults)
+    public function __construct(
+        private readonly string $path,
+        private readonly DefaultConfig $defaults,
+    ) {
+        $this->cache = null;
+    }
+
+    #[Override]
+    public function has(string $name): bool
     {
+        return $this->config()->has($name);
+    }
+
+    #[Override]
+    public function list(string $name): array
+    {
+        return $this->config()->list($name);
+    }
+
+    #[Override]
+    public function toArray(): array
+    {
+        return $this->config()->toArray();
+    }
+
+    /**
+     * Parses the YAML file and builds the layered configuration
+     *
+     * @throws PiquleException
+     */
+    private function config(): Config
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
         try {
-            $data = Yaml::parseFile($path);
+            $data = Yaml::parseFile($this->path);
         } catch (YamlParseException $e) {
             throw new PiquleException(
-                sprintf('Failed to parse "%s": %s', $path, $e->getMessage()),
+                sprintf('Failed to parse "%s": %s', $this->path, $e->getMessage()),
                 0,
                 $e,
             );
@@ -48,7 +81,7 @@ final readonly class YamlConfig implements Config
 
         if (!is_array($data)) {
             throw new PiquleException(
-                sprintf('Invalid configuration file "%s": expected a mapping', $path),
+                sprintf('Invalid configuration file "%s": expected a mapping', $this->path),
             );
         }
 
@@ -61,42 +94,21 @@ final readonly class YamlConfig implements Config
             ? $data['append']
             : [];
 
-        $pathKeys = new YamlPathKeys($overrides, $appends, $defaults);
+        $pathKeys = new YamlPathKeys($overrides, $appends, $this->defaults);
         $remaining = ['exclude', 'php.src'];
 
-        $this->config = new AppendConfig(
+        $this->cache = new AppendConfig(
             new OverrideConfig(
                 new DefaultConfig(
                     $pathKeys->phpSrc(),
                     $pathKeys->exclude(),
-                    $defaults->configPaths(),
+                    $this->defaults->configPaths(),
                 ),
                 array_diff_key($overrides, array_flip($remaining)),
             ),
             array_diff_key($appends, array_flip($remaining)),
         );
-    }
 
-    #[Override]
-    public function has(string $name): bool
-    {
-        return $this->config->has($name);
-    }
-
-    /**
-     * @throws PiquleException
-     * @return list<scalar>
-     */
-    #[Override]
-    public function list(string $name): array
-    {
-        return $this->config->list($name);
-    }
-
-    /** @throws PiquleException */
-    #[Override]
-    public function toArray(): array
-    {
-        return $this->config->toArray();
+        return $this->cache;
     }
 }

--- a/src/Config/YamlPathKeys.php
+++ b/src/Config/YamlPathKeys.php
@@ -12,39 +12,50 @@ use Haspadar\Piqule\PiquleException;
  */
 final readonly class YamlPathKeys
 {
-    /** @var list<string> */
-    private array $phpSrc;
-
-    /** @var list<string> */
-    private array $exclude;
-
     /**
      * @param array<string, mixed> $overrides
      * @param array<string, mixed> $appends
-     * @throws PiquleException
      */
-    public function __construct(array $overrides, array $appends, DefaultConfig $defaults)
+    public function __construct(
+        private array $overrides,
+        private array $appends,
+        private DefaultConfig $defaults,
+    ) {}
+
+    /**
+     * @throws PiquleException
+     * @return list<string>
+     */
+    public function phpSrc(): array
     {
-        $phpSrc = array_key_exists('php.src', $overrides) && is_array($overrides['php.src'])
-            ? $this->toStringList(array_values($overrides['php.src']), 'override.php.src')
-            : $this->toStringList($defaults->list('php.src'), 'php.src');
+        $result = array_key_exists('php.src', $this->overrides) && is_array($this->overrides['php.src'])
+            ? $this->toStringList(array_values($this->overrides['php.src']), 'override.php.src')
+            : $this->toStringList($this->defaults->list('php.src'), 'php.src');
 
-        $exclude = array_key_exists('exclude', $overrides) && is_array($overrides['exclude'])
-            ? $this->toStringList(array_values($overrides['exclude']), 'override.exclude')
-            : $this->toStringList($defaults->list('exclude'), 'exclude');
-
-        if (array_key_exists('exclude', $appends) && is_array($appends['exclude'])) {
-            $extra = $this->toStringList(array_values($appends['exclude']), 'append.exclude');
-            $exclude = array_values(array_unique(array_merge($exclude, $extra)));
+        if (array_key_exists('php.src', $this->appends) && is_array($this->appends['php.src'])) {
+            $extra = $this->toStringList(array_values($this->appends['php.src']), 'append.php.src');
+            $result = array_values(array_unique(array_merge($result, $extra)));
         }
 
-        if (array_key_exists('php.src', $appends) && is_array($appends['php.src'])) {
-            $extra = $this->toStringList(array_values($appends['php.src']), 'append.php.src');
-            $phpSrc = array_values(array_unique(array_merge($phpSrc, $extra)));
+        return $result;
+    }
+
+    /**
+     * @throws PiquleException
+     * @return list<string>
+     */
+    public function exclude(): array
+    {
+        $result = array_key_exists('exclude', $this->overrides) && is_array($this->overrides['exclude'])
+            ? $this->toStringList(array_values($this->overrides['exclude']), 'override.exclude')
+            : $this->toStringList($this->defaults->list('exclude'), 'exclude');
+
+        if (array_key_exists('exclude', $this->appends) && is_array($this->appends['exclude'])) {
+            $extra = $this->toStringList(array_values($this->appends['exclude']), 'append.exclude');
+            $result = array_values(array_unique(array_merge($result, $extra)));
         }
 
-        $this->phpSrc = $phpSrc;
-        $this->exclude = $exclude;
+        return $result;
     }
 
     /**
@@ -67,17 +78,5 @@ final readonly class YamlPathKeys
         }
 
         return $result;
-    }
-
-    /** @return list<string> */
-    public function phpSrc(): array
-    {
-        return $this->phpSrc;
-    }
-
-    /** @return list<string> */
-    public function exclude(): array
-    {
-        return $this->exclude;
     }
 }

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -168,4 +168,21 @@ final class DefaultConfigTest extends TestCase
             $folder->close();
         }
     }
+
+    #[Test]
+    public function throwsWhenConfigYamlContainsInvalidSyntax(): void
+    {
+        $folder = (new TempFolder())->withFile('broken.yaml', ": invalid: yaml: :");
+
+        $this->expectException(PiquleException::class);
+        $this->expectExceptionMessage('Failed to parse config');
+
+        $config = new DefaultConfig(paths: new ConfigPaths(configYaml: $folder->path() . '/broken.yaml'));
+
+        try {
+            $config->has('any');
+        } finally {
+            $folder->close();
+        }
+    }
 }

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -160,8 +160,10 @@ final class DefaultConfigTest extends TestCase
         $this->expectException(PiquleException::class);
         $this->expectExceptionMessage('Missing "defaults" section');
 
+        $config = new DefaultConfig(paths: new ConfigPaths(configYaml: $folder->path() . '/empty.yaml'));
+
         try {
-            new DefaultConfig(paths: new ConfigPaths(configYaml: $folder->path() . '/empty.yaml'));
+            $config->has('any');
         } finally {
             $folder->close();
         }

--- a/tests/Unit/Config/YamlConfigTest.php
+++ b/tests/Unit/Config/YamlConfigTest.php
@@ -105,22 +105,28 @@ final class YamlConfigTest extends TestCase
     }
 
     #[Test]
-    public function toArrayReturnsAllKeysWithOverridesAndAppendsApplied(): void
+    public function toArrayIncludesOverriddenValue(): void
     {
-        $path = $this->folder->withFile('.piqule.yaml', "override:\n    phpstan.level: 7\nappend:\n    phpstan.neon_includes:\n        - ../../rules.neon\n")->path() . '/.piqule.yaml';
+        $path = $this->folder->withFile('.piqule.yaml', "override:\n    phpstan.level: 7\n")->path() . '/.piqule.yaml';
 
+        self::assertSame(
+            [7],
+            (new YamlConfig($path, new DefaultConfig()))->toArray()['phpstan.level'],
+            'toArray must reflect overridden phpstan.level',
+        );
+    }
+
+    #[Test]
+    public function returnsCachedConfigOnRepeatedAccess(): void
+    {
+        $path = $this->folder->withFile('.piqule.yaml', "override:\n    phpstan.level: 7\n")->path() . '/.piqule.yaml';
         $config = new YamlConfig($path, new DefaultConfig());
+        $config->has('phpstan.level');
 
         self::assertSame(
             [7],
             $config->list('phpstan.level'),
-            'toArray must reflect overridden phpstan.level',
-        );
-
-        self::assertSame(
-            ['../../vendor/phpstan/phpstan-strict-rules/rules.neon', '../../rules.neon'],
-            $config->list('phpstan.neon_includes'),
-            'toArray must reflect appended phpstan.neon_includes',
+            'repeated access must return the same cached result',
         );
     }
 


### PR DESCRIPTION
- Refactored DefaultConfig to defer YAML parsing to first access
- Refactored YamlConfig to defer config building to first access
- Refactored YamlPathKeys to defer path resolution to method calls

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration values are now lazily loaded and cached for improved performance.
  * YAML parsing deferred until first access instead of at initialization.

* **Bug Fixes**
  * Enhanced error handling for invalid YAML syntax in configuration files.

* **Tests**
  * Added tests for configuration caching behavior and YAML syntax validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->