### PR TITLE
Unshallow Clone Before Envs Commands

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -184,6 +184,7 @@ This generates a workflow step:
 ```yaml
       - name: Set environment variables
         run: |
+          git fetch --tags
           echo "COMPOSER_ROOT_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')" >> "$GITHUB_ENV"
 ```
 

--- a/DEV.md
+++ b/DEV.md
@@ -184,7 +184,7 @@ This generates a workflow step:
 ```yaml
       - name: Set environment variables
         run: |
-          git fetch --tags
+          git fetch --tags --unshallow 2>/dev/null || git fetch --tags
           echo "COMPOSER_ROOT_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')" >> "$GITHUB_ENV"
 ```
 

--- a/src/Formula/Action/EnvsAction.php
+++ b/src/Formula/Action/EnvsAction.php
@@ -29,7 +29,7 @@ final readonly class EnvsAction implements Action
         }
 
         $indent = $this->unquotedIndent();
-        $lines = [sprintf('%s    git fetch --tags', $indent)];
+        $lines = [sprintf('%s    git fetch --tags --unshallow 2>/dev/null || git fetch --tags', $indent)];
 
         foreach ($vars as $name => $command) {
             $lines[] = sprintf(

--- a/src/Formula/Action/EnvsAction.php
+++ b/src/Formula/Action/EnvsAction.php
@@ -29,7 +29,7 @@ final readonly class EnvsAction implements Action
         }
 
         $indent = $this->unquotedIndent();
-        $lines = [];
+        $lines = [sprintf('%s    git fetch --tags', $indent)];
 
         foreach ($vars as $name => $command) {
             $lines[] = sprintf(

--- a/tests/Unit/Formula/Action/EnvsActionTest.php
+++ b/tests/Unit/Formula/Action/EnvsActionTest.php
@@ -25,7 +25,7 @@ final class EnvsActionTest extends TestCase
             new HasArgsValues([
                 "      - name: Set environment variables\n"
                 . "        run: |\n"
-                . "          git fetch --tags\n"
+                . "          git fetch --tags --unshallow 2>/dev/null || git fetch --tags\n"
                 . '          echo "MY_VAR=$(echo hello)" >> "$GITHUB_ENV"',
             ]),
             'EnvsAction must render a step that exports one variable',
@@ -43,7 +43,7 @@ final class EnvsActionTest extends TestCase
             new HasArgsValues([
                 "      - name: Set environment variables\n"
                 . "        run: |\n"
-                . "          git fetch --tags\n"
+                . "          git fetch --tags --unshallow 2>/dev/null || git fetch --tags\n"
                 . "          echo \"A=\$(cmd-a)\" >> \"\$GITHUB_ENV\"\n"
                 . '          echo "B=$(cmd-b)" >> "$GITHUB_ENV"',
             ]),

--- a/tests/Unit/Formula/Action/EnvsActionTest.php
+++ b/tests/Unit/Formula/Action/EnvsActionTest.php
@@ -25,6 +25,7 @@ final class EnvsActionTest extends TestCase
             new HasArgsValues([
                 "      - name: Set environment variables\n"
                 . "        run: |\n"
+                . "          git fetch --tags\n"
                 . '          echo "MY_VAR=$(echo hello)" >> "$GITHUB_ENV"',
             ]),
             'EnvsAction must render a step that exports one variable',
@@ -42,6 +43,7 @@ final class EnvsActionTest extends TestCase
             new HasArgsValues([
                 "      - name: Set environment variables\n"
                 . "        run: |\n"
+                . "          git fetch --tags\n"
                 . "          echo \"A=\$(cmd-a)\" >> \"\$GITHUB_ENV\"\n"
                 . '          echo "B=$(cmd-b)" >> "$GITHUB_ENV"',
             ]),


### PR DESCRIPTION
- Added git history unshallow before envs shell commands to ensure git describe works in CI
- Updated documentation example to reflect the generated workflow step

Closes #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow configuration with improved git tag fetching. The workflow now uses a more robust mechanism to retrieve tags with an automatic fallback option, ensuring reliable operation across different repository configurations during the build and release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->