### PR TITLE
Envs Parsing and Step Rendering for CI Workflows

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -81,7 +81,7 @@ defaults:
   phpmetrics.extensions: ["php"]
   phpmetrics.complexity.max_cyclomatic_per_method: 10
   phpmetrics.complexity.max_weighted_methods_per_class: 20
-  phpmetrics.coupling.max_afferent: 12
+  phpmetrics.coupling.max_afferent: 14
   phpmetrics.coupling.max_efferent: 10
   phpmetrics.halstead.max_bugs_per_method: 0.5
   phpmetrics.halstead.max_difficulty_per_method: 15

--- a/.piqule/phpmetrics/rules.php
+++ b/.piqule/phpmetrics/rules.php
@@ -23,7 +23,7 @@ return [
         'max_methods_per_class' => 10,
     ],
     'coupling' => [
-        'max_afferent' => 12,
+        'max_afferent' => 14,
         'max_efferent' => 25,
     ],
 ];

--- a/DEV.md
+++ b/DEV.md
@@ -439,7 +439,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | `phpmetrics.extensions` | `["php"]` | File extensions |
 | `phpmetrics.complexity.max_cyclomatic_per_method` | `10` | Max cyclomatic per method |
 | `phpmetrics.complexity.max_weighted_methods_per_class` | `20` | Max WMC per class |
-| `phpmetrics.coupling.max_afferent` | `12` | Max afferent coupling |
+| `phpmetrics.coupling.max_afferent` | `14` | Max afferent coupling |
 | `phpmetrics.coupling.max_efferent` | `10` | Max efferent coupling |
 | `phpmetrics.halstead.max_bugs_per_method` | `0.5` | Max Halstead bugs per method |
 | `phpmetrics.halstead.max_difficulty_per_method` | `15` | Max Halstead difficulty |

--- a/src/Envs/EmptyEnvs.php
+++ b/src/Envs/EmptyEnvs.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Envs;
+
+use Override;
+
+/**
+ * No environment variables configured.
+ */
+final readonly class EmptyEnvs implements Envs
+{
+    #[Override]
+    public function vars(): array
+    {
+        return [];
+    }
+}

--- a/src/Envs/Envs.php
+++ b/src/Envs/Envs.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Envs;
+
+use Haspadar\Piqule\PiquleException;
+
+/**
+ * Environment variables for CI workflows.
+ */
+interface Envs
+{
+    /**
+     * @throws PiquleException
+     * @return array<string, string> variable name => shell command
+     */
+    public function vars(): array;
+}

--- a/src/Envs/YamlEnvs.php
+++ b/src/Envs/YamlEnvs.php
@@ -31,10 +31,14 @@ final readonly class YamlEnvs implements Envs
             );
         }
 
+        if (!is_array($yaml)) {
+            throw new PiquleException(
+                sprintf('Expected a mapping in "%s", got %s', $this->path, get_debug_type($yaml)),
+            );
+        }
+
         /** @var mixed $envs */
-        $envs = is_array($yaml)
-            ? ($yaml['envs'] ?? [])
-            : [];
+        $envs = $yaml['envs'] ?? [];
 
         if (!is_array($envs)) {
             throw new PiquleException(

--- a/src/Envs/YamlEnvs.php
+++ b/src/Envs/YamlEnvs.php
@@ -52,6 +52,12 @@ final readonly class YamlEnvs implements Envs
                 );
             }
 
+            if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name) !== 1) {
+                throw new PiquleException(
+                    sprintf('Invalid environment variable name "%s" in "%s"', $name, $this->path),
+                );
+            }
+
             $vars[$name] = $command;
         }
 

