### PR TITLE
Cover CheckReport output formatting

### DIFF
--- a/tests/Fake/Check/FakeCheck.php
+++ b/tests/Fake/Check/FakeCheck.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fake\Check;
+
+use Haspadar\Piqule\Check\Check;
+use Override;
+
+final readonly class FakeCheck implements Check
+{
+    public function __construct(private string $name, private string $command = '/usr/bin/true') {}
+
+    #[Override]
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function command(): string
+    {
+        return $this->command;
+    }
+}

--- a/tests/Fake/Check/FakeChecks.php
+++ b/tests/Fake/Check/FakeChecks.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fake\Check;
+
+use Haspadar\Piqule\Check\Check;
+use Haspadar\Piqule\Check\Checks;
+use Override;
+
+final readonly class FakeChecks implements Checks
+{
+    /** @param list<Check> $checks */
+    public function __construct(private array $checks) {}
+
+    #[Override]
+    public function all(): iterable
+    {
+        return $this->checks;
+    }
+}

--- a/tests/Unit/Check/CheckReportTest.php
+++ b/tests/Unit/Check/CheckReportTest.php
@@ -12,49 +12,63 @@ use PHPUnit\Framework\TestCase;
 final class CheckReportTest extends TestCase
 {
     #[Test]
-    public function writesMutedMessageWhenCheckStartsInBatch(): void
-    {
-        $output = new FakeOutput();
-
-        (new CheckReport($output, 3))->started('phpstan', 1);
-
-        self::assertCount(
-            1,
-            $output->muteds(),
-            'started() must write one muted message for a batch run',
-        );
-    }
-
-    #[Test]
-    public function includesCheckNumberInBatchStartMessage(): void
+    public function formatsStartedMessageWithCounterInBatch(): void
     {
         $output = new FakeOutput();
 
         (new CheckReport($output, 3))->started('phpstan', 2);
 
-        self::assertStringContainsString(
-            '2/3',
+        self::assertSame(
+            '[RUN]  phpstan               2/3',
             $output->muteds()[0],
-            'started() must include check number and total in batch run',
+            'started() must format [RUN] with padded name and counter in batch',
         );
     }
 
     #[Test]
-    public function omitsCounterWhenSingleCheck(): void
+    public function formatsStartedMessageWithoutCounterWhenSingle(): void
     {
         $output = new FakeOutput();
 
         (new CheckReport($output, 1))->started('phpstan', 1);
 
-        self::assertStringNotContainsString(
-            '1/1',
+        self::assertSame(
+            '[RUN]  phpstan',
             $output->muteds()[0],
-            'started() must omit counter when only one check runs',
+            'started() must format [RUN] with name only when single check',
         );
     }
 
     #[Test]
-    public function writesSuccessMessageWhenCheckPasses(): void
+    public function formatsPassedMessageWithElapsedTime(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->passed('phpstan', 2.0);
+
+        self::assertSame(
+            '[OK]   phpstan              2.0s',
+            $output->successes()[0],
+            'passed() must format [OK] with padded name and elapsed time',
+        );
+    }
+
+    #[Test]
+    public function formatsFailedMessageWithElapsedTime(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->failed('phpstan', 3.0);
+
+        self::assertSame(
+            '[FAIL] phpstan              3.0s',
+            $output->errors()[0],
+            'failed() must format [FAIL] with padded name and elapsed time',
+        );
+    }
+
+    #[Test]
+    public function writesSuccessOutputChannelWhenPassed(): void
     {
         $output = new FakeOutput();
 
@@ -63,26 +77,12 @@ final class CheckReportTest extends TestCase
         self::assertCount(
             1,
             $output->successes(),
-            'passed() must write one success message',
+            'passed() must write exactly one success message',
         );
     }
 
     #[Test]
-    public function includesElapsedTimeInPassedMessage(): void
-    {
-        $output = new FakeOutput();
-
-        (new CheckReport($output, 1))->passed('phpstan', 2.0);
-
-        self::assertStringContainsString(
-            '2.0s',
-            $output->successes()[0],
-            'passed() must include elapsed time',
-        );
-    }
-
-    #[Test]
-    public function writesErrorMessageWhenCheckFails(): void
+    public function writesErrorOutputChannelWhenFailed(): void
     {
         $output = new FakeOutput();
 
@@ -91,49 +91,21 @@ final class CheckReportTest extends TestCase
         self::assertCount(
             1,
             $output->errors(),
-            'failed() must write one error message',
+            'failed() must write exactly one error message',
         );
     }
 
     #[Test]
-    public function includesFailPrefixInFailedMessage(): void
+    public function writesMutedOutputChannelWhenStarted(): void
     {
         $output = new FakeOutput();
 
-        (new CheckReport($output, 1))->failed('phpstan', 0.5);
+        (new CheckReport($output, 3))->started('phpstan', 1);
 
-        self::assertStringContainsString(
-            '[FAIL]',
-            $output->errors()[0],
-            'failed() must include [FAIL] prefix',
-        );
-    }
-
-    #[Test]
-    public function includesElapsedTimeInFailedMessage(): void
-    {
-        $output = new FakeOutput();
-
-        (new CheckReport($output, 1))->failed('phpstan', 3.0);
-
-        self::assertStringContainsString(
-            '3.0s',
-            $output->errors()[0],
-            'failed() must include elapsed time',
-        );
-    }
-
-    #[Test]
-    public function includesRunPrefixWhenSingleCheck(): void
-    {
-        $output = new FakeOutput();
-
-        (new CheckReport($output, 1))->started('phpstan', 1);
-
-        self::assertStringContainsString(
-            '[RUN]  phpstan',
-            $output->muteds()[0],
-            'started() must include [RUN] prefix and check name for single check',
+        self::assertCount(
+            1,
+            $output->muteds(),
+            'started() must write exactly one muted message',
         );
     }
 }

--- a/tests/Unit/Check/CheckReportTest.php
+++ b/tests/Unit/Check/CheckReportTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\CheckReport;
+use Haspadar\Piqule\Tests\Fake\Output\FakeOutput;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CheckReportTest extends TestCase
+{
+    #[Test]
+    public function writesMutedMessageWhenCheckStartsInBatch(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 3))->started('phpstan', 1);
+
+        self::assertCount(
+            1,
+            $output->muteds(),
+            'started() must write one muted message for a batch run',
+        );
+    }
+
+    #[Test]
+    public function includesCheckNumberInBatchStartMessage(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 3))->started('phpstan', 2);
+
+        self::assertStringContainsString(
+            '2/3',
+            $output->muteds()[0],
+            'started() must include check number and total in batch run',
+        );
+    }
+
+    #[Test]
+    public function omitsCounterWhenSingleCheck(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->started('phpstan', 1);
+
+        self::assertStringNotContainsString(
+            '1/1',
+            $output->muteds()[0],
+            'started() must omit counter when only one check runs',
+        );
+    }
+
+    #[Test]
+    public function writesSuccessMessageWhenCheckPasses(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->passed('phpstan', 1.5);
+
+        self::assertCount(
+            1,
+            $output->successes(),
+            'passed() must write one success message',
+        );
+    }
+
+    #[Test]
+    public function includesElapsedTimeInPassedMessage(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->passed('phpstan', 2.0);
+
+        self::assertStringContainsString(
+            '2.0s',
+            $output->successes()[0],
+            'passed() must include elapsed time',
+        );
+    }
+
+    #[Test]
+    public function writesErrorMessageWhenCheckFails(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->failed('phpstan', 0.5);
+
+        self::assertCount(
+            1,
+            $output->errors(),
+            'failed() must write one error message',
+        );
+    }
+
+    #[Test]
+    public function includesFailPrefixInFailedMessage(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->failed('phpstan', 0.5);
+
+        self::assertStringContainsString(
+            '[FAIL]',
+            $output->errors()[0],
+            'failed() must include [FAIL] prefix',
+        );
+    }
+}

