### PR TITLE
Cover CheckRun with integration tests

### DIFF
--- a/tests/Integration/Check/CheckRunTest.php
+++ b/tests/Integration/Check/CheckRunTest.php
@@ -98,7 +98,7 @@ final class CheckRunTest extends TestCase
     #[Test]
     public function measuresElapsedTime(): void
     {
-        $folder = (new TempFolder())->withFile('command.sh', 'true');
+        $folder = (new TempFolder())->withFile('command.sh', 'sleep 0.05');
 
         try {
             $result = (new CheckRun(

--- a/tests/Integration/Check/CheckRunTest.php
+++ b/tests/Integration/Check/CheckRunTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Integration\Check;
+
+use Haspadar\Piqule\Check\CheckRun;
+use Haspadar\Piqule\Tests\Fake\Check\FakeCheck;
+use Haspadar\Piqule\Tests\Fake\Check\FakeCliOption;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CheckRunTest extends TestCase
+{
+    #[Test]
+    public function returnsPassedResultWhenCommandSucceeds(): void
+    {
+        $folder = (new TempFolder())->withFile('command.sh', 'echo ok');
+
+        try {
+            $result = (new CheckRun(
+                new FakeCheck('test', $folder->path() . '/command.sh'),
+                new FakeCliOption(false),
+            ))->result();
+
+            self::assertTrue(
+                $result->passed(),
+                'CheckRun must return passed result when command exits with 0',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function returnsFailedResultWhenCommandFails(): void
+    {
+        $folder = (new TempFolder())->withFile('command.sh', 'exit 1');
+
+        try {
+            $result = (new CheckRun(
+                new FakeCheck('test', $folder->path() . '/command.sh'),
+                new FakeCliOption(false),
+            ))->result();
+
+            self::assertFalse(
+                $result->passed(),
+                'CheckRun must return failed result when command exits with non-zero',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function capturesCommandOutputInQuietMode(): void
+    {
+        $folder = (new TempFolder())->withFile('command.sh', 'echo "hello world"');
+
+        try {
+            $result = (new CheckRun(
+                new FakeCheck('test', $folder->path() . '/command.sh'),
+                new FakeCliOption(false),
+            ))->result();
+
+            self::assertSame(
+                'hello world',
+                $result->output(),
+                'CheckRun must capture command output in quiet mode',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function returnsEmptyOutputInVerboseMode(): void
+    {
+        $folder = (new TempFolder())->withFile('command.sh', 'echo "hello"');
+
+        try {
+            $result = (new CheckRun(
+                new FakeCheck('test', $folder->path() . '/command.sh'),
+                new FakeCliOption(true),
+            ))->result();
+
+            self::assertSame(
+                '',
+                $result->output(),
+                'CheckRun must return empty output in verbose mode (passthru writes directly)',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function measuresElapsedTime(): void
+    {
+        $folder = (new TempFolder())->withFile('command.sh', 'true');
+
+        try {
+            $result = (new CheckRun(
+                new FakeCheck('test', $folder->path() . '/command.sh'),
+                new FakeCliOption(false),
+            ))->result();
+
+            self::assertGreaterThan(
+                0.0,
+                $result->elapsed(),
+                'CheckRun must measure positive elapsed time',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add 5 integration tests for CheckRun: passed/failed result, output capture in quiet mode, empty output in verbose mode, elapsed time measurement
- Tests use real bash scripts via TempFolder fixture

Part of #599

## Test plan
- [x] All 5 CheckRunTest assertions pass
- [x] All existing tests remain green
- [x] piqule check passes (14/14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests verifying Check execution behavior, including exit code handling, output capture in different modes, and execution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->