### PR TITLE
CLI Option Classes for Check Flag Parsing

### DIFF
--- a/src/Check/CliOption.php
+++ b/src/Check/CliOption.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Haspadar\Piqule\PiquleException;
+
+/**
+ * A boolean CLI option that can be enabled or disabled
+ */
+interface CliOption
+{
+    /**
+     * Whether this option is enabled
+     *
+     * @throws PiquleException
+     */
+    public function enabled(): bool;
+}

--- a/src/Check/ConfigDefault.php
+++ b/src/Check/ConfigDefault.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Haspadar\Piqule\Config\Config;
+use Override;
+
+/**
+ * A CLI option whose value comes from a boolean config key.
+ */
+final readonly class ConfigDefault implements CliOption
+{
+    /** Initializes with project configuration and the config key. */
+    public function __construct(private Config $config, private string $key) {}
+
+    #[Override]
+    public function enabled(): bool
+    {
+        return filter_var(
+            $this->config->list($this->key)[0] ?? false,
+            FILTER_VALIDATE_BOOLEAN,
+            FILTER_NULL_ON_FAILURE,
+        ) ?? false;
+    }
+}

--- a/src/Check/ConfigOption.php
+++ b/src/Check/ConfigOption.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Override;
+
+/**
+ * A CLI option that falls back to a default when neither flag is set.
+ */
+final readonly class ConfigOption implements CliOption
+{
+    /** Initializes with positive flag, negative flag, and default. */
+    public function __construct(
+        private CliOption $on,
+        private CliOption $off,
+        private CliOption $default,
+    ) {}
+
+    #[Override]
+    public function enabled(): bool
+    {
+        if ($this->off->enabled()) {
+            return false;
+        }
+
+        return $this->on->enabled() || $this->default->enabled();
+    }
+}

--- a/src/Check/RequestedCheck.php
+++ b/src/Check/RequestedCheck.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+/**
+ * Extracts the requested check name from CLI arguments.
+ */
+final readonly class RequestedCheck
+{
+    private const array FLAGS = [
+        '-v', '--verbose',
+        '-p', '--parallel', '-P', '--no-parallel',
+        '-f', '--full', '-F', '--no-full',
+    ];
+
+    /**
+     * Initializes with the CLI argument list.
+     *
+     * @param list<string> $argv
+     */
+    public function __construct(private array $argv) {}
+
+    /** Returns the check name or empty string if none requested. */
+    public function name(): string
+    {
+        $args = array_values(
+            array_filter(
+                $this->argv,
+                static fn(string $a): bool => !in_array($a, self::FLAGS, true),
+            ),
+        );
+
+        return $args[1] ?? '';
+    }
+}

--- a/src/Check/ToggleOption.php
+++ b/src/Check/ToggleOption.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Check;
+
+use Override;
+
+/**
+ * A boolean flag parsed from CLI arguments.
+ */
+final readonly class ToggleOption implements CliOption
+{
+    /**
+     * Initializes with CLI arguments and flag variants.
+     *
+     * @param list<string> $argv
+     * @param list<string> $flags
+     */
+    public function __construct(private array $argv, private array $flags) {}
+
+    #[Override]
+    public function enabled(): bool
+    {
+        foreach ($this->flags as $flag) {
+            if (in_array($flag, $this->argv, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
- Added CliOption interface for boolean CLI flags
- Added ToggleOption, ConfigDefault, ConfigOption to compose flag parsing with config fallback
- Added RequestedCheck to extract check name from argv

Part of #578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line option configuration and argument parsing capabilities.
  * Introduced CLI option handling with support for toggle options, configuration-based defaults, and combined option logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->