### PR TITLE
Cover ConfigDefault boolean parsing

### DIFF
--- a/tests/Unit/Check/ConfigDefaultTest.php
+++ b/tests/Unit/Check/ConfigDefaultTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\ConfigDefault;
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigDefaultTest extends TestCase
+{
+    #[Test]
+    public function enabledWhenConfigValueIsTrue(): void
+    {
+        self::assertTrue(
+            (new ConfigDefault(
+                new FakeConfig(['check.verbose' => ['true']]),
+                'check.verbose',
+            ))->enabled(),
+            'ConfigDefault must be enabled when config value is "true"',
+        );
+    }
+
+    #[Test]
+    public function enabledWhenConfigValueIsOne(): void
+    {
+        self::assertTrue(
+            (new ConfigDefault(
+                new FakeConfig(['check.verbose' => ['1']]),
+                'check.verbose',
+            ))->enabled(),
+            'ConfigDefault must be enabled when config value is "1"',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenConfigValueIsFalse(): void
+    {
+        self::assertFalse(
+            (new ConfigDefault(
+                new FakeConfig(['check.verbose' => ['false']]),
+                'check.verbose',
+            ))->enabled(),
+            'ConfigDefault must be disabled when config value is "false"',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenConfigValueIsZero(): void
+    {
+        self::assertFalse(
+            (new ConfigDefault(
+                new FakeConfig(['check.verbose' => ['0']]),
+                'check.verbose',
+            ))->enabled(),
+            'ConfigDefault must be disabled when config value is "0"',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenConfigKeyAbsent(): void
+    {
+        self::assertFalse(
+            (new ConfigDefault(
+                new FakeConfig([]),
+                'check.verbose',
+            ))->enabled(),
+            'ConfigDefault must be disabled when config key is absent',
+        );
+    }
+
+    #[Test]
+    public function disabledWhenConfigValueIsUnparseable(): void
+    {
+        self::assertFalse(
+            (new ConfigDefault(
+                new FakeConfig(['check.verbose' => ['maybe']]),
+                'check.verbose',
+            ))->enabled(),
+            'ConfigDefault must be disabled when config value cannot be parsed as boolean',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Cover ConfigDefault: true/1, false/0, absent key, unparseable value

Part of #599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the ConfigDefault check functionality, verifying proper handling of various configuration values and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->