### PR TITLE
Config Keys Use Cli Instead of Enabled

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -28,9 +28,9 @@ defaults:
 
   docker.image: "ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23"
 
-  actionlint.enabled: true
+  actionlint.cli: true
 
-  hadolint.enabled: true
+  hadolint.cli: true
   hadolint.failure_threshold: "error"
   hadolint.ignore: ["vendor", "tests", ".git"]
   hadolint.ignored_yaml: "[]"
@@ -38,27 +38,27 @@ defaults:
   hadolint.override.warning_yaml: "[]"
   hadolint.patterns: ["Dockerfile*"]
 
-  jsonlint.enabled: true
+  jsonlint.cli: true
   jsonlint.compact: true
   jsonlint.continue: true
   jsonlint.duplicate_keys: false
   jsonlint.mode: ["json5"]
   jsonlint.patterns: ["**/*.json", "**/*.json5", "**/*.jsonc", "!vendor/**", "!tests/**", "!.git/**"]
 
-  markdownlint.enabled: true
+  markdownlint.cli: true
   markdownlint.ignores: ["vendor/**", "tests/**", ".git/**"]
 
-  php-cs-fixer.enabled: true
+  php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
   php_cs_fixer.paths: ["../.."]
 
-  phpcs.enabled: true
+  phpcs.cli: true
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""
 
-  phpmd.enabled: true
+  phpmd.cli: true
   phpmd.paths: ["src"]
   phpmd.class_complexity: 50
   phpmd.class_length: 200
@@ -69,7 +69,7 @@ defaults:
   phpmd.method_length: 50
   phpmd.npath: 200
 
-  phpmetrics.enabled: true
+  phpmetrics.cli: true
   phpmetrics.includes: ["../../src"]
   phpmetrics.excludes: ["vendor", "tests", ".git"]
   phpmetrics.extensions: ["php"]
@@ -89,32 +89,32 @@ defaults:
   phpmetrics.size.max_logical_loc_per_method: 20
   phpmetrics.structure.max_methods_per_class: 10
 
-  phpstan.enabled: true
+  phpstan.cli: true
   phpstan.level: 9
   phpstan.memory: "1G"
   phpstan.paths: ["../../src"]
   phpstan.checked_exceptions: ['\Throwable']
   phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon"]
 
-  phpunit.enabled: true
+  phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
   phpunit.source.include: ["../../src"]
   phpunit.testsuites.unit: ["../../tests/Unit"]
   phpunit.testsuites.integration: ["../../tests/Integration"]
 
-  psalm.enabled: true
+  psalm.cli: true
   psalm.error_level: 1
   psalm.project.directories: ["../../src"]
   psalm.project.files: []
   psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
   psalm.suppress.possibly_unused: []
 
-  infection.enabled: true
+  infection.cli: true
   infection.php_options: "-d memory_limit=1G"
   infection.source.directories: ["../../src"]
   infection.timeout: 30
 
-  shellcheck.enabled: true
+  shellcheck.cli: true
   shellcheck.exclude: []
   shellcheck.external_sources: true
   shellcheck.ignore_dirs: ["vendor", "tests", ".git"]
@@ -123,7 +123,7 @@ defaults:
   shellcheck.source_path: "."
 
   sonar.cloud: true
-  sonar.enabled: true
+  sonar.cli: true
   sonar.organization: []
   sonar.projectKey: []
   sonar.sources: ["src"]
@@ -131,9 +131,9 @@ defaults:
   sonar.exclusions: []
   sonar.php.coverage.reportPaths: [".piqule/codecov/coverage.xml"]
 
-  typos.enabled: true
+  typos.cli: true
   typos.exclude: ["vendor/", "tests/", ".git/"]
 
-  yamllint.enabled: true
+  yamllint.cli: true
   yamllint.ignore: ["vendor/**", "tests/**", ".git/**", ".piqule/**/html/**", ".piqule/**/coverage-report/**"]
   yamllint.line_length.max: 120

