### PR TITLE
Cover ProjectConfig and ConfigChecks remaining paths

### DIFF
--- a/tests/Unit/Check/ConfigChecksTest.php
+++ b/tests/Unit/Check/ConfigChecksTest.php
@@ -42,6 +42,38 @@ final class ConfigChecksTest extends TestCase
     }
 
     #[Test]
+    public function skipsKeysNotEndingWithCli(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule/phpstan/command.sh',
+            '#!/bin/bash',
+        );
+
+        $checks = new ConfigChecks(
+            new FakeConfig([
+                'phpstan.level' => [9],
+                'phpstan.cli' => [true],
+            ]),
+            $folder->path(),
+        );
+
+        try {
+            $names = [];
+            foreach ($checks->all() as $check) {
+                $names[] = $check->name();
+            }
+
+            self::assertSame(
+                ['phpstan'],
+                $names,
+                'ConfigChecks must skip config keys not ending with .cli',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
     public function skipsCheckWhenCommandFileMissing(): void
     {
         $checks = new ConfigChecks(

--- a/tests/Unit/Config/ProjectConfigTest.php
+++ b/tests/Unit/Config/ProjectConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Piqule\Tests\Unit\Config;
 
 use Haspadar\Piqule\Config\ProjectConfig;
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Tests\Fixture\TempFolder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -39,6 +40,81 @@ final class ProjectConfigTest extends TestCase
                 [5],
                 (new ProjectConfig($folder->path()))->list('phpstan.level'),
                 'ProjectConfig must apply overrides from .piqule.yaml',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function loadsConfigFromPiqulePhp(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.php',
+            <<<'PHP'
+            <?php
+            return new \Haspadar\Piqule\Tests\Fake\Config\FakeConfig([
+                'custom.key' => ['custom-value'],
+            ]);
+            PHP,
+        );
+
+        try {
+            self::assertSame(
+                ['custom-value'],
+                (new ProjectConfig($folder->path()))->list('custom.key'),
+                'ProjectConfig must load config from .piqule.php when .piqule.yaml is absent',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function throwsWhenPiqulePhpReturnsNonConfig(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.php',
+            '<?php return "not a config";',
+        );
+
+        try {
+            $this->expectException(PiquleException::class);
+            (new ProjectConfig($folder->path()))->has('any');
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function returnsConfigAsArray(): void
+    {
+        $folder = new TempFolder();
+
+        try {
+            self::assertIsArray(
+                (new ProjectConfig($folder->path()))->toArray(),
+                'ProjectConfig must return config as array',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function cachesConfigBetweenCalls(): void
+    {
+        $folder = new TempFolder();
+
+        try {
+            $config = new ProjectConfig($folder->path());
+            $first = $config->has('phpstan.level');
+            $second = $config->has('phpstan.level');
+
+            self::assertSame(
+                $first,
+                $second,
+                'ProjectConfig must return consistent results from cache',
             );
         } finally {
             $folder->close();

--- a/tests/Unit/Config/ProjectConfigTest.php
+++ b/tests/Unit/Config/ProjectConfigTest.php
@@ -89,12 +89,21 @@ final class ProjectConfigTest extends TestCase
     #[Test]
     public function returnsConfigAsArray(): void
     {
-        $folder = new TempFolder();
+        $folder = (new TempFolder())->withFile(
+            '.piqule.php',
+            <<<'PHP'
+            <?php
+            return new \Haspadar\Piqule\Tests\Fake\Config\FakeConfig([
+                'custom.key' => ['custom-value'],
+            ]);
+            PHP,
+        );
 
         try {
-            self::assertIsArray(
+            self::assertSame(
+                ['custom.key' => ['custom-value']],
                 (new ProjectConfig($folder->path()))->toArray(),
-                'ProjectConfig must return config as array',
+                'ProjectConfig must return the resolved config as array',
             );
         } finally {
             $folder->close();
@@ -102,19 +111,26 @@ final class ProjectConfigTest extends TestCase
     }
 
     #[Test]
-    public function cachesConfigBetweenCalls(): void
+    public function returnsCachedConfigOnSecondCall(): void
     {
-        $folder = new TempFolder();
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "override:\n    phpstan.level: 5",
+        );
 
         try {
             $config = new ProjectConfig($folder->path());
-            $first = $config->has('phpstan.level');
-            $second = $config->has('phpstan.level');
+            $config->has('phpstan.level');
+
+            file_put_contents(
+                $folder->path() . '/.piqule.yaml',
+                "override:\n    phpstan.level: 9",
+            );
 
             self::assertSame(
-                $first,
-                $second,
-                'ProjectConfig must return consistent results from cache',
+                [5],
+                $config->list('phpstan.level'),
+                'ProjectConfig must return cached value even after file changes',
             );
         } finally {
             $folder->close();


### PR DESCRIPTION
## Summary
- Cover ConfigChecks: skip non-.cli config keys
- Cover ProjectConfig: .piqule.php loader, invalid config exception, toArray, caching

Closes #599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for configuration key filtering in check selection.
  * Expanded test suite for `.piqule.php` file format support, configuration validation, array conversion, and caching consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->