### PR TITLE
PHPStan Rules 0.30.4 With Naming Rule Compliance

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1735,16 +1735,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.30.1",
+            "version": "v0.30.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "460c6afd0d61bb12383babcaaa118bcf381a8285"
+                "reference": "70513a9e85f3513b951ed332edeacce3194168d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/460c6afd0d61bb12383babcaaa118bcf381a8285",
-                "reference": "460c6afd0d61bb12383babcaaa118bcf381a8285",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/70513a9e85f3513b951ed332edeacce3194168d7",
+                "reference": "70513a9e85f3513b951ed332edeacce3194168d7",
                 "shasum": ""
             },
             "require": {
@@ -1782,9 +1782,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.30.1"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.30.4"
             },
-            "time": "2026-04-07T12:53:39+00:00"
+            "time": "2026-04-11T08:57:20+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/src/Check/ConfigCheck.php
+++ b/src/Check/ConfigCheck.php
@@ -16,7 +16,7 @@ use Override;
 final readonly class ConfigCheck implements Check
 {
     /** Initializes with the check name and project root path. */
-    public function __construct(private string $name, private string $projectRoot) {}
+    public function __construct(private string $name, private string $root) {}
 
     #[Override]
     public function name(): string
@@ -27,6 +27,6 @@ final readonly class ConfigCheck implements Check
     #[Override]
     public function command(): string
     {
-        return $this->projectRoot . '/.piqule/' . $this->name . '/command.sh';
+        return $this->root . '/.piqule/' . $this->name . '/command.sh';
     }
 }

--- a/src/Check/ConfigChecks.php
+++ b/src/Check/ConfigChecks.php
@@ -13,7 +13,7 @@ use Override;
 final readonly class ConfigChecks implements Checks
 {
     /** Initializes with project configuration and root path. */
-    public function __construct(private Config $config, private string $projectRoot) {}
+    public function __construct(private Config $config, private string $root) {}
 
     #[Override]
     public function all(): iterable
@@ -24,7 +24,7 @@ final readonly class ConfigChecks implements Checks
             }
 
             $name = substr($key, 0, -4);
-            $check = new ConfigCheck($name, $this->projectRoot);
+            $check = new ConfigCheck($name, $this->root);
 
             if (file_exists($check->command())) {
                 yield $check;

--- a/src/Check/ConfigOption.php
+++ b/src/Check/ConfigOption.php
@@ -13,7 +13,7 @@ final readonly class ConfigOption implements CliOption
 {
     /** Initializes with positive flag, negative flag, and default. */
     public function __construct(
-        private CliOption $on,
+        private CliOption $yes,
         private CliOption $off,
         private CliOption $default,
     ) {}
@@ -25,6 +25,6 @@ final readonly class ConfigOption implements CliOption
             return false;
         }
 
-        return $this->on->enabled() || $this->default->enabled();
+        return $this->yes->enabled() || $this->default->enabled();
     }
 }

--- a/src/Check/ProcessPool.php
+++ b/src/Check/ProcessPool.php
@@ -44,9 +44,9 @@ final readonly class ProcessPool
      * @param array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float} $handle
      * @return array{check: Check, result: CheckResult, elapsed: float}
      */
-    private function collect(array $handle, int $exitCode, float $elapsed): array
+    private function collect(array $handle, int $code, float $elapsed): array
     {
-        $status = $exitCode;
+        $status = $code;
 
         if ($status === -1) {
             $status = proc_close($handle['proc']);

--- a/src/Check/SingleCheck.php
+++ b/src/Check/SingleCheck.php
@@ -12,11 +12,11 @@ use Override;
 final readonly class SingleCheck implements Checks
 {
     /** Initializes with the check name and project root path. */
-    public function __construct(private string $name, private string $projectRoot) {}
+    public function __construct(private string $name, private string $root) {}
 
     #[Override]
     public function all(): iterable
     {
-        yield new ConfigCheck($this->name, $this->projectRoot);
+        yield new ConfigCheck($this->name, $this->root);
     }
 }

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -22,10 +22,10 @@ final readonly class ComposerRootNamespace
         $contents = @file_get_contents($this->path);
         /** @var array{autoload?: array{psr-4?: array<string, string>}} $data */
         $data = json_decode($contents === false ? '{}' : $contents, true) ?? [];
-        $psr4 = $data['autoload']['psr-4'] ?? [];
+        $namespaces = $data['autoload']['psr-4'] ?? [];
 
-        return $psr4 !== []
-            ? rtrim(array_key_first($psr4), '\\')
+        return $namespaces !== []
+            ? rtrim(array_key_first($namespaces), '\\')
             : '';
     }
 }

