### PR TITLE
Default PHPStan Design Rules for All Projects

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -100,7 +100,7 @@ defaults:
   phpstan.memory: "1G"
   phpstan.paths: ["../../src"]
   phpstan.checked_exceptions: ['\Throwable']
-  phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon"]
+  phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/.piqule/phpstan/phpstan.neon
+++ b/.piqule/phpstan/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - ../../vendor/phpstan/phpstan-strict-rules/rules.neon
+    - ../../vendor/haspadar/phpstan-rules/rules.neon
 
 parameters:
     level: 9

--- a/DEV.md
+++ b/DEV.md
@@ -462,7 +462,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | `phpstan.memory` | `"1G"` | Memory limit |
 | `phpstan.paths` | `["../../src"]` | Paths to analyze |
 | `phpstan.checked_exceptions` | `['\Throwable']` | Checked exception classes |
-| `phpstan.neon_includes` | `["../../vendor/phpstan/phpstan-strict-rules/rules.neon"]` | Neon includes |
+| `phpstan.neon_includes` | `["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]` | Neon includes |
 
 ### phpunit
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require": {
         "php": "~8.3.16 || ~8.4.3 || ~8.5.0",
         "friendsofphp/php-cs-fixer": "^3.91",
+        "haspadar/phpstan-rules": "^0.30.1",
         "infection/infection": "^0.32.0",
         "phpmd/phpmd": "^2.15",
         "phpmetrics/phpmetrics": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab70256952e4fcfc3a8ec44513a2b7db",
+    "content-hash": "6b0709d0fcced81424bad9d99f3f54d5",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1636,6 +1636,59 @@
                 }
             ],
             "time": "2026-02-20T16:13:53+00:00"
+        },
+        {
+            "name": "haspadar/phpstan-rules",
+            "version": "v0.30.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/haspadar/phpstan-rules.git",
+                "reference": "460c6afd0d61bb12383babcaaa118bcf381a8285"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/460c6afd0d61bb12383babcaaa118bcf381a8285",
+                "reference": "460c6afd0d61bb12383babcaaa118bcf381a8285",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "haspadar/piqule": "dev-main",
+                "kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
+                "slevomat/coding-standard": "^8.28"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Haspadar\\PHPStanRules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kanstantsinas Mesnikas",
+                    "email": "haspadar@gmail.com"
+                }
+            ],
+            "description": "PHPStan design rules for immutability and structure",
+            "support": {
+                "issues": "https://github.com/haspadar/phpstan-rules/issues",
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.30.1"
+            },
+            "time": "2026-04-07T12:53:39+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -100,7 +100,7 @@ defaults:
   phpstan.memory: "1G"
   phpstan.paths: ["../../src"]
   phpstan.checked_exceptions: ['\Throwable']
-  phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon"]
+  phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/tests/Unit/Config/YamlConfigTest.php
+++ b/tests/Unit/Config/YamlConfigTest.php
@@ -86,7 +86,7 @@ final class YamlConfigTest extends TestCase
         $path = $this->folder->withFile('.piqule.yaml', "append:\n    phpstan.neon_includes:\n        - ../../rules.neon\n")->path() . '/.piqule.yaml';
 
         self::assertSame(
-            ['../../vendor/phpstan/phpstan-strict-rules/rules.neon', '../../rules.neon'],
+            ['../../vendor/phpstan/phpstan-strict-rules/rules.neon', '../../vendor/haspadar/phpstan-rules/rules.neon', '../../rules.neon'],
             (new YamlConfig($path, new DefaultConfig()))->list('phpstan.neon_includes'),
             'YamlConfig must append values from the append section to the default list',
         );
@@ -98,7 +98,7 @@ final class YamlConfigTest extends TestCase
         $path = $this->folder->withFile('.piqule.yaml', "append:\n    phpstan.neon_includes:\n        - ../../extra.neon\n")->path() . '/.piqule.yaml';
 
         self::assertSame(
-            ['../../vendor/phpstan/phpstan-strict-rules/rules.neon', '../../extra.neon'],
+            ['../../vendor/phpstan/phpstan-strict-rules/rules.neon', '../../vendor/haspadar/phpstan-rules/rules.neon', '../../extra.neon'],
             (new YamlConfig($path, new DefaultConfig()))->list('phpstan.neon_includes'),
             'YamlConfig must preserve default values and append new ones after them',
         );


### PR DESCRIPTION
- Added haspadar/phpstan-rules as a required dependency
- Updated phpstan.neon_includes default to include design rules
- Updated test expectations for new neon include

Closes #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced static analysis with additional PHPStan ruleset, providing stricter code quality checks across the project.

* **Chores**
  * Added new dependency for extended static analysis rules.
  * Updated configuration defaults and test assertions to reflect new analysis ruleset inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->