--- a/src/Envs/YamlEnvs.php
+++ b/src/Envs/YamlEnvs.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Envs;
+
+use Haspadar\Piqule\PiquleException;
+use Override;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Parses the envs section from a .piqule.yaml file.
+ */
+final readonly class YamlEnvs implements Envs
+{
+    /** Initializes with the path to a .piqule.yaml file. */
+    public function __construct(private string $path) {}
+
+    #[Override]
+    public function vars(): array
+    {
+        try {
+            /** @var mixed $yaml */
+            $yaml = Yaml::parseFile($this->path);
+        } catch (ParseException $e) {
+            throw new PiquleException(
+                sprintf('Failed to parse "%s": %s', $this->path, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        /** @var mixed $envs */
+        $envs = is_array($yaml)
+            ? ($yaml['envs'] ?? [])
+            : [];
+
+        if (!is_array($envs)) {
+            throw new PiquleException(
+                sprintf('Invalid "envs" section in "%s": expected a mapping', $this->path),
+            );
+        }
+
+        /** @var array<string, string> $vars */
+        $vars = [];
+
+        foreach ($envs as $name => $command) {
+            if (!is_string($name) || !is_string($command)) {
+                throw new PiquleException(
+                    sprintf('Each entry in "envs" must be string => string in "%s"', $this->path),
+                );
+            }
+
+            $vars[$name] = $command;
+        }
+
+        return $vars;
+    }
+}

--- a/src/Formula/Action/EnvsAction.php
+++ b/src/Formula/Action/EnvsAction.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Action;
+
+use Haspadar\Piqule\Envs\Envs;
+use Haspadar\Piqule\Formula\Args\Args;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Formula\Args\UnquotedArgs;
+use InvalidArgumentException;
+use Override;
+
+/**
+ * Renders a GitHub Actions step that exports environment variables via $GITHUB_ENV.
+ */
+final readonly class EnvsAction implements Action
+{
+    /** Initializes with environment variables and YAML indentation prefix. */
+    public function __construct(private Envs $envs, private string $indent) {}
+
+    #[Override]
+    public function transformed(Args $args): Args
+    {
+        $vars = $this->envs->vars();
+
+        if ($vars === []) {
+            return new ListArgs(['']);
+        }
+
+        $indent = $this->unquotedIndent();
+        $lines = [];
+
+        foreach ($vars as $name => $command) {
+            $lines[] = sprintf(
+                '%s    echo "%s=$(%s)" >> "$GITHUB_ENV"',
+                $indent,
+                $name,
+                $command,
+            );
+        }
+
+        return new ListArgs([
+            sprintf(
+                "%s- name: Set environment variables\n%s  run: |\n%s",
+                $indent,
+                $indent,
+                implode("\n", $lines),
+            ),
+        ]);
+    }
+
+    /**
+     * Strips outer quotes from the raw indent argument.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function unquotedIndent(): string
+    {
+        $values = (new UnquotedArgs(
+            new ListArgs([$this->indent]),
+        ))->values();
+
+        return (string) ($values[0] ?? '');
+    }
+}

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -81,7 +81,7 @@ defaults:
   phpmetrics.extensions: ["php"]
   phpmetrics.complexity.max_cyclomatic_per_method: 10
   phpmetrics.complexity.max_weighted_methods_per_class: 20
-  phpmetrics.coupling.max_afferent: 12
+  phpmetrics.coupling.max_afferent: 14
   phpmetrics.coupling.max_efferent: 10
   phpmetrics.halstead.max_bugs_per_method: 0.5
   phpmetrics.halstead.max_difficulty_per_method: 15

--- a/tests/Fake/Envs/FakeEnvs.php
+++ b/tests/Fake/Envs/FakeEnvs.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fake\Envs;
+
+use Haspadar\Piqule\Envs\Envs;
+
+final class FakeEnvs implements Envs
+{
+    /** @param array<string, string> $vars */
+    public function __construct(private array $vars) {}
+
+    public function vars(): array
+    {
+        return $this->vars;
+    }
+}

--- a/tests/Fake/Envs/FakeEnvs.php
+++ b/tests/Fake/Envs/FakeEnvs.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Fake\Envs;
 
 use Haspadar\Piqule\Envs\Envs;
+use Override;
 
-final class FakeEnvs implements Envs
+final readonly class FakeEnvs implements Envs
 {
     /** @param array<string, string> $vars */
     public function __construct(private array $vars) {}
 
+    #[Override]
     public function vars(): array
     {
         return $this->vars;

--- a/tests/Unit/Envs/EmptyEnvsTest.php
+++ b/tests/Unit/Envs/EmptyEnvsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Envs;
+
+use Haspadar\Piqule\Envs\EmptyEnvs;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EmptyEnvsTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyArray(): void
+    {
+        self::assertSame(
+            [],
+            (new EmptyEnvs())->vars(),
+            'EmptyEnvs must return an empty array',
+        );
+    }
+}

--- a/tests/Unit/Envs/YamlEnvsTest.php
+++ b/tests/Unit/Envs/YamlEnvsTest.php
@@ -107,4 +107,17 @@ final class YamlEnvsTest extends TestCase
 
         (new YamlEnvs($path))->vars();
     }
+
+    #[Test]
+    public function throwsWhenEnvsNameIsInvalid(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "envs:\n  1INVALID: \"echo hello\"\n",
+        )->path() . '/.piqule.yaml';
+
+        (new YamlEnvs($path))->vars();
+    }
 }

--- a/tests/Unit/Envs/YamlEnvsTest.php
+++ b/tests/Unit/Envs/YamlEnvsTest.php
@@ -94,4 +94,17 @@ final class YamlEnvsTest extends TestCase
 
         (new YamlEnvs($path))->vars();
     }
+
+    #[Test]
+    public function throwsWhenYamlIsMalformed(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "envs:\n  BROKEN: [\n",
+        )->path() . '/.piqule.yaml';
+
+        (new YamlEnvs($path))->vars();
+    }
 }

--- a/tests/Unit/Envs/YamlEnvsTest.php
+++ b/tests/Unit/Envs/YamlEnvsTest.php
@@ -120,4 +120,17 @@ final class YamlEnvsTest extends TestCase
 
         (new YamlEnvs($path))->vars();
     }
+
+    #[Test]
+    public function throwsWhenYamlRootIsNotMapping(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "just a string\n",
+        )->path() . '/.piqule.yaml';
+
+        (new YamlEnvs($path))->vars();
+    }
 }