--- a/src/Config/ConfigPaths.php
+++ b/src/Config/ConfigPaths.php
@@ -11,19 +11,19 @@ final readonly class ConfigPaths
 {
     /** Initializes with optional custom paths for composer.json and config.yaml. */
     public function __construct(
-        private string $composerJson = '',
-        private string $configYaml = __DIR__ . '/../../templates/always/.piqule/config.yaml',
+        private string $composer = '',
+        private string $config = __DIR__ . '/../../templates/always/.piqule/config.yaml',
     ) {}
 
     /** Returns the composer.json file path. */
     public function composerJson(): string
     {
-        return $this->composerJson;
+        return $this->composer;
     }
 
     /** Returns the config.yaml file path. */
     public function configYaml(): string
     {
-        return $this->configYaml;
+        return $this->config;
     }
 }

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -21,7 +21,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  *     new DefaultConfig();
  *
- *     new DefaultConfig(paths: new ConfigPaths(composerJson: '/path/to/composer.json'));
+ *     new DefaultConfig(paths: new ConfigPaths(composer: '/path/to/composer.json'));
  */
 final class DefaultConfig implements Config
 {
@@ -31,11 +31,11 @@ final class DefaultConfig implements Config
     /**
      * Initializes with source directories, exclusions, and config paths.
      *
-     * @param list<string> $phpSrc
+     * @param list<string> $source
      * @param list<string> $exclude
      */
     public function __construct(
-        private readonly array $phpSrc = [],
+        private readonly array $source = [],
         private readonly array $exclude = [],
         private readonly ConfigPaths $paths = new ConfigPaths(),
     ) {
@@ -104,8 +104,8 @@ final class DefaultConfig implements Config
         $base = $yaml['defaults'];
 
         /** @var list<string> $resolvedPhpSrc */
-        $resolvedPhpSrc = $this->phpSrc !== []
-            ? $this->phpSrc
+        $resolvedPhpSrc = $this->source !== []
+            ? $this->source
             : ($base['php.src'] ?? []);
 
         /** @var list<string> $resolvedExclude */
@@ -123,16 +123,16 @@ final class DefaultConfig implements Config
     /**
      * Reads dynamic defaults derived from composer.json paths and directory lists.
      *
-     * @param list<string> $phpSrc
+     * @param list<string> $source
      * @param list<string> $exclude
      * @return array<string, scalar|list<scalar>>
      */
-    private function dynamic(array $phpSrc, array $exclude): array
+    private function dynamic(array $source, array $exclude): array
     {
-        $projectIncludes = (new ProjectDirs($phpSrc))->toList();
+        $projectIncludes = (new ProjectDirs($source))->toList();
 
         return [
-            'php.src' => $phpSrc,
+            'php.src' => $source,
             'exclude' => $exclude,
             'hadolint.ignore' => $exclude,
             'jsonlint.patterns' => array_merge(
@@ -144,7 +144,7 @@ final class DefaultConfig implements Config
             'phpcs.excludes' => (new GlobDirs($exclude))->toList(),
             'phpcs.files' => $projectIncludes,
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
-            'phpmd.paths' => $phpSrc,
+            'phpmd.paths' => $source,
             'phpmetrics.includes' => $projectIncludes,
             'phpmetrics.excludes' => $exclude,
             'phpstan.paths' => $projectIncludes,
@@ -153,7 +153,7 @@ final class DefaultConfig implements Config
             'psalm.project.ignore' => (new ProjectDirs($exclude))->toList(),
             'infection.source.directories' => $projectIncludes,
             'shellcheck.ignore_dirs' => $exclude,
-            'sonar.sources' => $phpSrc,
+            'sonar.sources' => $source,
             'typos.exclude' => (new TrailingSlashDirs($exclude))->toList(),
             'yamllint.ignore' => array_merge(
                 (new TrailingGlobDirs($exclude))->toList(),

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -103,8 +103,8 @@ final class DefaultConfig implements Config
         /** @var array<string, mixed> $base */
         $base = $yaml['defaults'];
 
-        /** @var list<string> $resolvedPhpSrc */
-        $resolvedPhpSrc = $this->source !== []
+        /** @var list<string> $resolvedSource */
+        $resolvedSource = $this->source !== []
             ? $this->source
             : ($base['php.src'] ?? []);
 
@@ -114,7 +114,7 @@ final class DefaultConfig implements Config
             : ($base['exclude'] ?? []);
 
         /** @var array<string, scalar|list<scalar>> $defaults */
-        $defaults = array_merge($base, $this->dynamic($resolvedPhpSrc, $resolvedExclude));
+        $defaults = array_merge($base, $this->dynamic($resolvedSource, $resolvedExclude));
         $this->cache = $defaults;
 
         return $defaults;

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -19,7 +19,7 @@ final class ProjectConfig implements Config
     private ?Config $cache;
 
     /** Initializes with the project root directory path. */
-    public function __construct(private readonly string $projectRoot)
+    public function __construct(private readonly string $root)
     {
         $this->cache = null;
     }
@@ -56,11 +56,11 @@ final class ProjectConfig implements Config
         $defaults = new DefaultConfig(
             [],
             [],
-            new ConfigPaths($this->projectRoot . '/composer.json'),
+            new ConfigPaths($this->root . '/composer.json'),
         );
 
-        $yamlPath = $this->projectRoot . '/.piqule.yaml';
-        $phpPath = $this->projectRoot . '/.piqule.php';
+        $yamlPath = $this->root . '/.piqule.yaml';
+        $phpPath = $this->root . '/.piqule.php';
 
         if (file_exists($yamlPath)) {
             $this->cache = new YamlConfig($yamlPath, $defaults);

--- a/tests/Fake/Check/FakeCliOption.php
+++ b/tests/Fake/Check/FakeCliOption.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fake\Check;
+
+use Haspadar\Piqule\Check\CliOption;
+
+final readonly class FakeCliOption implements CliOption
+{
+    public function __construct(private bool $enabled) {}
+
+    public function enabled(): bool
+    {
+        return $this->enabled;
+    }
+}

--- a/tests/Unit/Check/ConfigCheckTest.php
+++ b/tests/Unit/Check/ConfigCheckTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\ConfigCheck;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigCheckTest extends TestCase
+{
+    #[Test]
+    public function returnsNamePassedToConstructor(): void
+    {
+        self::assertSame(
+            'phpstan',
+            (new ConfigCheck('phpstan', '/tmp'))->name(),
+            'ConfigCheck must return the check name',
+        );
+    }
+
+    #[Test]
+    public function returnsCommandPathUnderPiquleDirectory(): void
+    {
+        self::assertSame(
+            '/project/.piqule/phpstan/command.sh',
+            (new ConfigCheck('phpstan', '/project'))->command(),
+            'ConfigCheck must build command path from root and name',
+        );
+    }
+}

--- a/tests/Unit/Check/ConfigChecksTest.php
+++ b/tests/Unit/Check/ConfigChecksTest.php
@@ -25,18 +25,20 @@ final class ConfigChecksTest extends TestCase
             $folder->path(),
         );
 
-        $names = [];
-        foreach ($checks->all() as $check) {
-            $names[] = $check->name();
+        try {
+            $names = [];
+            foreach ($checks->all() as $check) {
+                $names[] = $check->name();
+            }
+
+            self::assertSame(
+                ['phpstan'],
+                $names,
+                'ConfigChecks must yield checks with existing command files',
+            );
+        } finally {
+            $folder->close();
         }
-
-        $folder->close();
-
-        self::assertSame(
-            ['phpstan'],
-            $names,
-            'ConfigChecks must yield checks with existing command files',
-        );
     }
 
     #[Test]

--- a/tests/Unit/Check/ConfigChecksTest.php
+++ b/tests/Unit/Check/ConfigChecksTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\ConfigChecks;
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigChecksTest extends TestCase
+{
+    #[Test]
+    public function yieldsCheckWhenCommandFileExists(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule/phpstan/command.sh',
+            '#!/bin/bash',
+        );
+
+        $checks = new ConfigChecks(
+            new FakeConfig(['phpstan.cli' => [true]]),
+            $folder->path(),
+        );
+
+        $names = [];
+        foreach ($checks->all() as $check) {
+            $names[] = $check->name();
+        }
+
+        $folder->close();
+
+        self::assertSame(
+            ['phpstan'],
+            $names,
+            'ConfigChecks must yield checks with existing command files',
+        );
+    }
+
+    #[Test]
+    public function skipsCheckWhenCommandFileMissing(): void
+    {
+        $checks = new ConfigChecks(
+            new FakeConfig(['phpstan.cli' => [true]]),
+            '/nonexistent',
+        );
+
+        $names = [];
+        foreach ($checks->all() as $check) {
+            $names[] = $check->name();
+        }
+
+        self::assertSame(
+            [],
+            $names,
+            'ConfigChecks must skip checks without command files',
+        );
+    }
+}

--- a/tests/Unit/Check/ConfigOptionTest.php
+++ b/tests/Unit/Check/ConfigOptionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\ConfigOption;
+use Haspadar\Piqule\Tests\Fake\Check\FakeCliOption;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigOptionTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueWhenPositiveFlagEnabled(): void
+    {
+        self::assertTrue(
+            (new ConfigOption(
+                new FakeCliOption(true),
+                new FakeCliOption(false),
+                new FakeCliOption(false),
+            ))->enabled(),
+            'ConfigOption must be enabled when positive flag is set',
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenNegativeFlagEnabled(): void
+    {
+        self::assertFalse(
+            (new ConfigOption(
+                new FakeCliOption(true),
+                new FakeCliOption(true),
+                new FakeCliOption(false),
+            ))->enabled(),
+            'ConfigOption must be disabled when negative flag overrides',
+        );
+    }
+
+    #[Test]
+    public function fallsBackToDefaultWhenNoFlagSet(): void
+    {
+        self::assertTrue(
+            (new ConfigOption(
+                new FakeCliOption(false),
+                new FakeCliOption(false),
+                new FakeCliOption(true),
+            ))->enabled(),
+            'ConfigOption must fall back to default when no flag is set',
+        );
+    }
+}

--- a/tests/Unit/Check/ConfigOptionTest.php
+++ b/tests/Unit/Check/ConfigOptionTest.php
@@ -12,6 +12,19 @@ use PHPUnit\Framework\TestCase;
 final class ConfigOptionTest extends TestCase
 {
     #[Test]
+    public function returnsFalseWhenAllFlagsDisabled(): void
+    {
+        self::assertFalse(
+            (new ConfigOption(
+                new FakeCliOption(false),
+                new FakeCliOption(false),
+                new FakeCliOption(false),
+            ))->enabled(),
+            'ConfigOption must be disabled when all flags are off',
+        );
+    }
+
+    #[Test]
     public function returnsTrueWhenPositiveFlagEnabled(): void
     {
         self::assertTrue(

--- a/tests/Unit/Check/SingleCheckTest.php
+++ b/tests/Unit/Check/SingleCheckTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\SingleCheck;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SingleCheckTest extends TestCase
+{
+    #[Test]
+    public function yieldsSingleCheckWithGivenName(): void
+    {
+        $checks = new SingleCheck('phpunit', '/project');
+        $items = iterator_to_array($checks->all());
+
+        self::assertCount(
+            1,
+            $items,
+            'SingleCheck must yield exactly one check',
+        );
+
+        self::assertSame(
+            'phpunit',
+            $items[0]->name(),
+            'SingleCheck must yield a check with the given name',
+        );
+    }
+}

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -160,7 +160,7 @@ final class DefaultConfigTest extends TestCase
         $this->expectException(PiquleException::class);
         $this->expectExceptionMessage('Missing "defaults" section');
 
-        $config = new DefaultConfig(paths: new ConfigPaths(configYaml: $folder->path() . '/empty.yaml'));
+        $config = new DefaultConfig(paths: new ConfigPaths(config: $folder->path() . '/empty.yaml'));
 
         try {
             $config->has('any');
@@ -177,7 +177,7 @@ final class DefaultConfigTest extends TestCase
         $this->expectException(PiquleException::class);
         $this->expectExceptionMessage('Failed to parse config');
 
-        $config = new DefaultConfig(paths: new ConfigPaths(configYaml: $folder->path() . '/broken.yaml'));
+        $config = new DefaultConfig(paths: new ConfigPaths(config: $folder->path() . '/broken.yaml'));
 
         try {
             $config->has('any');

--- a/tests/Unit/Config/ProjectConfigTest.php
+++ b/tests/Unit/Config/ProjectConfigTest.php
@@ -16,12 +16,14 @@ final class ProjectConfigTest extends TestCase
     {
         $folder = new TempFolder();
 
-        self::assertTrue(
-            (new ProjectConfig($folder->path()))->has('phpstan.level'),
-            'ProjectConfig must load defaults when no .piqule.yaml exists',
-        );
-
-        $folder->close();
+        try {
+            self::assertTrue(
+                (new ProjectConfig($folder->path()))->has('phpstan.level'),
+                'ProjectConfig must load defaults when no .piqule.yaml exists',
+            );
+        } finally {
+            $folder->close();
+        }
     }
 
     #[Test]
@@ -32,12 +34,14 @@ final class ProjectConfigTest extends TestCase
             "override:\n    phpstan.level: 5",
         );
 
-        self::assertSame(
-            [5],
-            (new ProjectConfig($folder->path()))->list('phpstan.level'),
-            'ProjectConfig must apply overrides from .piqule.yaml',
-        );
-
-        $folder->close();
+        try {
+            self::assertSame(
+                [5],
+                (new ProjectConfig($folder->path()))->list('phpstan.level'),
+                'ProjectConfig must apply overrides from .piqule.yaml',
+            );
+        } finally {
+            $folder->close();
+        }
     }
 }

--- a/tests/Unit/Config/ProjectConfigTest.php
+++ b/tests/Unit/Config/ProjectConfigTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Config;
+
+use Haspadar\Piqule\Config\ProjectConfig;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectConfigTest extends TestCase
+{
+    #[Test]
+    public function loadsDefaultsWhenNoProjectConfigExists(): void
+    {
+        $folder = new TempFolder();
+
+        self::assertTrue(
+            (new ProjectConfig($folder->path()))->has('phpstan.level'),
+            'ProjectConfig must load defaults when no .piqule.yaml exists',
+        );
+
+        $folder->close();
+    }
+
+    #[Test]
+    public function loadsOverridesFromPiquleYaml(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "override:\n    phpstan.level: 5",
+        );
+
+        self::assertSame(
+            [5],
+            (new ProjectConfig($folder->path()))->list('phpstan.level'),
+            'ProjectConfig must apply overrides from .piqule.yaml',
+        );
+
+        $folder->close();
+    }
+}


### PR DESCRIPTION
- Updated phpstan-rules to 0.30.4 and phpunit to 12.5.17
- Renamed camelCase parameters and variables to satisfy new ParameterNameRule and VariableNameRule
- Added unit tests for Check classes and ProjectConfig to satisfy patch coverage

Closes #593

**Breaking changes:**
- `ConfigPaths` named arguments renamed: `composerJson:` → `composer:`, `configYaml:` → `config:`
- `ConfigOption` named argument renamed: `on:` → `yes:`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests for config checks, option handling, check discovery, single checks, and project config to boost coverage and reliability.

* **Refactor**
  * Harmonized internal naming across configuration and check components to improve consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->