### PR TITLE
#584: Ignore coverage.xml produced by PHPUnit

### DIFF
--- a/.piqule/.gitignore
+++ b/.piqule/.gitignore
@@ -1,5 +1,6 @@
 php-cs-fixer/.php-cs-fixer.cache
 codecov/coverage-report/
+codecov/coverage.xml
 infection/*.log
 ast-metrics/reports/
 phpmetrics/phpmetrics.json

--- a/templates/always/.piqule/.gitignore
+++ b/templates/always/.piqule/.gitignore
@@ -1,5 +1,6 @@
 php-cs-fixer/.php-cs-fixer.cache
 codecov/coverage-report/
+codecov/coverage.xml
 infection/*.log
 ast-metrics/reports/
 phpmetrics/phpmetrics.json


### PR DESCRIPTION
## Summary

- Add `codecov/coverage.xml` to the generated `.piqule/.gitignore` template

## Test plan

- [ ] Run `piqule sync` — `.piqule/.gitignore` contains `codecov/coverage.xml`
- [ ] Run tests that produce coverage — `coverage.xml` does not show as untracked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to ensure coverage report artifacts are properly ignored by version control systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->