### PR TITLE
Muted Output and Skipped Storage Reactions

### DIFF
--- a/src/Output/Console.php
+++ b/src/Output/Console.php
@@ -37,4 +37,13 @@ final readonly class Console implements Output
             "\033[31m$text\033[0m" . PHP_EOL,
         );
     }
+
+    #[Override]
+    public function muted(string $text): void
+    {
+        fwrite(
+            STDOUT,
+            "\033[90m$text\033[0m" . PHP_EOL,
+        );
+    }
 }

--- a/src/Output/Output.php
+++ b/src/Output/Output.php
@@ -23,4 +23,9 @@ interface Output
      * Emits an error message
      */
     public function error(string $text): void;
+
+    /**
+     * Emits a muted (secondary) message
+     */
+    public function muted(string $text): void;
 }

--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -32,6 +32,8 @@ final readonly class DiffingStorage implements Storage
             || $this->origin->mode($path) !== $file->mode();
 
         if (!$changed) {
+            $this->reaction->skipped($path);
+
             return $this;
         }
 

--- a/src/Storage/Reaction/ReportingStorageReaction.php
+++ b/src/Storage/Reaction/ReportingStorageReaction.php
@@ -30,4 +30,12 @@ final readonly class ReportingStorageReaction implements StorageReaction
             sprintf('Updated: %s', $path),
         );
     }
+
+    #[Override]
+    public function skipped(string $path): void
+    {
+        $this->output->muted(
+            sprintf('Skipped: %s', $path),
+        );
+    }
 }

--- a/src/Storage/Reaction/StorageReaction.php
+++ b/src/Storage/Reaction/StorageReaction.php
@@ -18,4 +18,9 @@ interface StorageReaction
      * Called when an existing file is overwritten at the given path
      */
     public function updated(string $path): void;
+
+    /**
+     * Called when a file is unchanged and writing is skipped
+     */
+    public function skipped(string $path): void;
 }

--- a/src/Storage/Reaction/StorageReactions.php
+++ b/src/Storage/Reaction/StorageReactions.php
@@ -33,4 +33,12 @@ final readonly class StorageReactions implements StorageReaction
             $reaction->updated($path);
         }
     }
+
+    #[Override]
+    public function skipped(string $path): void
+    {
+        foreach ($this->reactions as $reaction) {
+            $reaction->skipped($path);
+        }
+    }
 }

--- a/tests/Fake/Output/FakeOutput.php
+++ b/tests/Fake/Output/FakeOutput.php
@@ -17,6 +17,9 @@ final class FakeOutput implements Output
     /** @var list<string> */
     private array $errors = [];
 
+    /** @var list<string> */
+    private array $muteds = [];
+
     public function info(string $text): void
     {
         $this->infos[] = $text;
@@ -30,6 +33,11 @@ final class FakeOutput implements Output
     public function error(string $text): void
     {
         $this->errors[] = $text;
+    }
+
+    public function muted(string $text): void
+    {
+        $this->muteds[] = $text;
     }
 
     /** @return list<string> */
@@ -48,5 +56,11 @@ final class FakeOutput implements Output
     public function errors(): array
     {
         return $this->errors;
+    }
+
+    /** @return list<string> */
+    public function muteds(): array
+    {
+        return $this->muteds;
     }
 }

--- a/tests/Fake/Storage/Reaction/FakeStorageReaction.php
+++ b/tests/Fake/Storage/Reaction/FakeStorageReaction.php
@@ -15,6 +15,9 @@ final class FakeStorageReaction implements StorageReaction
     /** @var list<string> */
     private array $updated = [];
 
+    /** @var list<string> */
+    private array $skipped = [];
+
     #[Override]
     public function created(string $path): void
     {
@@ -27,6 +30,12 @@ final class FakeStorageReaction implements StorageReaction
         $this->updated[] = $path;
     }
 
+    #[Override]
+    public function skipped(string $path): void
+    {
+        $this->skipped[] = $path;
+    }
+
     /** @return list<string> */
     public function createdPaths(): array
     {
@@ -37,5 +46,11 @@ final class FakeStorageReaction implements StorageReaction
     public function updatedPaths(): array
     {
         return $this->updated;
+    }
+
+    /** @return list<string> */
+    public function skippedPaths(): array
+    {
+        return $this->skipped;
     }
 }


### PR DESCRIPTION
- Added Output::muted() for secondary (gray) messages
- Added StorageReaction::skipped() to notify when a file is unchanged
- Updated DiffingStorage to call skipped() when content has not changed

Part of #578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced muted message output type for displaying secondary and less critical information
  * File write operations now notify when files are skipped because their content and permissions remain unchanged

* **Tests**
  * Enhanced test infrastructure to track and verify muted message output
  * Added test utilities to monitor skipped file operation events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->