--- a/.piqule/sonar/command.sh
+++ b/.piqule/sonar/command.sh
@@ -37,7 +37,7 @@ else
 fi
 
 PROJECT_ROOT="$(pwd)"
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:a8efe1ce4921b5faebe7f9f0dcc8465151f5a2db5637aa0b4cd27c9e44cdfcef}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/DEV.md
+++ b/DEV.md
@@ -237,7 +237,7 @@ For a full description of every class and the decorator pattern, see [docs/archi
 2. Add any config keys the tool needs to `src/Config/DefaultConfig.php` (`DEFAULTS` array)
 3. Register the new key type in `src/Config/OverrideConfig.php` (`OverrideMap` PHPDoc)
 4. Add the tool name to `$checks` in `bin/piqule-check`
-5. Add `'<tool>.enabled' => true` to `DefaultConfig` and `'<tool>.enabled'?: bool` to `OverrideMap` in `OverrideConfig`
+5. Add `'<tool>.cli' => true` to `DefaultConfig` and `'<tool>.cli'?: bool` to `OverrideMap` in `OverrideConfig`
 6. Run `vendor/bin/piqule sync` to verify template rendering
 7. Write unit and integration tests
 
@@ -286,9 +286,9 @@ Each env var implements `EnvVar` (`src/EnvVar/EnvVar.php`):
 
 | Class | Name | Type | Enabled when |
 |-------|------|------|-------------|
-| `CodecovSecret` | `CODECOV_TOKEN` | Secret | `phpunit.enabled` is true |
-| `InfectionSecret` | `STRYKER_DASHBOARD_API_KEY` | Secret | `infection.enabled` is true |
-| `SonarEnvVar` | `SONAR_TOKEN` | EnvVar | `sonar.cloud` is false and `sonar.enabled` is true |
+| `CodecovSecret` | `CODECOV_TOKEN` | Secret | `phpunit.cli` is true |
+| `InfectionSecret` | `STRYKER_DASHBOARD_API_KEY` | Secret | `infection.cli` is true |
+| `SonarEnvVar` | `SONAR_TOKEN` | EnvVar | `sonar.cloud` is false and `sonar.cli` is true |
 
 ### Adding a Secret
 
@@ -350,13 +350,13 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `actionlint.enabled` | `true` | Enable GitHub Actions linting |
+| `actionlint.cli` | `true` | Enable GitHub Actions linting |
 
 ### hadolint
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `hadolint.enabled` | `true` | Enable Dockerfile linting |
+| `hadolint.cli` | `true` | Enable Dockerfile linting |
 | `hadolint.failure_threshold` | `"error"` | Minimum severity to fail |
 | `hadolint.ignore` | `["vendor", "tests", ".git"]` | Ignored directories |
 | `hadolint.ignored_yaml` | `"[]"` | Ignored rules (YAML literal) |
@@ -368,7 +368,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `jsonlint.enabled` | `true` | Enable JSON linting |
+| `jsonlint.cli` | `true` | Enable JSON linting |
 | `jsonlint.compact` | `true` | Compact output |
 | `jsonlint.continue` | `true` | Continue on error |
 | `jsonlint.duplicate_keys` | `false` | Allow duplicate keys |
@@ -379,14 +379,14 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `markdownlint.enabled` | `true` | Enable Markdown linting |
+| `markdownlint.cli` | `true` | Enable Markdown linting |
 | `markdownlint.ignores` | `["vendor/**", "tests/**", ".git/**"]` | Ignored patterns |
 
 ### php-cs-fixer
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `php-cs-fixer.enabled` | `true` | Enable PHP CS Fixer |
+| `php-cs-fixer.cli` | `true` | Enable PHP CS Fixer |
 | `php_cs_fixer.allow_unsupported` | `["true"]` | Allow unsupported PHP versions |
 | `php_cs_fixer.exclude` | `["vendor", "tests", ".git"]` | Excluded directories |
 | `php_cs_fixer.paths` | `["../.."]` | Paths to fix |
@@ -395,7 +395,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `phpcs.enabled` | `true` | Enable PHP_CodeSniffer |
+| `phpcs.cli` | `true` | Enable PHP_CodeSniffer |
 | `phpcs.excludes` | `["vendor/*", "tests/*", ".git/*"]` | Excluded patterns |
 | `phpcs.files` | `["../../src"]` | Files/directories to check |
 | `phpcs.root_namespace` | `""` | Root namespace for PSR-4 check |
@@ -404,7 +404,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `phpmd.enabled` | `true` | Enable PHP Mess Detector |
+| `phpmd.cli` | `true` | Enable PHP Mess Detector |
 | `phpmd.paths` | `["src"]` | Source paths |
 | `phpmd.class_complexity` | `50` | Max class complexity |
 | `phpmd.class_length` | `200` | Max class length |
@@ -419,7 +419,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `phpmetrics.enabled` | `true` | Enable PHP Metrics |
+| `phpmetrics.cli` | `true` | Enable PHP Metrics |
 | `phpmetrics.includes` | `["../../src"]` | Included directories |
 | `phpmetrics.excludes` | `["vendor", "tests", ".git"]` | Excluded directories |
 | `phpmetrics.extensions` | `["php"]` | File extensions |
@@ -443,7 +443,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `phpstan.enabled` | `true` | Enable PHPStan |
+| `phpstan.cli` | `true` | Enable PHPStan |
 | `phpstan.level` | `9` | Analysis level (0-9) |
 | `phpstan.memory` | `"1G"` | Memory limit |
 | `phpstan.paths` | `["../../src"]` | Paths to analyze |
@@ -454,7 +454,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `phpunit.enabled` | `true` | Enable PHPUnit |
+| `phpunit.cli` | `true` | Enable PHPUnit |
 | `phpunit.php_options` | `"-d memory_limit=1G"` | PHP CLI options |
 | `phpunit.source.include` | `["../../src"]` | Source directories for coverage |
 | `phpunit.testsuites.unit` | `["../../tests/Unit"]` | Unit test directories |
@@ -464,7 +464,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `psalm.enabled` | `true` | Enable Psalm |
+| `psalm.cli` | `true` | Enable Psalm |
 | `psalm.error_level` | `1` | Error level (1-8) |
 | `psalm.project.directories` | `["../../src"]` | Directories to analyze |
 | `psalm.project.files` | `[]` | Individual files to analyze |
@@ -475,7 +475,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `infection.enabled` | `true` | Enable Infection mutation testing |
+| `infection.cli` | `true` | Enable Infection mutation testing |
 | `infection.php_options` | `"-d memory_limit=1G"` | PHP CLI options |
 | `infection.source.directories` | `["../../src"]` | Source directories |
 | `infection.timeout` | `30` | Timeout per mutant (seconds) |
@@ -484,7 +484,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `shellcheck.enabled` | `true` | Enable ShellCheck |
+| `shellcheck.cli` | `true` | Enable ShellCheck |
 | `shellcheck.exclude` | `[]` | Excluded rule codes |
 | `shellcheck.external_sources` | `true` | Follow sourced files |
 | `shellcheck.ignore_dirs` | `["vendor", "tests", ".git"]` | Ignored directories |
@@ -497,7 +497,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | Key | Default | Description |
 |-----|---------|-------------|
 | `sonar.cloud` | `true` | Use SonarCloud automatic analysis (skip local scanner and SONAR_TOKEN) |
-| `sonar.enabled` | `true` | Enable SonarCloud |
+| `sonar.cli` | `true` | Enable local sonar-scanner |
 | `sonar.organization` | `[]` | SonarCloud organization |
 | `sonar.projectKey` | `[]` | SonarCloud project key |
 | `sonar.sources` | `["src"]` | Source directories |
@@ -509,13 +509,13 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `typos.enabled` | `true` | Enable typo checking |
+| `typos.cli` | `true` | Enable typo checking |
 | `typos.exclude` | `["vendor/", "tests/", ".git/"]` | Excluded directories |
 
 ### yamllint
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `yamllint.enabled` | `true` | Enable YAML linting |
+| `yamllint.cli` | `true` | Enable YAML linting |
 | `yamllint.ignore` | `["vendor/**", "tests/**", ...]` | Ignored patterns |
 | `yamllint.line_length.max` | `120` | Maximum line length |

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -102,9 +102,9 @@ if ($requested === '' && !$full) {
 }
 
 $isEnabled = static function(string $key) use ($config): bool {
-    $enabledKey = "{$key}.enabled";
+    $cliKey = "{$key}.cli";
 
-    return !$config->has($enabledKey) || (bool)($config->list($enabledKey)[0] ?? true);
+    return !$config->has($cliKey) || (bool)($config->list($cliKey)[0] ?? true);
 };
 
 $total = $requested !== ''

--- a/src/EnvVar/SonarEnvVar.php
+++ b/src/EnvVar/SonarEnvVar.php
@@ -33,12 +33,12 @@ final readonly class SonarEnvVar implements EnvVar
             return false;
         }
 
