### PR TITLE
Cover Check and StorageReactions classes with unit tests

### DIFF
--- a/tests/Unit/Check/CheckResultTest.php
+++ b/tests/Unit/Check/CheckResultTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\CheckResult;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CheckResultTest extends TestCase
+{
+    #[Test]
+    public function passedWhenStatusIsZero(): void
+    {
+        self::assertTrue(
+            (new CheckResult(0, 'ok', 1.0))->passed(),
+            'CheckResult must report passed when status is 0',
+        );
+    }
+
+    #[Test]
+    public function failedWhenStatusIsNonZero(): void
+    {
+        self::assertFalse(
+            (new CheckResult(1, 'fail', 2.0))->passed(),
+            'CheckResult must report failed when status is non-zero',
+        );
+    }
+
+    #[Test]
+    public function returnsOutput(): void
+    {
+        self::assertSame(
+            'some output',
+            (new CheckResult(0, 'some output', 0.5))->output(),
+            'CheckResult must return the output string',
+        );
+    }
+
+    #[Test]
+    public function returnsElapsed(): void
+    {
+        self::assertSame(
+            3.14,
+            (new CheckResult(0, '', 3.14))->elapsed(),
+            'CheckResult must return the elapsed time in seconds',
+        );
+    }
+}

--- a/tests/Unit/Check/ElapsedTimeTest.php
+++ b/tests/Unit/Check/ElapsedTimeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\ElapsedTime;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ElapsedTimeTest extends TestCase
+{
+    #[Test]
+    public function formatsSecondsUnderOneMinute(): void
+    {
+        self::assertSame(
+            '5.0s',
+            (new ElapsedTime(5.0))->formatted(),
+            'ElapsedTime must format seconds under 60 as Xs',
+        );
+    }
+
+    #[Test]
+    public function formatsSubSecondValue(): void
+    {
+        self::assertSame(
+            '0.3s',
+            (new ElapsedTime(0.25))->formatted(),
+            'ElapsedTime must round sub-second values to one decimal',
+        );
+    }
+
+    #[Test]
+    public function formatsExactlyOneMinute(): void
+    {
+        self::assertSame(
+            '1m00s',
+            (new ElapsedTime(60.0))->formatted(),
+            'ElapsedTime must format 60 seconds as 1m00s',
+        );
+    }
+
+    #[Test]
+    public function formatsMinutesAndSeconds(): void
+    {
+        self::assertSame(
+            '2m30s',
+            (new ElapsedTime(150.0))->formatted(),
+            'ElapsedTime must format 150 seconds as 2m30s',
+        );
+    }
+
+    #[Test]
+    public function formatsZeroSeconds(): void
+    {
+        self::assertSame(
+            '0.0s',
+            (new ElapsedTime(0.0))->formatted(),
+            'ElapsedTime must format zero as 0.0s',
+        );
+    }
+}

--- a/tests/Unit/Check/ElapsedTimeTest.php
+++ b/tests/Unit/Check/ElapsedTimeTest.php
@@ -59,4 +59,14 @@ final class ElapsedTimeTest extends TestCase
             'ElapsedTime must format zero as 0.0s',
         );
     }
+
+    #[Test]
+    public function switchesToMinutesWhenRoundedToSixty(): void
+    {
+        self::assertSame(
+            '1m00s',
+            (new ElapsedTime(59.95))->formatted(),
+            'ElapsedTime must use minutes format when rounding pushes value to 60',
+        );
+    }
 }

--- a/tests/Unit/Check/ElapsedTimeTest.php
+++ b/tests/Unit/Check/ElapsedTimeTest.php
@@ -61,6 +61,16 @@ final class ElapsedTimeTest extends TestCase
     }
 
     #[Test]
