### PR TITLE
Cover EnabledChecks and FastChecks filtering

### DIFF
--- a/tests/Unit/Check/EnabledChecksTest.php
+++ b/tests/Unit/Check/EnabledChecksTest.php
@@ -24,9 +24,14 @@ final class EnabledChecksTest extends TestCase
             new FakeConfig([]),
         );
 
-        self::assertCount(
-            2,
+        $names = array_map(
+            static fn($c) => $c->name(),
             iterator_to_array($checks->all()),
+        );
+
+        self::assertSame(
+            ['phpstan', 'phpunit'],
+            $names,
             'EnabledChecks must yield all checks when no cli config disables them',
         );
     }
@@ -62,9 +67,14 @@ final class EnabledChecksTest extends TestCase
             new FakeConfig(['phpstan.cli' => [true]]),
         );
 
-        self::assertCount(
-            1,
+        $names = array_map(
+            static fn($c) => $c->name(),
             iterator_to_array($checks->all()),
+        );
+
+        self::assertSame(
+            ['phpstan'],
+            $names,
             'EnabledChecks must yield check when .cli config is true',
         );
     }

--- a/tests/Unit/Check/EnabledChecksTest.php
+++ b/tests/Unit/Check/EnabledChecksTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\EnabledChecks;
+use Haspadar\Piqule\Tests\Fake\Check\FakeCheck;
+use Haspadar\Piqule\Tests\Fake\Check\FakeChecks;
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EnabledChecksTest extends TestCase
+{
+    #[Test]
+    public function yieldsAllChecksWhenNoneDisabled(): void
+    {
+        $checks = new EnabledChecks(
+            new FakeChecks([
+                new FakeCheck('phpstan'),
+                new FakeCheck('phpunit'),
+            ]),
+            new FakeConfig([]),
+        );
+
+        self::assertCount(
+            2,
+            iterator_to_array($checks->all()),
+            'EnabledChecks must yield all checks when no cli config disables them',
+        );
+    }
+
+    #[Test]
+    public function skipsCheckWhenCliConfigIsFalse(): void
+    {
+        $checks = new EnabledChecks(
+            new FakeChecks([
+                new FakeCheck('phpstan'),
+                new FakeCheck('phpunit'),
+            ]),
+            new FakeConfig(['phpstan.cli' => [false]]),
+        );
+
+        $names = array_map(
+            static fn($c) => $c->name(),
+            iterator_to_array($checks->all()),
+        );
+
+        self::assertSame(
+            ['phpunit'],
+            $names,
+            'EnabledChecks must skip checks whose .cli config is false',
+        );
+    }
+
+    #[Test]
+    public function yieldsCheckWhenCliConfigIsTrue(): void
+    {
+        $checks = new EnabledChecks(
+            new FakeChecks([new FakeCheck('phpstan')]),
+            new FakeConfig(['phpstan.cli' => [true]]),
+        );
+
+        self::assertCount(
+            1,
+            iterator_to_array($checks->all()),
+            'EnabledChecks must yield check when .cli config is true',
+        );
+    }
+}

--- a/tests/Unit/Check/FastChecksTest.php
+++ b/tests/Unit/Check/FastChecksTest.php
@@ -24,9 +24,14 @@ final class FastChecksTest extends TestCase
             new FakeConfig(['check.slow' => []]),
         );
 
-        self::assertCount(
-            2,
+        $names = array_map(
+            static fn($c) => $c->name(),
             iterator_to_array($checks->all()),
+        );
+
+        self::assertSame(
+            ['phpstan', 'phpunit'],
+            $names,
             'FastChecks must yield all checks when check.slow is empty',
         );
     }

--- a/tests/Unit/Check/FastChecksTest.php
+++ b/tests/Unit/Check/FastChecksTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Check;
+
+use Haspadar\Piqule\Check\FastChecks;
+use Haspadar\Piqule\Tests\Fake\Check\FakeCheck;
+use Haspadar\Piqule\Tests\Fake\Check\FakeChecks;
+use Haspadar\Piqule\Tests\Fake\Config\FakeConfig;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FastChecksTest extends TestCase
+{
+    #[Test]
+    public function yieldsAllChecksWhenNoSlowConfigured(): void
+    {
+        $checks = new FastChecks(
+            new FakeChecks([
+                new FakeCheck('phpstan'),
+                new FakeCheck('phpunit'),
+            ]),
+            new FakeConfig(['check.slow' => []]),
+        );
+
+        self::assertCount(
+            2,
+            iterator_to_array($checks->all()),
+            'FastChecks must yield all checks when check.slow is empty',
+        );
+    }
+
+    #[Test]
+    public function excludesSlowChecks(): void
+    {
+        $checks = new FastChecks(
+            new FakeChecks([
+                new FakeCheck('phpstan'),
+                new FakeCheck('infection'),
+                new FakeCheck('phpunit'),
+            ]),
+            new FakeConfig(['check.slow' => ['infection']]),
+        );
+
+        $names = array_map(
+            static fn($c) => $c->name(),
+            iterator_to_array($checks->all()),
+        );
+
+        self::assertSame(
+            ['phpstan', 'phpunit'],
+            $names,
+            'FastChecks must exclude checks listed in check.slow config',
+        );
+    }
+
+    #[Test]
+    public function yieldsNothingWhenAllAreSlow(): void
+    {
+        $checks = new FastChecks(
+            new FakeChecks([new FakeCheck('infection')]),
+            new FakeConfig(['check.slow' => ['infection']]),
+        );
+
+        self::assertCount(
+            0,
+            iterator_to_array($checks->all()),
+            'FastChecks must yield nothing when all checks are slow',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Cover EnabledChecks: yields all when none disabled, skips when cli=false, yields when cli=true
- Cover FastChecks: yields all when no slow, excludes slow checks, yields nothing when all slow

Part of #599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for check filtering and configuration logic, improving test coverage for the checking system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->