-        if (!$config->has('sonar.enabled')) {
+        if (!$config->has('sonar.cli')) {
             return true;
         }
 
         return filter_var(
-            $config->list('sonar.enabled')[0] ?? true,
+            $config->list('sonar.cli')[0] ?? true,
             FILTER_VALIDATE_BOOLEAN,
             FILTER_NULL_ON_FAILURE,
         ) ?? true;

--- a/src/Secret/CodecovSecret.php
+++ b/src/Secret/CodecovSecret.php
@@ -27,12 +27,12 @@ final readonly class CodecovSecret implements Secret
     #[Override]
     public function enabled(Config $config): bool
     {
-        if (!$config->has('phpunit.enabled')) {
+        if (!$config->has('phpunit.cli')) {
             return true;
         }
 
         return filter_var(
-            $config->list('phpunit.enabled')[0] ?? true,
+            $config->list('phpunit.cli')[0] ?? true,
             FILTER_VALIDATE_BOOLEAN,
             FILTER_NULL_ON_FAILURE,
         ) ?? true;

--- a/src/Secret/InfectionSecret.php
+++ b/src/Secret/InfectionSecret.php
@@ -27,12 +27,12 @@ final readonly class InfectionSecret implements Secret
     #[Override]
     public function enabled(Config $config): bool
     {
-        if (!$config->has('infection.enabled')) {
+        if (!$config->has('infection.cli')) {
             return true;
         }
 
         return filter_var(
-            $config->list('infection.enabled')[0] ?? true,
+            $config->list('infection.cli')[0] ?? true,
             FILTER_VALIDATE_BOOLEAN,
             FILTER_NULL_ON_FAILURE,
         ) ?? true;

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -28,9 +28,9 @@ defaults:
 
   docker.image: "ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23"
 
-  actionlint.enabled: true
+  actionlint.cli: true
 
-  hadolint.enabled: true
+  hadolint.cli: true
   hadolint.failure_threshold: "error"
   hadolint.ignore: ["vendor", "tests", ".git"]
   hadolint.ignored_yaml: "[]"
@@ -38,27 +38,27 @@ defaults:
   hadolint.override.warning_yaml: "[]"
   hadolint.patterns: ["Dockerfile*"]
 
-  jsonlint.enabled: true
+  jsonlint.cli: true
   jsonlint.compact: true
   jsonlint.continue: true
   jsonlint.duplicate_keys: false
   jsonlint.mode: ["json5"]
   jsonlint.patterns: ["**/*.json", "**/*.json5", "**/*.jsonc", "!vendor/**", "!tests/**", "!.git/**"]
 
-  markdownlint.enabled: true
+  markdownlint.cli: true
   markdownlint.ignores: ["vendor/**", "tests/**", ".git/**"]
 
-  php-cs-fixer.enabled: true
+  php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
   php_cs_fixer.paths: ["../.."]
 
-  phpcs.enabled: true
+  phpcs.cli: true
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""
 
-  phpmd.enabled: true
+  phpmd.cli: true
   phpmd.paths: ["src"]
   phpmd.class_complexity: 50
   phpmd.class_length: 200
@@ -69,7 +69,7 @@ defaults:
   phpmd.method_length: 50
   phpmd.npath: 200
 
-  phpmetrics.enabled: true
+  phpmetrics.cli: true
   phpmetrics.includes: ["../../src"]
   phpmetrics.excludes: ["vendor", "tests", ".git"]
   phpmetrics.extensions: ["php"]
@@ -89,32 +89,32 @@ defaults:
   phpmetrics.size.max_logical_loc_per_method: 20
   phpmetrics.structure.max_methods_per_class: 10
 
-  phpstan.enabled: true
+  phpstan.cli: true
   phpstan.level: 9
   phpstan.memory: "1G"
   phpstan.paths: ["../../src"]
   phpstan.checked_exceptions: ['\Throwable']
   phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon"]
 
-  phpunit.enabled: true
+  phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
   phpunit.source.include: ["../../src"]
   phpunit.testsuites.unit: ["../../tests/Unit"]
   phpunit.testsuites.integration: ["../../tests/Integration"]
 
-  psalm.enabled: true
+  psalm.cli: true
   psalm.error_level: 1
   psalm.project.directories: ["../../src"]
   psalm.project.files: []
   psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
   psalm.suppress.possibly_unused: []
 
-  infection.enabled: true
+  infection.cli: true
   infection.php_options: "-d memory_limit=1G"
   infection.source.directories: ["../../src"]
   infection.timeout: 30
 
-  shellcheck.enabled: true
+  shellcheck.cli: true
   shellcheck.exclude: []
   shellcheck.external_sources: true
   shellcheck.ignore_dirs: ["vendor", "tests", ".git"]
@@ -123,7 +123,7 @@ defaults:
   shellcheck.source_path: "."
 
   sonar.cloud: true
-  sonar.enabled: true
+  sonar.cli: true
   sonar.organization: []
   sonar.projectKey: []
   sonar.sources: ["src"]
@@ -131,9 +131,9 @@ defaults:
   sonar.exclusions: []
   sonar.php.coverage.reportPaths: [".piqule/codecov/coverage.xml"]
 
-  typos.enabled: true
+  typos.cli: true
   typos.exclude: ["vendor/", "tests/", ".git/"]
 
-  yamllint.enabled: true
+  yamllint.cli: true
   yamllint.ignore: ["vendor/**", "tests/**", ".git/**", ".piqule/**/html/**", ".piqule/**/coverage-report/**"]
   yamllint.line_length.max: 120

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -86,7 +86,7 @@ final class DefaultConfigTest extends TestCase
     {
         self::assertSame(
             [true],
-            (new DefaultConfig())->list('hadolint.enabled'),
+            (new DefaultConfig())->list('hadolint.cli'),
             'hadolint must be enabled by default',
         );
     }

--- a/tests/Unit/EnvVar/SonarEnvVarTest.php
+++ b/tests/Unit/EnvVar/SonarEnvVarTest.php
@@ -48,9 +48,9 @@ final class SonarEnvVarTest extends TestCase
             false,
             (new SonarEnvVar())->enabled(new FakeConfig([
                 'sonar.cloud' => [false],
-                'sonar.enabled' => [false],
+                'sonar.cli' => [false],
             ])),
-            'SonarEnvVar must be disabled when sonar.enabled is false even in scanner mode',
+            'SonarEnvVar must be disabled when sonar.cli is false even in scanner mode',
         );
     }
 
@@ -61,9 +61,9 @@ final class SonarEnvVarTest extends TestCase
             true,
             (new SonarEnvVar())->enabled(new FakeConfig([
                 'sonar.cloud' => [false],
-                'sonar.enabled' => [true],
+                'sonar.cli' => [true],
             ])),
-            'SonarEnvVar must be enabled when sonar.cloud is false and sonar.enabled is true',
+            'SonarEnvVar must be enabled when sonar.cloud is false and sonar.cli is true',
         );
     }
 
@@ -74,9 +74,9 @@ final class SonarEnvVarTest extends TestCase
             false,
             (new SonarEnvVar())->enabled(new FakeConfig([
                 'sonar.cloud' => [true],
-                'sonar.enabled' => [false],
+                'sonar.cli' => [false],
             ])),
-            'SonarEnvVar must be disabled when sonar.cloud is true regardless of sonar.enabled',
+            'SonarEnvVar must be disabled when sonar.cloud is true regardless of sonar.cli',
         );
     }
 
