### PR TITLE
Check and Checks Interfaces With Collection Decorators

### DIFF
--- a/src/Check/Check.php
+++ b/src/Check/Check.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+/**
+ * A named quality check with a shell command
+ */
+interface Check
+{
+    /**
+     * Check name, e.g. "phpstan" or "phpunit"
+     */
+    public function name(): string;
+
+    /**
+     * Absolute path to the command.sh file
+     */
+    public function command(): string;
+}

--- a/src/Check/Checks.php
+++ b/src/Check/Checks.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Haspadar\Piqule\PiquleException;
+
+/**
+ * A collection of quality checks
+ */
+interface Checks
+{
+    /**
+     * Returns all checks in this collection.
+     *
+     * @throws PiquleException
+     * @return iterable<Check>
+     */
+    public function all(): iterable;
+}

--- a/src/Check/ConfigCheck.php
+++ b/src/Check/ConfigCheck.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Override;
+
+/**
+ * A quality check discovered from a config key with a matching command.sh.
+ *
+ * Example:
+ *
+ *     new ConfigCheck('phpstan', '/path/to/project');
+ */
+final readonly class ConfigCheck implements Check
+{
+    /** Initializes with the check name and project root path. */
+    public function __construct(private string $name, private string $projectRoot) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function command(): string
+    {
+        return $this->projectRoot . '/.piqule/' . $this->name . '/command.sh';
+    }
+}

--- a/src/Check/ConfigChecks.php
+++ b/src/Check/ConfigChecks.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Haspadar\Piqule\Config\Config;
+use Override;
+
+/**
+ * Discovers available checks from config keys ending in ".cli".
+ */
+final readonly class ConfigChecks implements Checks
+{
+    /** Initializes with project configuration and root path. */
+    public function __construct(private Config $config, private string $projectRoot) {}
+
+    #[Override]
+    public function all(): iterable
+    {
+        foreach (array_keys($this->config->toArray()) as $key) {
+            if (!str_ends_with($key, '.cli')) {
+                continue;
+            }
+
+            $name = substr($key, 0, -4);
+            $check = new ConfigCheck($name, $this->projectRoot);
+
+            if (file_exists($check->command())) {
+                yield $check;
+            }
+        }
+    }
+}

--- a/src/Check/EnabledChecks.php
+++ b/src/Check/EnabledChecks.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Haspadar\Piqule\Config\Config;
+use Override;
+
+/**
+ * Yields only checks that are not explicitly disabled via config.
+ */
+final readonly class EnabledChecks implements Checks
+{
+    /** Initializes with a check collection and project configuration. */
+    public function __construct(private Checks $origin, private Config $config) {}
+
+    #[Override]
+    public function all(): iterable
+    {
+        foreach ($this->origin->all() as $check) {
+            $key = $check->name() . '.cli';
+
+            if ($this->config->has($key) && !((bool) ($this->config->list($key)[0] ?? true))) {
+                continue;
+            }
+
+            yield $check;
+        }
+    }
+}

--- a/src/Check/EnabledChecks.php
+++ b/src/Check/EnabledChecks.php
@@ -21,7 +21,7 @@ final readonly class EnabledChecks implements Checks
         foreach ($this->origin->all() as $check) {
             $key = $check->name() . '.cli';
 
-            if ($this->config->has($key) && !((bool) ($this->config->list($key)[0] ?? true))) {
+            if ($this->config->has($key) && !(bool) ($this->config->list($key)[0] ?? true)) {
                 continue;
             }
 

--- a/src/Check/FastChecks.php
+++ b/src/Check/FastChecks.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Haspadar\Piqule\Config\Config;
+use Override;
+
+/**
+ * Excludes slow checks listed in the "check.slow" config key.
+ */
+final readonly class FastChecks implements Checks
+{
+    /** Initializes with a check collection and project configuration. */
+    public function __construct(private Checks $origin, private Config $config) {}
+
+    #[Override]
+    public function all(): iterable
+    {
+        $slow = array_map('strval', $this->config->list('check.slow'));
+
+        foreach ($this->origin->all() as $check) {
+            if (!in_array($check->name(), $slow, true)) {
+                yield $check;
+            }
+        }
+    }
+}

--- a/src/Check/SingleCheck.php
+++ b/src/Check/SingleCheck.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Override;
+
+/**
+ * A single-element collection for a specifically requested check.
+ */
+final readonly class SingleCheck implements Checks
+{
+    /** Initializes with the check name and project root path. */
+    public function __construct(private string $name, private string $projectRoot) {}
+
+    #[Override]
+    public function all(): iterable
+    {
+        yield new ConfigCheck($this->name, $this->projectRoot);
+    }
+}


### PR DESCRIPTION
- Added Check interface as the abstraction for a single quality check
- Added Checks interface as the collection abstraction
- Added ConfigCheck as the default implementation backed by command.sh
- Added ConfigChecks, EnabledChecks, FastChecks, and SingleCheck decorators for discovery and filtering

Part of #578