--- a/tests/Unit/Envs/YamlEnvsTest.php
+++ b/tests/Unit/Envs/YamlEnvsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Envs;
+
+use Haspadar\Piqule\Envs\YamlEnvs;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class YamlEnvsTest extends TestCase
+{
+    private TempFolder $folder;
+
+    protected function setUp(): void
+    {
+        $this->folder = new TempFolder();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->folder->close();
+    }
+
+    #[Test]
+    public function parsesEnvsSection(): void
+    {
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "envs:\n  MY_VAR: \"echo hello\"\n",
+        )->path() . '/.piqule.yaml';
+
+        self::assertSame(
+            ['MY_VAR' => 'echo hello'],
+            (new YamlEnvs($path))->vars(),
+            'YamlEnvs must parse envs section into name => command map',
+        );
+    }
+
+    #[Test]
+    public function parsesMultipleEnvs(): void
+    {
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "envs:\n  A: \"cmd-a\"\n  B: \"cmd-b\"\n",
+        )->path() . '/.piqule.yaml';
+
+        self::assertSame(
+            ['A' => 'cmd-a', 'B' => 'cmd-b'],
+            (new YamlEnvs($path))->vars(),
+            'YamlEnvs must parse multiple envs entries',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoEnvsSection(): void
+    {
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "override:\n  phpstan.level: 8\n",
+        )->path() . '/.piqule.yaml';
+
+        self::assertSame(
+            [],
+            (new YamlEnvs($path))->vars(),
+            'YamlEnvs must return empty array when envs section is absent',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenEnvsSectionIsNotMapping(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "envs: not-a-mapping\n",
+        )->path() . '/.piqule.yaml';
+
+        (new YamlEnvs($path))->vars();
+    }
+
+    #[Test]
+    public function throwsWhenEnvsValueIsNotString(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        $path = $this->folder->withFile(
+            '.piqule.yaml',
+            "envs:\n  MY_VAR: 42\n",
+        )->path() . '/.piqule.yaml';
+
+        (new YamlEnvs($path))->vars();
+    }
+}

--- a/tests/Unit/Formula/Action/EnvsActionTest.php
+++ b/tests/Unit/Formula/Action/EnvsActionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Action;
+
+use Haspadar\Piqule\Envs\EmptyEnvs;
+use Haspadar\Piqule\Formula\Action\EnvsAction;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsValues;
+use Haspadar\Piqule\Tests\Fake\Envs\FakeEnvs;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EnvsActionTest extends TestCase
+{
+    #[Test]
+    public function rendersStepWithSingleVariable(): void
+    {
+        self::assertThat(
+            (new EnvsAction(
+                new FakeEnvs(['MY_VAR' => 'echo hello']),
+                '"      "',
+            ))->transformed(new ListArgs([])),
+            new HasArgsValues([
+                "      - name: Set environment variables\n"
+                . "        run: |\n"
+                . '          echo "MY_VAR=$(echo hello)" >> "$GITHUB_ENV"',
+            ]),
+            'EnvsAction must render a step that exports one variable',
+        );
+    }
+
+    #[Test]
+    public function rendersStepWithMultipleVariables(): void
+    {
+        self::assertThat(
+            (new EnvsAction(
+                new FakeEnvs(['A' => 'cmd-a', 'B' => 'cmd-b']),
+                '"      "',
+            ))->transformed(new ListArgs([])),
+            new HasArgsValues([
+                "      - name: Set environment variables\n"
+                . "        run: |\n"
+                . "          echo \"A=\$(cmd-a)\" >> \"\$GITHUB_ENV\"\n"
+                . '          echo "B=$(cmd-b)" >> "$GITHUB_ENV"',
+            ]),
+            'EnvsAction must render a step that exports multiple variables',
+        );
+    }
+
+    #[Test]
+    public function rendersEmptyStringWhenNoVariables(): void
+    {
+        self::assertThat(
+            (new EnvsAction(
+                new EmptyEnvs(),
+                '"      "',
+            ))->transformed(new ListArgs([])),
+            new HasArgsValues(['']),
+            'EnvsAction must return empty string when no env vars are configured',
+        );
+    }
+}


### PR DESCRIPTION
- Added Envs interface and implementations (YamlEnvs, EmptyEnvs) for parsing envs section from .piqule.yaml
- Added EnvsAction to render GitHub Actions step that exports environment variables via $GITHUB_ENV
- Added unit tests for all new classes including malformed YAML handling

Part of #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure environment variables in .piqule.yaml (name → command) and render them as GitHub Actions steps that append to GITHUB_ENV.
  * Added an option to control indentation of the generated step block.

* **Bug Fixes / Validation**
  * Strict validation of env names and values with clear errors for malformed YAML or invalid entries.

* **Tests**
  * Unit tests covering parsing, validation, empty cases, and workflow-step rendering; plus a test helper for env providers.

* **Chores**
  * Increased PHP Metrics afferent coupling threshold (configs/docs updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->