@@ -87,7 +87,7 @@ final class SonarEnvVarTest extends TestCase
             false,
             (new SonarEnvVar())->enabled(new FakeConfig([
                 'sonar.cloud' => ['false'],
-                'sonar.enabled' => ['false'],
+                'sonar.cli' => ['false'],
             ])),
             'SonarEnvVar must handle string "false" for both keys',
         );

--- a/tests/Unit/Secret/CodecovSecretTest.php
+++ b/tests/Unit/Secret/CodecovSecretTest.php
@@ -16,8 +16,8 @@ final class CodecovSecretTest extends TestCase
     {
         self::assertSame(
             true,
-            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.enabled' => [true]])),
-            'CodecovSecret must be enabled when phpunit.enabled is true',
+            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.cli' => [true]])),
+            'CodecovSecret must be enabled when phpunit.cli is true',
         );
     }
 
@@ -27,7 +27,7 @@ final class CodecovSecretTest extends TestCase
         self::assertSame(
             true,
             (new CodecovSecret())->enabled(new FakeConfig([])),
-            'CodecovSecret must be enabled when phpunit.enabled key is absent',
+            'CodecovSecret must be enabled when phpunit.cli key is absent',
         );
     }
 
@@ -36,8 +36,8 @@ final class CodecovSecretTest extends TestCase
     {
         self::assertSame(
             false,
-            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.enabled' => [false]])),
-            'CodecovSecret must be disabled when phpunit.enabled is false',
+            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.cli' => [false]])),
+            'CodecovSecret must be disabled when phpunit.cli is false',
         );
     }
 