+    public function staysInSecondsWhenRoundedBelowSixty(): void
+    {
+        self::assertSame(
+            '59.9s',
+            (new ElapsedTime(59.94))->formatted(),
+            'ElapsedTime must stay in seconds format when rounding keeps value below 60',
+        );
+    }
+
+    #[Test]
     public function switchesToMinutesWhenRoundedToSixty(): void
     {
         self::assertSame(

--- a/tests/Unit/Check/RequestedCheckTest.php
+++ b/tests/Unit/Check/RequestedCheckTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\RequestedCheck;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RequestedCheckTest extends TestCase
+{
+    #[Test]
+    public function returnsCheckNameFromArgv(): void
+    {
+        self::assertSame(
+            'phpstan',
+            (new RequestedCheck(['check', 'phpstan']))->name(),
+            'RequestedCheck must return the second positional argument',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoCheckSpecified(): void
+    {
+        self::assertSame(
+            '',
+            (new RequestedCheck(['check']))->name(),
+            'RequestedCheck must return empty string when no check name given',
+        );
+    }
+
+    #[Test]
+    public function skipsVerboseFlag(): void
+    {
+        self::assertSame(
+            'phpunit',
+            (new RequestedCheck(['check', '-v', 'phpunit']))->name(),
+            'RequestedCheck must skip -v flag when extracting name',
+        );
+    }
+
+    #[Test]
+    public function skipsLongVerboseFlag(): void
+    {
+        self::assertSame(
+            'psalm',
+            (new RequestedCheck(['check', '--verbose', 'psalm']))->name(),
+            'RequestedCheck must skip --verbose flag when extracting name',
+        );
+    }
+
+    #[Test]
+    public function skipsParallelFlag(): void
+    {
+        self::assertSame(
+            'phpcs',
+            (new RequestedCheck(['check', '-p', 'phpcs']))->name(),
+            'RequestedCheck must skip -p flag when extracting name',
+        );
+    }
+
+    #[Test]
+    public function skipsMultipleFlags(): void
+    {
+        self::assertSame(
+            'infection',
+            (new RequestedCheck(['check', '-v', '-p', 'infection']))->name(),
+            'RequestedCheck must skip multiple flags when extracting name',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenOnlyFlagsPresent(): void
+    {
+        self::assertSame(
+            '',
+            (new RequestedCheck(['-v', '--parallel']))->name(),
+            'RequestedCheck must return empty when argv contains only flags',
+        );
+    }
+
+    #[Test]
+    public function skipsFullFlag(): void
+    {
+        self::assertSame(
+            'phpstan',
+            (new RequestedCheck(['check', '-f', 'phpstan']))->name(),
+            'RequestedCheck must skip -f flag when extracting name',
+        );
+    }
+
+    #[Test]
+    public function skipsNoParallelFlag(): void
+    {
+        self::assertSame(
+            'phpunit',
+            (new RequestedCheck(['check', '-P', 'phpunit']))->name(),
+            'RequestedCheck must skip -P (no-parallel) flag when extracting name',
+        );
+    }
+}

--- a/tests/Unit/Check/ToggleOptionTest.php
+++ b/tests/Unit/Check/ToggleOptionTest.php
@@ -45,4 +45,13 @@ final class ToggleOptionTest extends TestCase
             'ToggleOption must be disabled when argv is empty',
         );
     }
+
+    #[Test]
+    public function disabledWhenFlagHasValueSuffix(): void
+    {
+        self::assertFalse(
+            (new ToggleOption(['check', '--verbose=1'], ['-v', '--verbose']))->enabled(),
+            'ToggleOption must not match --verbose=1 as --verbose',
+        );
+    }
 }

--- a/tests/Unit/Check/ToggleOptionTest.php
+++ b/tests/Unit/Check/ToggleOptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\ToggleOption;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ToggleOptionTest extends TestCase
+{
+    #[Test]
+    public function enabledWhenShortFlagPresent(): void
+    {
+        self::assertTrue(
+            (new ToggleOption(['check', '-v'], ['-v', '--verbose']))->enabled(),
+            'ToggleOption must be enabled when short flag is in argv',
+        );
+    }
+
+    #[Test]
+    public function enabledWhenLongFlagPresent(): void
+    {
+        self::assertTrue(
+            (new ToggleOption(['check', '--verbose'], ['-v', '--verbose']))->enabled(),
+            'ToggleOption must be enabled when long flag is in argv',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenFlagAbsent(): void
+    {
+        self::assertFalse(
+            (new ToggleOption(['check', 'phpstan'], ['-v', '--verbose']))->enabled(),
+            'ToggleOption must be disabled when flag is not in argv',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenArgvEmpty(): void
+    {
+        self::assertFalse(
+            (new ToggleOption([], ['-p', '--parallel']))->enabled(),
+            'ToggleOption must be disabled when argv is empty',
+        );
+    }
+}

--- a/tests/Unit/Storage/Reaction/StorageReactionsTest.php
+++ b/tests/Unit/Storage/Reaction/StorageReactionsTest.php
@@ -42,4 +42,20 @@ final class StorageReactionsTest extends TestCase
             'StorageReactions must delegate updated() to all contained reactions',
         );
     }
+
+    #[Test]
+    public function delegatesSkippedToAllReactions(): void
+    {
+        $first = new FakeStorageReaction();
+        $second = new FakeStorageReaction();
+
+        (new StorageReactions([$first, $second]))
+            ->skipped('file.txt');
+
+        self::assertSame(
+            ['file.txt'],
+            $first->skippedPaths(),
+            'StorageReactions must delegate skipped() to all contained reactions',
+        );
+    }
 }

--- a/tests/Unit/Storage/Reaction/StorageReactionsTest.php
+++ b/tests/Unit/Storage/Reaction/StorageReactionsTest.php
@@ -44,7 +44,7 @@ final class StorageReactionsTest extends TestCase
     }
 
     #[Test]
-    public function delegatesSkippedToAllReactions(): void
+    public function delegatesSkippedToFirstReaction(): void
     {
         $first = new FakeStorageReaction();
         $second = new FakeStorageReaction();
@@ -55,7 +55,23 @@ final class StorageReactionsTest extends TestCase
         self::assertSame(
             ['file.txt'],
             $first->skippedPaths(),
-            'StorageReactions must delegate skipped() to all contained reactions',
+            'StorageReactions must delegate skipped() to the first reaction',
+        );
+    }
+
+    #[Test]
+    public function delegatesSkippedToSecondReaction(): void
+    {
+        $first = new FakeStorageReaction();
+        $second = new FakeStorageReaction();
+
+        (new StorageReactions([$first, $second]))
+            ->skipped('file.txt');
+
+        self::assertSame(
+            ['file.txt'],
+            $second->skippedPaths(),
+            'StorageReactions must delegate skipped() to the second reaction',
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add unit tests for CheckResult, ElapsedTime, RequestedCheck, ToggleOption
- Cover StorageReactions skipped() delegation to both reactions
- Cover ElapsedTime rounding boundary at 59.95s

Part of #599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for check result behavior, elapsed-time formatting (including rounding and minute boundaries), command-line name extraction (ignoring common flags), toggle option flag detection (short, long, and value-suffixed cases), and storage reaction delegation for skipped items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->