### PR TITLE
Infection MSI Threshold Configuration

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -6,6 +6,8 @@ override:
   ci.piqule_bin: bin/piqule
   sonar.organization: haspadar-org
   sonar.projectKey: haspadar_piqule
+  infection.min_msi: 80
+  infection.min_covered_msi: 85
   psalm.project.files:
     - "../../bin/piqule"
     - "../../bin/piqule-check"

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -116,6 +116,8 @@ defaults:
   psalm.suppress.possibly_unused: []
 
   infection.cli: true
+  infection.min_msi: 50
+  infection.min_covered_msi: 80
   infection.php_options: "-d memory_limit=1G"
   infection.source.directories: ["../../src"]
   infection.timeout: 30

--- a/.piqule/infection/infection.json5
+++ b/.piqule/infection/infection.json5
@@ -15,6 +15,8 @@
 
   "initialTestsPhpOptions": "-d memory_limit=1G",
   "timeout": 30,
+  "minMsi": 80,
+  "minCoveredMsi": 85,
   "logs": {
     "text": "infection.log",
     "summary": "infection-summary.log",

--- a/DEV.md
+++ b/DEV.md
@@ -511,6 +511,8 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | Key | Default | Description |
 |-----|---------|-------------|
 | `infection.cli` | `true` | Enable Infection mutation testing |
+| `infection.min_msi` | `50` | Minimum Mutation Score Indicator (0–100) |
+| `infection.min_covered_msi` | `80` | Minimum Covered Code MSI (0–100) |
 | `infection.php_options` | `"-d memory_limit=1G"` | PHP CLI options |
 | `infection.source.directories` | `["../../src"]` | Source directories |
 | `infection.timeout` | `30` | Timeout per mutant (seconds) |

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -116,6 +116,8 @@ defaults:
   psalm.suppress.possibly_unused: []
 
   infection.cli: true
+  infection.min_msi: 50
+  infection.min_covered_msi: 80
   infection.php_options: "-d memory_limit=1G"
   infection.source.directories: ["../../src"]
   infection.timeout: 30

--- a/templates/always/.piqule/infection/infection.json5
+++ b/templates/always/.piqule/infection/infection.json5
@@ -18,6 +18,8 @@
 
   "initialTestsPhpOptions": "<< config(infection.php_options) >>",
   "timeout": << config(infection.timeout) >>,
+  "minMsi": << config(infection.min_msi) >>,
+  "minCoveredMsi": << config(infection.min_covered_msi) >>,
   "logs": {
     "text": "infection.log",
     "summary": "infection-summary.log",


### PR DESCRIPTION
- Added infection.min_msi and infection.min_covered_msi config keys with defaults 50 and 80
- Added minMsi and minCoveredMsi rendering in Infection config template
- Updated piqule project thresholds to minMsi=80 and minCoveredMsi=85

Part of #596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration parameters `infection.min_msi` (default: 50) and `infection.min_covered_msi` (default: 80) for Infection mutation testing thresholds.

* **Documentation**
  * Updated configuration reference documentation with new Infection threshold settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->