--- a/tests/Unit/Check/CheckReportTest.php
+++ b/tests/Unit/Check/CheckReportTest.php
@@ -108,4 +108,32 @@ final class CheckReportTest extends TestCase
             'failed() must include [FAIL] prefix',
         );
     }
+
+    #[Test]
+    public function includesElapsedTimeInFailedMessage(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->failed('phpstan', 3.0);
+
+        self::assertStringContainsString(
+            '3.0s',
+            $output->errors()[0],
+            'failed() must include elapsed time',
+        );
+    }
+
+    #[Test]
+    public function includesRunPrefixWhenSingleCheck(): void
+    {
+        $output = new FakeOutput();
+
+        (new CheckReport($output, 1))->started('phpstan', 1);
+
+        self::assertStringContainsString(
+            '[RUN]  phpstan',
+            $output->muteds()[0],
+            'started() must include [RUN] prefix and check name for single check',
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add FakeCheck and FakeChecks test doubles for Check/Checks interfaces
- Cover CheckReport: batch/single started(), passed(), failed() with elapsed time

Part of #599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test utilities that provide fake check instances and collections to support check validation and batch scenarios.
  * Expanded unit tests for check reporting to verify started/passed/failed output channels, padded name/counter formatting, elapsed-time formatting (e.g., "2.0s"), and failure message prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->