### PR TITLE
Explicit Check Overrides Disabled Cli Setting

### DIFF
--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -128,7 +128,9 @@ $formatTime = static function(float $seconds): string {
 
 $totalStart = microtime(true);
 
-$runCheck = static function(string $key) use ($projectRoot, $isEnabled, $green, $red, $gray, $formatTime, $titleWidth, $total, &$current, $verbose): bool {
+$yellow = static fn(string $s): string => "\033[33m{$s}\033[0m";
+
+$runCheck = static function(string $key, bool $force = false) use ($projectRoot, $isEnabled, $green, $red, $gray, $yellow, $formatTime, $titleWidth, $total, &$current, $verbose): bool {
     $command = "{$projectRoot}/.piqule/{$key}/command.sh";
 
     if (!file_exists($command)) {
@@ -138,9 +140,13 @@ $runCheck = static function(string $key) use ($projectRoot, $isEnabled, $green, 
     }
 
     if (!$isEnabled($key)) {
-        echo ($gray)("[SKIP] {$key}") . "\n";
+        if (!$force) {
+            echo ($gray)("[SKIP] {$key}") . "\n";
 
-        return true;
+            return true;
+        }
+
+        echo ($yellow)("[TIP]  {$key}.cli is false — running because explicitly requested") . "\n";
     }
 
     $current++;
@@ -180,7 +186,7 @@ $runCheck = static function(string $key) use ($projectRoot, $isEnabled, $green, 
 };
 
 if ($requested !== '') {
-    exit($runCheck($requested) ? 0 : 1);
+    exit($runCheck($requested, force: true) ? 0 : 1);
 }
 
 if (!$parallel) {


### PR DESCRIPTION
- Added force mode when a tool is explicitly requested via `piqule check <tool>`
- Added TIP message indicating the tool's cli setting is false but running anyway

Closes #562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added force execution capability for disabled checks with informative tip feedback
  * Explicitly requested checks now bypass disabled status and always execute
  * Enhanced check system with improved control over check execution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->