### PR TITLE
#586: Move kubawerlos/php-cs-fixer-custom-fixers to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "friendsofphp/php-cs-fixer": "^3.91",
         "haspadar/phpstan-rules": "^0.30.1",
         "infection/infection": "^0.32.0",
+        "kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
         "phpmd/phpmd": "^2.15",
         "phpmetrics/phpmetrics": "^2.9",
         "phpstan/phpstan": "^2.1",
@@ -49,8 +50,5 @@
         },
         "sort-packages": true
     },
-    "prefer-stable": true,
-    "require-dev": {
-        "kubawerlos/php-cs-fixer-custom-fixers": "^3.36"
-    }
+    "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f0f4f8ca6ad99bbe6c7e39f6eb5b0e3",
+    "content-hash": "b1643b9c668c8421c31c5da9785b4732",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2284,6 +2284,58 @@
                 "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
             },
             "time": "2023-02-03T21:26:53+00:00"
+        },
+        {
+            "name": "kubawerlos/php-cs-fixer-custom-fixers",
+            "version": "v3.36.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
+                "reference": "ec9776e80f5ea9bf0d8ec16d662e431bfab19a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/ec9776e80f5ea9bf0d8ec16d662e431bfab19a24",
+                "reference": "ec9776e80f5ea9bf0d8ec16d662e431bfab19a24",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-tokenizer": "*",
+                "friendsofphp/php-cs-fixer": "^3.87",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6.24 || ^10.5.51 || ^11.5.44"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixerCustomFixers\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kuba Werłos",
+                    "email": "werlos@gmail.com"
+                }
+            ],
+            "description": "A set of custom fixers for PHP CS Fixer",
+            "support": {
+                "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
+                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.36.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kubawerlos",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-07T11:35:13+00:00"
         },
         {
             "name": "league/uri",
@@ -8423,60 +8475,7 @@
             "time": "2026-02-27T10:28:38+00:00"
         }
     ],
-    "packages-dev": [
-        {
-            "name": "kubawerlos/php-cs-fixer-custom-fixers",
-            "version": "v3.36.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
-                "reference": "ec9776e80f5ea9bf0d8ec16d662e431bfab19a24"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/ec9776e80f5ea9bf0d8ec16d662e431bfab19a24",
-                "reference": "ec9776e80f5ea9bf0d8ec16d662e431bfab19a24",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "*",
-                "ext-tokenizer": "*",
-                "friendsofphp/php-cs-fixer": "^3.87",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.6.24 || ^10.5.51 || ^11.5.44"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PhpCsFixerCustomFixers\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kuba Werłos",
-                    "email": "werlos@gmail.com"
-                }
-            ],
-            "description": "A set of custom fixers for PHP CS Fixer",
-            "support": {
-                "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
-                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.36.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/kubawerlos",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-03-07T11:35:13+00:00"
-        }
-    ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},


### PR DESCRIPTION
## Summary

- Move `kubawerlos/php-cs-fixer-custom-fixers` from `require-dev` to `require` so it is installed transitively in consumer projects
- Without this, `piqule check php-cs-fixer` fails in consumer projects because custom fixers class is not found

## Test plan

- [ ] Install piqule in a consumer project — `kubawerlos/php-cs-fixer-custom-fixers` is present in `vendor/`
- [ ] Run `piqule check php-cs-fixer` in a consumer project — passes without errors