### PR TITLE
Cover Console ANSI output with integration tests

### DIFF
--- a/tests/Fixture/ConsoleProcess.php
+++ b/tests/Fixture/ConsoleProcess.php
@@ -42,7 +42,13 @@ final readonly class ConsoleProcess
         $this->stderr = (string) stream_get_contents($pipes[2]);
         fclose($pipes[1]);
         fclose($pipes[2]);
-        proc_close($proc);
+        $exitCode = proc_close($proc);
+
+        if ($exitCode !== 0) {
+            throw new \RuntimeException(
+                sprintf('Subprocess exited with code %d: %s', $exitCode, $this->stderr),
+            );
+        }
     }
 
     public function stdout(): string

--- a/tests/Fixture/ConsoleProcess.php
+++ b/tests/Fixture/ConsoleProcess.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fixture;
+
+final readonly class ConsoleProcess
+{
+    private string $stdout;
+
+    private string $stderr;
+
+    public function __construct(string $method, string $text)
+    {
+        $script = sprintf(
+            'require %s; (new \Haspadar\Piqule\Output\Console())->%s(%s);',
+            escapeshellarg(dirname(__DIR__, 2) . '/vendor/autoload.php'),
+            $method,
+            var_export($text, true),
+        );
+
+        $proc = proc_open(
+            ['php', '-r', $script],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
+
+        $this->stdout = (string) stream_get_contents($pipes[1]);
+        $this->stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($proc);
+    }
+
+    public function stdout(): string
+    {
+        return $this->stdout;
+    }
+
+    public function stderr(): string
+    {
+        return $this->stderr;
+    }
+}

--- a/tests/Fixture/ConsoleProcess.php
+++ b/tests/Fixture/ConsoleProcess.php
@@ -6,25 +6,38 @@ namespace Haspadar\Piqule\Tests\Fixture;
 
 final readonly class ConsoleProcess
 {
+    private const array ALLOWED = ['info', 'success', 'error', 'muted'];
+
     private string $stdout;
 
     private string $stderr;
 
     public function __construct(string $method, string $text)
     {
+        if (!in_array($method, self::ALLOWED, true)) {
+            throw new \InvalidArgumentException(
+                sprintf('Method %s is not allowed', var_export($method, true)),
+            );
+        }
+
         $script = sprintf(
             'require %s; (new \Haspadar\Piqule\Output\Console())->%s(%s);',
-            escapeshellarg(dirname(__DIR__, 2) . '/vendor/autoload.php'),
+            var_export(dirname(__DIR__, 2) . '/vendor/autoload.php', true),
             $method,
             var_export($text, true),
         );
 
         $proc = proc_open(
-            ['php', '-r', $script],
-            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            [PHP_BINARY, '-r', $script],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
             $pipes,
         );
 
+        if (!is_resource($proc)) {
+            throw new \RuntimeException('Failed to start subprocess');
+        }
+
+        fclose($pipes[0]);
         $this->stdout = (string) stream_get_contents($pipes[1]);
         $this->stderr = (string) stream_get_contents($pipes[2]);
         fclose($pipes[1]);

--- a/tests/Integration/Output/ConsoleTest.php
+++ b/tests/Integration/Output/ConsoleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Integration\Output;
+
+use Haspadar\Piqule\Tests\Fixture\ConsoleProcess;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ConsoleTest extends TestCase
+{
+    #[Test]
+    public function writesYellowTextToStdoutOnInfo(): void
+    {
+        self::assertSame(
+            "\033[33mhello\033[0m\n",
+            (new ConsoleProcess('info', 'hello'))->stdout(),
+            'info() must write yellow ANSI text to stdout',
+        );
+    }
+
+    #[Test]
+    public function writesGreenTextToStdoutOnSuccess(): void
+    {
+        self::assertSame(
+            "\033[32mdone\033[0m\n",
+            (new ConsoleProcess('success', 'done'))->stdout(),
+            'success() must write green ANSI text to stdout',
+        );
+    }
+
+    #[Test]
+    public function writesRedTextToStderrOnError(): void
+    {
+        self::assertSame(
+            "\033[31mfail\033[0m\n",
+            (new ConsoleProcess('error', 'fail'))->stderr(),
+            'error() must write red ANSI text to stderr',
+        );
+    }
+
+    #[Test]
+    public function writesGrayTextToStdoutOnMuted(): void
+    {
+        self::assertSame(
+            "\033[90mskip\033[0m\n",
+            (new ConsoleProcess('muted', 'skip'))->stdout(),
+            'muted() must write gray ANSI text to stdout',
+        );
+    }
+}

--- a/tests/Integration/Output/ConsoleTest.php
+++ b/tests/Integration/Output/ConsoleTest.php
@@ -49,4 +49,44 @@ final class ConsoleTest extends TestCase
             'muted() must write gray ANSI text to stdout',
         );
     }
+
+    #[Test]
+    public function writesNothingToStderrOnInfo(): void
+    {
+        self::assertSame(
+            '',
+            (new ConsoleProcess('info', 'hello'))->stderr(),
+            'info() must not write to stderr',
+        );
+    }
+
+    #[Test]
+    public function writesNothingToStderrOnSuccess(): void
+    {
+        self::assertSame(
+            '',
+            (new ConsoleProcess('success', 'done'))->stderr(),
+            'success() must not write to stderr',
+        );
+    }
+
+    #[Test]
+    public function writesNothingToStdoutOnError(): void
+    {
+        self::assertSame(
+            '',
+            (new ConsoleProcess('error', 'fail'))->stdout(),
+            'error() must not write to stdout',
+        );
+    }
+
+    #[Test]
+    public function writesNothingToStderrOnMuted(): void
+    {
+        self::assertSame(
+            '',
+            (new ConsoleProcess('muted', 'skip'))->stderr(),
+            'muted() must not write to stderr',
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add `ConsoleProcess` fixture to capture subprocess stdout/stderr for ANSI output assertions
- Add 4 integration tests verifying Console writes correct ANSI-colored text to stdout (info/success/muted) and stderr (error)

Part of #599

## Test plan
- [x] All 4 ConsoleTest assertions pass
- [x] All existing tests remain green
- [x] piqule check passes (14/14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test fixture that runs console output in a separate PHP subprocess and captures stdout/stderr.
  * Added integration tests asserting exact ANSI-colored output, newline behavior, and correct stdout/stderr routing for info, success, error, and muted severities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->