### PR TITLE
Shared ProjectConfig for All Bin Scripts

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -1,4 +1,5 @@
 override:
+  phpmetrics.coupling.max_afferent: 15
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
   ci.pr.max_lines_changed: 2000

--- a/.piqule/phpmetrics/rules.php
+++ b/.piqule/phpmetrics/rules.php
@@ -23,7 +23,7 @@ return [
         'max_methods_per_class' => 10,
     ],
     'coupling' => [
-        'max_afferent' => 14,
+        'max_afferent' => 15,
         'max_efferent' => 25,
     ],
 ];

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -29,14 +29,5 @@
             </errorLevel>
         </UnusedClass>
 
-        <UnresolvableInclude errorLevel="suppress">
-            <errorLevel type="suppress">
-                <file name="../../bin/piqule" />
-                <file name="../../bin/piqule-check" />
-                <file name="../../bin/piqule-fix" />
-                <file name="../../bin/piqule-sync" />
-                <file name="../../bin/piqule-tokens-check" />
-            </errorLevel>
-        </UnresolvableInclude>
     </issueHandlers>
 </psalm>

--- a/bin/piqule-check
+++ b/bin/piqule-check
@@ -3,48 +3,19 @@
 
 declare(strict_types=1);
 
-use Haspadar\Piqule\Config\Config;
-use Haspadar\Piqule\Config\ConfigPaths;
-use Haspadar\Piqule\Config\DefaultConfig;
-use Haspadar\Piqule\Config\YamlConfig;
+use Haspadar\Piqule\Config\ProjectConfig;
+use Haspadar\Piqule\PiquleException;
 
 require_once __DIR__ . '/bootstrap-autoload.php';
 
-$cwd = getcwd();
-
-if ($cwd === false) {
-    throw new RuntimeException('Cannot determine cwd');
-}
-
-$projectRoot = $cwd;
-
-$yamlPath = $projectRoot . '/.piqule.yaml';
+$projectRoot = getcwd()
+    ?: throw new RuntimeException('Cannot determine cwd');
 
 try {
-    $defaults = new DefaultConfig(paths: new ConfigPaths($projectRoot . '/composer.json'));
-} catch (Throwable $e) {
-    fwrite(STDERR, "Failed to load default config: {$e->getMessage()}\n");
+    $config = new ProjectConfig($projectRoot);
+} catch (PiquleException $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
     exit(1);
-}
-
-if (file_exists($yamlPath)) {
-    try {
-        $config = new YamlConfig($yamlPath, $defaults);
-    } catch (Throwable $e) {
-        fwrite(STDERR, "Failed to load .piqule.yaml: {$e->getMessage()}\n");
-        exit(1);
-    }
-} elseif (file_exists($projectRoot . '/.piqule.php')) {
-    $loaded = require $projectRoot . '/.piqule.php';
-
-    if (!$loaded instanceof Config) {
-        fwrite(STDERR, ".piqule.php must return an instance of Config\n");
-        exit(1);
-    }
-
-    $config = $loaded;
-} else {
-    $config = $defaults;
 }
 
 $flags = ['-v', '--verbose', '-p', '--parallel', '-P', '--no-parallel', '-f', '--full', '-F', '--no-full'];

--- a/bin/piqule-sync
+++ b/bin/piqule-sync
@@ -3,10 +3,7 @@
 
 declare(strict_types=1);
 
-use Haspadar\Piqule\Config\Config;
-use Haspadar\Piqule\Config\ConfigPaths;
-use Haspadar\Piqule\Config\DefaultConfig;
-use Haspadar\Piqule\Config\YamlConfig;
+use Haspadar\Piqule\Config\ProjectConfig;
 use Haspadar\Piqule\Envs\EmptyEnvs;
 use Haspadar\Piqule\Envs\YamlEnvs;
 use Haspadar\Piqule\File\ConfiguredFile;