--- a/tests/Unit/Secret/InfectionSecretTest.php
+++ b/tests/Unit/Secret/InfectionSecretTest.php
@@ -16,8 +16,8 @@ final class InfectionSecretTest extends TestCase
     {
         self::assertSame(
             true,
-            (new InfectionSecret())->enabled(new FakeConfig(['infection.enabled' => [true]])),
-            'InfectionSecret must be enabled when infection.enabled is true',
+            (new InfectionSecret())->enabled(new FakeConfig(['infection.cli' => [true]])),
+            'InfectionSecret must be enabled when infection.cli is true',
         );
     }
 
@@ -27,7 +27,7 @@ final class InfectionSecretTest extends TestCase
         self::assertSame(
             true,
             (new InfectionSecret())->enabled(new FakeConfig([])),
-            'InfectionSecret must be enabled when infection.enabled key is absent',
+            'InfectionSecret must be enabled when infection.cli key is absent',
         );
     }
 
@@ -36,8 +36,8 @@ final class InfectionSecretTest extends TestCase
     {
         self::assertSame(
             false,
-            (new InfectionSecret())->enabled(new FakeConfig(['infection.enabled' => [false]])),
-            'InfectionSecret must be disabled when infection.enabled is false',
+            (new InfectionSecret())->enabled(new FakeConfig(['infection.cli' => [false]])),
+            'InfectionSecret must be disabled when infection.cli is false',
         );
     }
 


### PR DESCRIPTION
- Renamed all 16 `*.enabled` config keys to `*.cli` for consistent naming
- Updated `isEnabled` check in piqule-check to read `*.cli`
- Updated SonarEnvVar, CodecovSecret, and InfectionSecret to use `*.cli` keys
- Updated tests and documentation to reflect the new naming

Part of #562

**Breaking changes:**
- All `*.enabled` config keys renamed to `*.cli` (e.g. `phpstan.enabled` → `phpstan.cli`)
- Users with `*.enabled` overrides in `.piqule.yaml` must rename them to `*.cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed tool enablement configuration keys from `enabled` to `cli` across multiple development tools.
  * Updated Docker image digest for sonar-scanner.

* **Documentation**
  * Updated configuration documentation and guides to reflect key naming changes.

* **Tests**
  * Updated test fixtures and assertions to align with configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->