### PR TITLE
Cloud Service Config for Codecov, CodeRabbit, and Sonar

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -138,7 +138,7 @@ jobs:
       # Upload coverage to Codecov (if coverage exists)
       # ------------------------------------------------------------
       - name: Upload coverage to Codecov
-        if: hashFiles('.piqule/codecov/coverage.xml') != ''
+        if: true == true && hashFiles('.piqule/codecov/coverage.xml') != ''
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -26,6 +26,12 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
+  codecov.cloud: true
+  codecov.cli: false
+
+  coderabbit.cloud: true
+  coderabbit.cli: false
+
   docker.image: "ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23"
 
   actionlint.cli: true
@@ -123,7 +129,7 @@ defaults:
   shellcheck.source_path: "."
 
   sonar.cloud: true
-  sonar.cli: true
+  sonar.cli: false
   sonar.organization: []
   sonar.projectKey: []
   sonar.sources: ["src"]

--- a/DEV.md
+++ b/DEV.md
@@ -340,6 +340,20 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | `coverage.project.target` | `80` | Minimum project coverage % |
 | `coverage.project.threshold` | `2` | Allowed drop below target |
 
+### codecov
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `codecov.cloud` | `true` | Upload coverage to Codecov in CI |
+| `codecov.cli` | `false` | Enable codecov-cli locally |
+
+### coderabbit
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `coderabbit.cloud` | `true` | Enable CodeRabbit GitHub App reviews |
+| `coderabbit.cli` | `false` | Enable coderabbit-cli locally |
+
 ### Docker
 
 | Key | Default | Description |
@@ -497,7 +511,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | Key | Default | Description |
 |-----|---------|-------------|
 | `sonar.cloud` | `true` | Use SonarCloud automatic analysis (skip local scanner and SONAR_TOKEN) |
-| `sonar.cli` | `true` | Enable local sonar-scanner |
+| `sonar.cli` | `false` | Enable local sonar-scanner |
 | `sonar.organization` | `[]` | SonarCloud organization |
 | `sonar.projectKey` | `[]` | SonarCloud project key |
 | `sonar.sources` | `["src"]` | Source directories |

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -138,7 +138,7 @@ jobs:
       # Upload coverage to Codecov (if coverage exists)
       # ------------------------------------------------------------
       - name: Upload coverage to Codecov
-        if: hashFiles('.piqule/codecov/coverage.xml') != ''
+        if: << config(codecov.cloud)|first()|join("") >> == true && hashFiles('.piqule/codecov/coverage.xml') != ''
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -26,6 +26,12 @@ defaults:
   coverage.project.target: 80
   coverage.project.threshold: 2
 
+  codecov.cloud: true
+  codecov.cli: false
+
+  coderabbit.cloud: true
+  coderabbit.cli: false
+
   docker.image: "ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23"
 
   actionlint.cli: true
@@ -123,7 +129,7 @@ defaults:
   shellcheck.source_path: "."
 
   sonar.cloud: true
-  sonar.cli: true
+  sonar.cli: false
   sonar.organization: []
   sonar.projectKey: []
   sonar.sources: ["src"]


### PR DESCRIPTION
- Added `codecov.cloud` and `codecov.cli` config keys for Codecov service control
- Added `coderabbit.cloud` and `coderabbit.cli` config keys for CodeRabbit service control
- Updated `sonar.cli` default to `false` since SonarCloud handles analysis automatically
- Updated Codecov CI workflow step to respect `codecov.cloud` setting

Part of #562

**Breaking changes:**
- `sonar.cli` now defaults to `false` — users who rely on local sonar-scanner must set `sonar.cli: true` in `.piqule.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration for code quality analysis tools (Codecov, CodeRabbit, and SonarQube) to use cloud-based reporting and disable CLI-based execution
  * Updated workflow and documentation to reflect new configuration defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->