@@ -42,26 +39,10 @@ try {
 
     $libraryRoot = $installPath;
 
+    $config = new ProjectConfig($projectRoot);
+
     $yamlPath = $projectRoot . '/.piqule.yaml';
-    $defaults = new DefaultConfig(paths: new ConfigPaths($projectRoot . '/composer.json'));
-
-    $hasYaml = file_exists($yamlPath);
-
-    if ($hasYaml) {
-        $config = new YamlConfig($yamlPath, $defaults);
-    } elseif (file_exists($projectRoot . '/.piqule.php')) {
-        $loaded = require $projectRoot . '/.piqule.php';
-
-        if (!$loaded instanceof Config) {
-            throw new PiquleException('.piqule.php must return an instance of Config');
-        }
-
-        $config = $loaded;
-    } else {
-        $config = $defaults;
-    }
-
-    $envs = $hasYaml
+    $envs = file_exists($yamlPath)
         ? new YamlEnvs($yamlPath)
         : new EmptyEnvs();
 

--- a/bin/piqule-tokens-check
+++ b/bin/piqule-tokens-check
@@ -3,13 +3,11 @@
 
 declare(strict_types=1);
 
-use Haspadar\Piqule\Config\Config;
-use Haspadar\Piqule\Config\ConfigPaths;
-use Haspadar\Piqule\Config\DefaultConfig;
-use Haspadar\Piqule\Config\YamlConfig;
+use Haspadar\Piqule\Config\ProjectConfig;
 use Haspadar\Piqule\EnvVar\EnvVars;
 use Haspadar\Piqule\EnvVar\SonarEnvVar;
 use Haspadar\Piqule\Output\Console;
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Secret\CodecovSecret;
 use Haspadar\Piqule\Secret\InfectionSecret;
 use Haspadar\Piqule\Secret\Secrets;
@@ -19,33 +17,12 @@ require_once __DIR__ . '/bootstrap-autoload.php';
 $output = new Console();
 
 $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
-$yamlPath = $projectRoot . '/.piqule.yaml';
 
 try {
-    $defaults = new DefaultConfig(paths: new ConfigPaths($projectRoot . '/composer.json'));
-} catch (Throwable $e) {
-    $output->error("Failed to load default config: {$e->getMessage()}");
+    $config = new ProjectConfig($projectRoot);
+} catch (PiquleException $e) {
+    $output->error($e->getMessage());
     exit(1);
-}
-
-if (file_exists($yamlPath)) {
-    try {
-        $config = new YamlConfig($yamlPath, $defaults);
-    } catch (Throwable $e) {
-        $output->error("Failed to load .piqule.yaml: {$e->getMessage()}");
-        exit(1);
-    }
-} elseif (file_exists($projectRoot . '/.piqule.php')) {
-    $loaded = require $projectRoot . '/.piqule.php';
-
-    if (!$loaded instanceof Config) {
-        $output->error('.piqule.php must return an instance of Config');
-        exit(1);
-    }
-
-    $config = $loaded;
-} else {
-    $config = $defaults;
 }
 
 $envVars = new EnvVars([

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Config;
+
+use Haspadar\Piqule\PiquleException;
+use Override;
+
+/**
+ * Loads project configuration from .piqule.yaml, .piqule.php, or defaults.
+ *
+ * Example:
+ *
+ *     new ProjectConfig('/path/to/project');
+ */
+final class ProjectConfig implements Config
+{
+    private ?Config $cache;
+
+    /** Initializes with the project root directory path. */
+    public function __construct(
+        private readonly string $projectRoot,
+    ) {
+        $this->cache = null;
+    }
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return $this->config()->has($name);
+    }
+
+    #[Override]
+    public function list(string $name): array
+    {
+        return $this->config()->list($name);
+    }
+
+    #[Override]
+    public function toArray(): array
+    {
+        return $this->config()->toArray();
+    }
+
+    /**
+     * Resolves configuration from .piqule.yaml, .piqule.php, or defaults.
+     *
+     * @throws PiquleException
+     */
+    private function config(): Config
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        $defaults = new DefaultConfig(
+            paths: new ConfigPaths($this->projectRoot . '/composer.json'),
+        );
+
+        $yamlPath = $this->projectRoot . '/.piqule.yaml';
+        $phpPath = $this->projectRoot . '/.piqule.php';
+
+        if (file_exists($yamlPath)) {
+            $this->cache = new YamlConfig($yamlPath, $defaults);
+        } elseif (file_exists($phpPath)) {
+            $loaded = require $phpPath;
+
+            if (!$loaded instanceof Config) {
+                throw new PiquleException('.piqule.php must return an instance of Config');
+            }
+
+            $this->cache = $loaded;
+        } else {
+            $this->cache = $defaults;
+        }
+
+        return $this->cache;
+    }
+}

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -19,9 +19,8 @@ final class ProjectConfig implements Config
     private ?Config $cache;
 
     /** Initializes with the project root directory path. */
-    public function __construct(
-        private readonly string $projectRoot,
-    ) {
+    public function __construct(private readonly string $projectRoot)
+    {
         $this->cache = null;
     }
 
@@ -55,7 +54,9 @@ final class ProjectConfig implements Config
         }
 
         $defaults = new DefaultConfig(
-            paths: new ConfigPaths($this->projectRoot . '/composer.json'),
+            [],
+            [],
+            new ConfigPaths($this->projectRoot . '/composer.json'),
         );
 
         $yamlPath = $this->projectRoot . '/.piqule.yaml';

--- a/templates/always/.piqule/psalm/psalm.xml
+++ b/templates/always/.piqule/psalm/psalm.xml
@@ -22,6 +22,5 @@
             </errorLevel>
         </UnusedClass>
 << config(psalm.suppress.possibly_unused)|format_each('                <directory name="%s" />')|join("\n")|if_not_empty()|format('        <PossiblyUnusedMethod errorLevel="suppress">\n            <errorLevel type="suppress">\n%s\n            </errorLevel>\n        </PossiblyUnusedMethod>') >>
-<< config(psalm.project.files)|format_each('                <file name="%s" />')|join("\n")|if_not_empty()|format('        <UnresolvableInclude errorLevel="suppress">\n            <errorLevel type="suppress">\n%s\n            </errorLevel>\n        </UnresolvableInclude>') >>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
- Added ProjectConfig to encapsulate config loading from .piqule.yaml, .piqule.php, or defaults
- Removed duplicated config loading logic from piqule-check, piqule-sync, and piqule-tokens-check
- Removed psalm UnresolvableInclude suppression no longer needed after require moved to ProjectConfig
- Updated afferent coupling limit to accommodate the new class

Part of #578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified configuration initialization mechanism to streamline loading across command-line tools.

* **Chores**
  * Updated maximum afferent coupling threshold from 14 to 15.
  * Removed Psalm include-resolution suppression configuration for stricter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->