### PR TITLE
PHPDoc Compliance With Phpstan-rules

### DIFF
--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -32,12 +32,6 @@ final readonly class AppendConfig implements Config
         return $this->defaults->has($name);
     }
 
-    /**
-     * Returns the default list with appended values merged in
-     *
-     * @throws PiquleException
-     * @return list<scalar>
-     */
     #[Override]
     public function list(string $name): array
     {
@@ -74,7 +68,6 @@ final readonly class AppendConfig implements Config
         return [...$this->defaults->list($name), ...$scalars];
     }
 
-    /** @throws PiquleException */
     #[Override]
     public function toArray(): array
     {

--- a/src/Config/ConfigPaths.php
+++ b/src/Config/ConfigPaths.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Config;
 
 /**
- * Paths used to locate configuration files
+ * Paths used to locate configuration files.
  */
 final readonly class ConfigPaths
 {
+    /** Initializes with optional custom paths for composer.json and config.yaml. */
     public function __construct(
         private string $composerJson = '',
         private string $configYaml = __DIR__ . '/../../templates/always/.piqule/config.yaml',
     ) {}
 
-    /** Returns the composer.json file path */
+    /** Returns the composer.json file path. */
     public function composerJson(): string
     {
         return $this->composerJson;
     }
 
-    /** Returns the config.yaml file path */
+    /** Returns the config.yaml file path. */
     public function configYaml(): string
     {
         return $this->configYaml;

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -29,7 +29,7 @@ final class DefaultConfig implements Config
     private ?array $cache;
 
     /**
-     * Initializes with source directories, exclusions, and config paths
+     * Initializes with source directories, exclusions, and config paths.
      *
      * @param list<string> $phpSrc
      * @param list<string> $exclude
@@ -48,7 +48,6 @@ final class DefaultConfig implements Config
         return array_key_exists($name, $this->defaults());
     }
 
-    /** @return list<int|float|string|bool> */
     #[Override]
     public function list(string $name): array
     {
@@ -69,14 +68,14 @@ final class DefaultConfig implements Config
         return $this->defaults();
     }
 
-    /** Returns the configuration paths */
+    /** Returns the configuration paths. */
     public function configPaths(): ConfigPaths
     {
         return $this->paths;
     }
 
     /**
-     * Parses YAML and computes all defaults with dynamic path derivations
+     * Parses YAML and computes all defaults with dynamic path derivations.
      *
      * @throws PiquleException
      * @return array<string, scalar|list<scalar>>
@@ -122,6 +121,8 @@ final class DefaultConfig implements Config
     }
 
     /**
+     * Reads dynamic defaults derived from composer.json paths and directory lists.
+     *
      * @param list<string> $phpSrc
      * @param list<string> $exclude
      * @return array<string, scalar|list<scalar>>

--- a/src/Config/Dirs/GlobDirs.php
+++ b/src/Config/Dirs/GlobDirs.php
@@ -18,7 +18,6 @@ final readonly class GlobDirs implements Dirs
      */
     public function __construct(private array $dirs) {}
 
-    /** @return list<string> */
     #[Override]
     public function toList(): array
     {

--- a/src/Config/Dirs/NegatedGlobDirs.php
+++ b/src/Config/Dirs/NegatedGlobDirs.php
@@ -18,7 +18,6 @@ final readonly class NegatedGlobDirs implements Dirs
      */
     public function __construct(private array $dirs) {}
 
-    /** @return list<string> */
     #[Override]
     public function toList(): array
     {

--- a/src/Config/Dirs/ProjectDirs.php
+++ b/src/Config/Dirs/ProjectDirs.php
@@ -18,7 +18,6 @@ final readonly class ProjectDirs implements Dirs
      */
     public function __construct(private array $dirs) {}
 
-    /** @return list<string> */
     #[Override]
     public function toList(): array
     {

--- a/src/Config/Dirs/TrailingGlobDirs.php
+++ b/src/Config/Dirs/TrailingGlobDirs.php
@@ -18,7 +18,6 @@ final readonly class TrailingGlobDirs implements Dirs
      */
     public function __construct(private array $dirs) {}
 
-    /** @return list<string> */
     #[Override]
     public function toList(): array
     {

--- a/src/Config/Dirs/TrailingSlashDirs.php
+++ b/src/Config/Dirs/TrailingSlashDirs.php
@@ -18,7 +18,6 @@ final readonly class TrailingSlashDirs implements Dirs
      */
     public function __construct(private array $dirs) {}
 
-    /** @return list<string> */
     #[Override]
     public function toList(): array
     {

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -25,7 +25,6 @@ final readonly class OverrideConfig implements Config
         return $this->defaults->has($name);
     }
 
-    /** @throws PiquleException */
     #[Override]
     public function list(string $name): array
     {
@@ -71,7 +70,6 @@ final readonly class OverrideConfig implements Config
         return array_values(array_filter($value, static fn($item) => is_scalar($item)));
     }
 
-    /** @throws PiquleException */
     #[Override]
     public function toArray(): array
     {

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -10,7 +10,7 @@ use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Loads project configuration from a .piqule.yaml file
+ * Loads project configuration from a .piqule.yaml file.
  *
  * Supports two sections:
  * - override: replaces default values
@@ -31,7 +31,7 @@ final class YamlConfig implements Config
     private ?Config $cache;
 
     /**
-     * Initializes with a YAML file path and default configuration
+     * Initializes with a YAML file path and default configuration.
      */
     public function __construct(
         private readonly string $path,
@@ -59,7 +59,7 @@ final class YamlConfig implements Config
     }
 
     /**
-     * Parses the YAML file and builds the layered configuration
+     * Parses the YAML file and builds the layered configuration.
      *
      * @throws PiquleException
      */

--- a/src/Config/YamlPathKeys.php
+++ b/src/Config/YamlPathKeys.php
@@ -7,12 +7,15 @@ namespace Haspadar\Piqule\Config;
 use Haspadar\Piqule\PiquleException;
 
 /**
- * Resolves include and exclude lists from .piqule.yaml override/append sections,
- * cascading into DefaultConfig so all derived path keys reflect the project layout.
+ * Resolves include and exclude lists from .piqule.yaml override/append sections.
+ *
+ * Cascades into DefaultConfig so all derived path keys reflect the project layout.
  */
 final readonly class YamlPathKeys
 {
     /**
+     * Initializes with override and append maps alongside the base defaults.
+     *
      * @param array<string, mixed> $overrides
      * @param array<string, mixed> $appends
      */
@@ -23,6 +26,8 @@ final readonly class YamlPathKeys
     ) {}
 
     /**
+     * Resolves the effective PHP source directories after overrides and appends.
+     *
      * @throws PiquleException
      * @return list<string>
      */
@@ -41,6 +46,8 @@ final readonly class YamlPathKeys
     }
 
     /**
+     * Resolves the effective exclude patterns after overrides and appends.
+     *
      * @throws PiquleException
      * @return list<string>
      */
@@ -59,6 +66,8 @@ final readonly class YamlPathKeys
     }
 
     /**
+     * Converts a mixed list to a validated list of strings.
+     *
      * @param list<mixed> $value
      * @throws PiquleException
      * @return list<string>

--- a/src/EnvVar/SonarEnvVar.php
+++ b/src/EnvVar/SonarEnvVar.php
@@ -25,7 +25,6 @@ final readonly class SonarEnvVar implements EnvVar
         return 'https://sonarcloud.io/account/security';
     }
 
-    /** @throws PiquleException */
     #[Override]
     public function enabled(Config $config): bool
     {

--- a/src/File/ConfiguredFile.php
+++ b/src/File/ConfiguredFile.php
@@ -21,10 +21,11 @@ use InvalidArgumentException;
 use Override;
 
 /**
- * Replaces DSL placeholders in a file's contents using configuration values
+ * Replaces DSL placeholders in a file's contents using configuration values.
  */
 final readonly class ConfiguredFile implements File
 {
+    /** Wraps a file and a configuration source for placeholder resolution. */
     public function __construct(private File $origin, private Config $config) {}
 
     #[Override]
@@ -49,7 +50,11 @@ final readonly class ConfiguredFile implements File
         return $this->origin->mode();
     }
 
-    /** @throws PiquleException */
+    /**
+     * Returns the result of evaluating a single DSL expression against the config.
+     *
+     * @throws PiquleException
+     */
     private function replaced(string $expression): string
     {
         try {
@@ -73,7 +78,11 @@ final readonly class ConfiguredFile implements File
         }
     }
 
-    /** @return array<string, callable(string): Action> */
+    /**
+     * Returns the map of supported action names to their factory callables.
+     *
+     * @return array<string, callable(string): Action>
+     */
     private function actions(): array
     {
         return [

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -47,7 +47,7 @@ final readonly class FormatAction implements Action
         $templateValues = $templateArgs->values();
         $template = $this->normalize((string) ($templateValues[0] ?? ''));
 
-        $scalar = (new StringifiedArgs($args))->values()[0] ?? '';
+        $scalar = (string) ((new StringifiedArgs($args))->values()[0] ?? '');
 
         try {
             $result = sprintf($template, $scalar);

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -14,7 +14,7 @@ use Override;
 use ValueError;
 
 /**
- * Applies a sprintf template to a single incoming value
+ * Applies a sprintf template to a single incoming value.
  */
 final readonly class FormatAction implements Action
 {
@@ -25,6 +25,7 @@ final readonly class FormatAction implements Action
         '\\t' => "\t",
     ];
 
+    /** Initializes with the raw sprintf template string. */
     public function __construct(private string $raw) {}
 
     #[Override]

--- a/src/Formula/Action/FormatEachAction.php
+++ b/src/Formula/Action/FormatEachAction.php
@@ -27,7 +27,7 @@ final readonly class FormatEachAction implements Action
 
         return new ListArgs(
             array_map(
-                static fn(int|float|string|bool $item): string => sprintf($template, $item),
+                static fn(int|float|string|bool $item): string => sprintf($template, (string) $item),
                 (new StringifiedArgs($args))->values(),
             ),
         );

--- a/src/Formula/Action/FormatEachAction.php
+++ b/src/Formula/Action/FormatEachAction.php
@@ -11,10 +11,11 @@ use Haspadar\Piqule\Formula\Args\UnquotedArgs;
 use Override;
 
 /**
- * Applies a sprintf template to each incoming value individually
+ * Applies a sprintf template to each incoming value individually.
  */
 final readonly class FormatEachAction implements Action
 {
+    /** Initializes with the raw sprintf template string. */
     public function __construct(private string $raw) {}
 
     #[Override]
@@ -26,7 +27,7 @@ final readonly class FormatEachAction implements Action
 
         return new ListArgs(
             array_map(
-                static fn(string $item): string => sprintf($template, $item),
+                static fn(int|float|string|bool $item): string => sprintf($template, $item),
                 (new StringifiedArgs($args))->values(),
             ),
         );

--- a/src/Formula/Args/ListArgs.php
+++ b/src/Formula/Args/ListArgs.php
@@ -18,7 +18,6 @@ final readonly class ListArgs implements Args
      */
     public function __construct(private array $values) {}
 
-    /** @return list<int|float|string|bool> */
     #[Override]
     public function values(): array
     {

--- a/src/Formula/Args/StringifiedArgs.php
+++ b/src/Formula/Args/StringifiedArgs.php
@@ -14,7 +14,6 @@ final readonly class StringifiedArgs implements Args
     /** Initializes with the args to stringify. */
     public function __construct(private Args $origin) {}
 
-    /** @return list<string> */
     #[Override]
     public function values(): array
     {

--- a/src/Formula/Args/TrimmedArgs.php
+++ b/src/Formula/Args/TrimmedArgs.php
@@ -14,7 +14,6 @@ final readonly class TrimmedArgs implements Args
     /** Initializes with the args to trim. */
     public function __construct(private Args $origin) {}
 
-    /** @return list<int|float|string|bool> */
     #[Override]
     public function values(): array
     {

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -16,7 +16,6 @@ final readonly class UnquotedArgs implements Args
     /** Initializes with the args to unquote. */
     public function __construct(private Args $origin) {}
 
-    /** @return list<int|float|string|bool> */
     #[Override]
     public function values(): array
     {

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -13,10 +13,11 @@ use SplFileInfo;
 use function assert;
 
 /**
- * Filesystem-backed storage rooted at a given directory
+ * Filesystem-backed storage rooted at a given directory.
  */
 final readonly class DiskStorage implements Storage
 {
+    /** Initializes storage rooted at the given directory path. */
     public function __construct(private string $root) {}
 
     #[Override]
@@ -118,7 +119,11 @@ final readonly class DiskStorage implements Storage
         return $perms & 0o777;
     }
 
-    /** @throws PiquleException */
+    /**
+     * Resolves the absolute filesystem path for a given storage location.
+     *
+     * @throws PiquleException
+     */
     private function pathOf(string $location): string
     {
         return (new SafePath($this->root))->resolve($location);

--- a/src/Storage/InMemoryStorage.php
+++ b/src/Storage/InMemoryStorage.php
@@ -9,11 +9,15 @@ use Haspadar\Piqule\PiquleException;
 use Override;
 
 /**
- * Immutable in-memory storage backed by a location-to-File map
+ * Immutable in-memory storage backed by a location-to-File map.
  */
 final readonly class InMemoryStorage implements Storage
 {
-    /** @param array<string, File> $entries location => File */
+    /**
+     * Initializes with pre-loaded file entries.
+     *
+     * @param array<string, File> $entries Location-to-File map.
+     */
     public function __construct(private array $entries = []) {}
 
     #[Override]
@@ -51,7 +55,6 @@ final readonly class InMemoryStorage implements Storage
         ]);
     }
 
-    /** @return iterable<string> */
     #[Override]
     public function entries(string $location): iterable
     {


### PR DESCRIPTION
- Removed PHPDoc from overridden methods to satisfy noPhpdocOverride rule
- Added missing PHPDoc summaries and punctuation across 21 files
- Fixed sprintf type coercion to satisfy Psalm scalar checks

Part of #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated and expanded documentation across codebase with improved clarity and consistent formatting standards.

* **Refactor**
  * Enhanced formatting operations to accept numeric types (integers, floats) alongside strings with improved type safety through explicit casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->