### PR TITLE
Cover SafePath, OnceStorage and ReportingStorageReaction

### DIFF
--- a/tests/Unit/Storage/OnceStorageTest.php
+++ b/tests/Unit/Storage/OnceStorageTest.php
@@ -134,4 +134,16 @@ final class OnceStorageTest extends TestCase
             'exists() must delegate to origin storage',
         );
     }
+
+    #[Test]
+    public function checksNonExistenceViaOrigin(): void
+    {
+        self::assertFalse(
+            (new OnceStorage(
+                new InMemoryStorage(),
+                new FakeStorageReaction(),
+            ))->exists('missing.php'),
+            'exists() must return false when file is absent in origin',
+        );
+    }
 }

--- a/tests/Unit/Storage/OnceStorageTest.php
+++ b/tests/Unit/Storage/OnceStorageTest.php
@@ -122,4 +122,16 @@ final class OnceStorageTest extends TestCase
             'mode() must delegate to origin storage',
         );
     }
+
+    #[Test]
+    public function checksExistenceViaOrigin(): void
+    {
+        self::assertTrue(
+            (new OnceStorage(
+                new InMemoryStorage(['app.php' => new TextFile('app.php', '<?php')]),
+                new FakeStorageReaction(),
+            ))->exists('app.php'),
+            'exists() must delegate to origin storage',
+        );
+    }
 }

--- a/tests/Unit/Storage/Reaction/ReportingStorageReactionTest.php
+++ b/tests/Unit/Storage/Reaction/ReportingStorageReactionTest.php
@@ -40,4 +40,19 @@ final class ReportingStorageReactionTest extends TestCase
             'ReportingStorageReaction must write one info message when a file is updated',
         );
     }
+
+    #[Test]
+    public function writesMutedMessageWhenFileIsSkipped(): void
+    {
+        $output = new FakeOutput();
+
+        (new ReportingStorageReaction($output))
+            ->skipped('file.txt');
+
+        self::assertCount(
+            1,
+            $output->muteds(),
+            'ReportingStorageReaction must write one muted message when a file is skipped',
+        );
+    }
 }

--- a/tests/Unit/Storage/SafePathTest.php
+++ b/tests/Unit/Storage/SafePathTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Tests\Unit\Storage;
 
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Storage\SafePath;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -27,6 +28,54 @@ final class SafePathTest extends TestCase
             '/root/file.txt',
             (new SafePath('/root/'))->resolve('file.txt'),
             'SafePath must strip trailing slash from root before joining',
+        );
+    }
+
+    #[Test]
+    public function resolvesSimplePath(): void
+    {
+        self::assertSame(
+            '/root/dir/file.txt',
+            (new SafePath('/root'))->resolve('dir/file.txt'),
+            'SafePath must join root with relative location',
+        );
+    }
+
+    #[Test]
+    public function skipsDotSegments(): void
+    {
+        self::assertSame(
+            '/root/a/b',
+            (new SafePath('/root'))->resolve('a/./b'),
+            'SafePath must skip dot segments in location',
+        );
+    }
+
+    #[Test]
+    public function resolvesDotDotWithinBounds(): void
+    {
+        self::assertSame(
+            '/root/b',
+            (new SafePath('/root'))->resolve('a/../b'),
+            'SafePath must resolve .. by popping the previous segment',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenDotDotEscapesRoot(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new SafePath('/root'))->resolve('../etc/passwd');
+    }
+
+    #[Test]
+    public function skipsEmptySegments(): void
+    {
+        self::assertSame(
+            '/root/a/b',
+            (new SafePath('/root'))->resolve('a//b'),
+            'SafePath must skip empty segments from consecutive slashes',
         );
     }
 }


### PR DESCRIPTION
## Summary

- Cover SafePath traversal prevention, dot/empty segment normalization
- Cover OnceStorage exists() delegation to origin
- Cover ReportingStorageReaction skipped() muted output

Part of #599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating existence checks against underlying storage.
  * Added tests ensuring a muted/reporting message is produced when files are skipped.
  * Added comprehensive path-resolution tests: joining root with relative paths, ignoring ".", correctly handling ".." within root, rejecting escapes above root, and skipping empty segments from repeated slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->