### PR TITLE
Upgrade phpstan-rules to v0.31.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "~8.3.16 || ~8.4.3 || ~8.5.0",
         "friendsofphp/php-cs-fixer": "^3.91",
-        "haspadar/phpstan-rules": "^0.30.1",
+        "haspadar/phpstan-rules": ">=0.30.1 <1.0.0",
         "infection/infection": "^0.32.0",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
         "phpmd/phpmd": "^2.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1643b9c668c8421c31c5da9785b4732",
+    "content-hash": "b968e1709dca99bb63f62379dd7bf7d3",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1805,16 +1805,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.30.4",
+            "version": "v0.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "70513a9e85f3513b951ed332edeacce3194168d7"
+                "reference": "55a104a3116fa5efffc3733187bbb18bcfc4a5f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/70513a9e85f3513b951ed332edeacce3194168d7",
-                "reference": "70513a9e85f3513b951ed332edeacce3194168d7",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/55a104a3116fa5efffc3733187bbb18bcfc4a5f6",
+                "reference": "55a104a3116fa5efffc3733187bbb18bcfc4a5f6",
                 "shasum": ""
             },
             "require": {
@@ -1852,9 +1852,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.30.4"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.31.0"
             },
-            "time": "2026-04-11T08:57:20+00:00"
+            "time": "2026-04-15T07:30:17+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/src/Check/CheckReport.php
+++ b/src/Check/CheckReport.php
@@ -21,8 +21,7 @@ final readonly class CheckReport
     {
         $this->output->muted(
             $this->total > 1
-                ? sprintf('[RUN]  %-' . self::TITLE_WIDTH . 's', $name)
-                    . sprintf('%5s', "{$number}/{$this->total}")
+                ? sprintf('[RUN]  %-*s%5s', self::TITLE_WIDTH, $name, "{$number}/{$this->total}")
                 : "[RUN]  {$name}",
         );
     }
@@ -31,8 +30,7 @@ final readonly class CheckReport
     public function passed(string $name, float $elapsed): void
     {
         $this->output->success(
-            sprintf('[OK]   %-' . self::TITLE_WIDTH . 's', $name)
-                . sprintf('%5s', (new ElapsedTime($elapsed))->formatted()),
+            sprintf('[OK]   %-*s%5s', self::TITLE_WIDTH, $name, (new ElapsedTime($elapsed))->formatted()),
         );
     }
 
@@ -40,8 +38,7 @@ final readonly class CheckReport
     public function failed(string $name, float $elapsed): void
     {
         $this->output->error(
-            sprintf('[FAIL] %-' . self::TITLE_WIDTH . 's', $name)
-                . sprintf('%5s', (new ElapsedTime($elapsed))->formatted()),
+            sprintf('[FAIL] %-*s%5s', self::TITLE_WIDTH, $name, (new ElapsedTime($elapsed))->formatted()),
         );
     }
 }

--- a/src/Check/CheckRun.php
+++ b/src/Check/CheckRun.php
@@ -21,7 +21,7 @@ final readonly class CheckRun
      */
     public function result(): CheckResult
     {
-        $command = 'bash ' . escapeshellarg($this->check->command());
+        $command = sprintf('bash %s', escapeshellarg($this->check->command()));
         $start = microtime(true);
 
         if ($this->verbose->enabled()) {
@@ -35,7 +35,7 @@ final readonly class CheckRun
         }
 
         $output = [];
-        exec($command . ' 2>&1', $output, $status);
+        exec("{$command} 2>&1", $output, $status);
 
         /** @var list<string> $lines */
         $lines = $output;

--- a/src/Check/ConfigCheck.php
+++ b/src/Check/ConfigCheck.php
@@ -27,6 +27,6 @@ final readonly class ConfigCheck implements Check
     #[Override]
     public function command(): string
     {
-        return $this->root . '/.piqule/' . $this->name . '/command.sh';
+        return "{$this->root}/.piqule/{$this->name}/command.sh";
     }
 }

--- a/src/Check/ConfigChecks.php
+++ b/src/Check/ConfigChecks.php
@@ -12,7 +12,7 @@ use Override;
  */
 final readonly class ConfigChecks implements Checks
 {
-    private const int CLI_SUFFIX_LENGTH = 4;
+    private const string CLI_SUFFIX = '.cli';
 
     /** Initializes with project configuration and root path. */
     public function __construct(private Config $config, private string $root) {}
@@ -21,11 +21,11 @@ final readonly class ConfigChecks implements Checks
     public function all(): iterable
     {
         foreach (array_keys($this->config->toArray()) as $key) {
-            if (!str_ends_with($key, '.cli')) {
+            if (!str_ends_with($key, self::CLI_SUFFIX)) {
                 continue;
             }
 
-            $name = substr($key, 0, -self::CLI_SUFFIX_LENGTH);
+            $name = substr($key, 0, -strlen(self::CLI_SUFFIX));
             $check = new ConfigCheck($name, $this->root);
 
             if (file_exists($check->command())) {

--- a/src/Check/ConfigChecks.php
+++ b/src/Check/ConfigChecks.php
@@ -12,6 +12,8 @@ use Override;
  */
 final readonly class ConfigChecks implements Checks
 {
+    private const int CLI_SUFFIX_LENGTH = 4;
+
     /** Initializes with project configuration and root path. */
     public function __construct(private Config $config, private string $root) {}
 
@@ -23,7 +25,7 @@ final readonly class ConfigChecks implements Checks
                 continue;
             }
 
-            $name = substr($key, 0, -4);
+            $name = substr($key, 0, -self::CLI_SUFFIX_LENGTH);
             $check = new ConfigCheck($name, $this->root);
 
             if (file_exists($check->command())) {

--- a/src/Check/ElapsedTime.php
+++ b/src/Check/ElapsedTime.php
@@ -9,6 +9,8 @@ namespace Haspadar\Piqule\Check;
  */
 final readonly class ElapsedTime
 {
+    private const int SECONDS_PER_MINUTE = 60;
+
     /** Initializes with elapsed seconds. */
     public function __construct(private float $seconds) {}
 
@@ -17,12 +19,12 @@ final readonly class ElapsedTime
     {
         $rounded = round($this->seconds, 1);
 
-        if ($rounded < 60) {
+        if ($rounded < self::SECONDS_PER_MINUTE) {
             return sprintf('%.1fs', $rounded);
         }
 
         $total = (int) round($this->seconds);
 
-        return sprintf('%dm%02ds', intdiv($total, 60), $total % 60);
+        return sprintf('%dm%02ds', intdiv($total, self::SECONDS_PER_MINUTE), $total % self::SECONDS_PER_MINUTE);
     }
 }

--- a/src/Check/EnabledChecks.php
+++ b/src/Check/EnabledChecks.php
@@ -19,7 +19,7 @@ final readonly class EnabledChecks implements Checks
     public function all(): iterable
     {
         foreach ($this->origin->all() as $check) {
-            $key = $check->name() . '.cli';
+            $key = "{$check->name()}.cli";
 
             if ($this->config->has($key) && !(bool) ($this->config->list($key)[0] ?? true)) {
                 continue;

--- a/src/Check/ParallelRun.php
+++ b/src/Check/ParallelRun.php
@@ -14,6 +14,10 @@ use Override;
  */
 final readonly class ParallelRun implements Runnable
 {
+    private const int STDOUT_FD = 1;
+
+    private const int STDERR_FD = 2;
+
     private const array DEPENDS_ON = [
         'sonar' => ['phpunit'],
         'infection' => ['phpunit'],
@@ -127,8 +131,8 @@ final readonly class ParallelRun implements Runnable
         }
 
         $proc = proc_open(
-            'bash ' . escapeshellarg($check->command()),
-            [1 => $stdout, 2 => $stderr],
+            sprintf('bash %s', escapeshellarg($check->command())),
+            [self::STDOUT_FD => $stdout, self::STDERR_FD => $stderr],
             $pipes,
         );
 

--- a/src/Check/ProcessPool.php
+++ b/src/Check/ProcessPool.php
@@ -9,6 +9,10 @@ namespace Haspadar\Piqule\Check;
  */
 final readonly class ProcessPool
 {
+    private const int POLL_INTERVAL_USEC = 50_000;
+
+    private const int UNKNOWN_EXIT_CODE = -1;
+
     /**
      * Waits for all processes to finish and yields each result.
      *
@@ -34,7 +38,7 @@ final readonly class ProcessPool
                 unset($pending[$i]);
             }
 
-            usleep(50_000);
+            usleep(self::POLL_INTERVAL_USEC);
         }
     }
 
@@ -48,7 +52,7 @@ final readonly class ProcessPool
     {
         $status = $code;
 
-        if ($status === -1) {
+        if ($status === self::UNKNOWN_EXIT_CODE) {
             $status = proc_close($handle['proc']);
         } else {
             proc_close($handle['proc']);

--- a/src/Check/ProcessPool.php
+++ b/src/Check/ProcessPool.php
@@ -68,7 +68,7 @@ final readonly class ProcessPool
 
         return [
             'check' => $handle['check'],
-            'result' => new CheckResult($status, $out . $err, $elapsed),
+            'result' => new CheckResult($status, "{$out}{$err}", $elapsed),
             'elapsed' => $elapsed,
         ];
     }

--- a/src/Check/SequentialRun.php
+++ b/src/Check/SequentialRun.php
@@ -37,7 +37,7 @@ final readonly class SequentialRun implements Runnable
 
             if (!$result->passed()) {
                 if ($result->output() !== '') {
-                    echo $result->output() . "\n";
+                    echo "{$result->output()}\n";
                 }
 
                 $report->failed($check->name(), $result->elapsed());

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -11,6 +11,7 @@ use Haspadar\Piqule\Config\Dirs\TrailingGlobDirs;
 use Haspadar\Piqule\Config\Dirs\TrailingSlashDirs;
 use Haspadar\Piqule\PiquleException;
 use Override;
+use stdClass;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -23,10 +24,9 @@ use Symfony\Component\Yaml\Yaml;
  *
  *     new DefaultConfig(paths: new ConfigPaths(composer: '/path/to/composer.json'));
  */
-final class DefaultConfig implements Config
+final readonly class DefaultConfig implements Config
 {
-    /** @var array<string, scalar|list<scalar>>|null */
-    private ?array $cache;
+    private stdClass $cache;
 
     /**
      * Initializes with source directories, exclusions, and config paths.
@@ -35,11 +35,11 @@ final class DefaultConfig implements Config
      * @param list<string> $exclude
      */
     public function __construct(
-        private readonly array $source = [],
-        private readonly array $exclude = [],
-        private readonly ConfigPaths $paths = new ConfigPaths(),
+        private array $source = [],
+        private array $exclude = [],
+        private ConfigPaths $paths = new ConfigPaths(),
     ) {
-        $this->cache = null;
+        $this->cache = new stdClass();
     }
 
     #[Override]
@@ -82,8 +82,11 @@ final class DefaultConfig implements Config
      */
     private function defaults(): array
     {
-        if ($this->cache !== null) {
-            return $this->cache;
+        if (isset($this->cache->value)) {
+            /** @var array<string, scalar|list<scalar>> $cached */
+            $cached = $this->cache->value;
+
+            return $cached;
         }
 
         try {
@@ -115,7 +118,7 @@ final class DefaultConfig implements Config
 
         /** @var array<string, scalar|list<scalar>> $defaults */
         $defaults = array_merge($base, $this->dynamic($resolvedSource, $resolvedExclude));
-        $this->cache = $defaults;
+        $this->cache->value = $defaults;
 
         return $defaults;
     }

--- a/src/Config/Dirs/GlobDirs.php
+++ b/src/Config/Dirs/GlobDirs.php
@@ -21,6 +21,6 @@ final readonly class GlobDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(static fn(string $dir): string => $dir . '/*', $this->dirs);
+        return array_map(static fn(string $dir): string => "{$dir}/*", $this->dirs);
     }
 }

--- a/src/Config/Dirs/NegatedGlobDirs.php
+++ b/src/Config/Dirs/NegatedGlobDirs.php
@@ -21,6 +21,6 @@ final readonly class NegatedGlobDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(static fn(string $dir): string => '!' . $dir . '/**', $this->dirs);
+        return array_map(static fn(string $dir): string => "!{$dir}/**", $this->dirs);
     }
 }

--- a/src/Config/Dirs/ProjectDirs.php
+++ b/src/Config/Dirs/ProjectDirs.php
@@ -21,6 +21,6 @@ final readonly class ProjectDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(static fn(string $dir): string => '../../' . $dir, $this->dirs);
+        return array_map(static fn(string $dir): string => "../../{$dir}", $this->dirs);
     }
 }

--- a/src/Config/Dirs/TrailingGlobDirs.php
+++ b/src/Config/Dirs/TrailingGlobDirs.php
@@ -21,6 +21,6 @@ final readonly class TrailingGlobDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(static fn(string $dir): string => $dir . '/**', $this->dirs);
+        return array_map(static fn(string $dir): string => "{$dir}/**", $this->dirs);
     }
 }

--- a/src/Config/Dirs/TrailingSlashDirs.php
+++ b/src/Config/Dirs/TrailingSlashDirs.php
@@ -21,6 +21,6 @@ final readonly class TrailingSlashDirs implements Dirs
     #[Override]
     public function toList(): array
     {
-        return array_map(static fn(string $dir): string => $dir . '/', $this->dirs);
+        return array_map(static fn(string $dir): string => "{$dir}/", $this->dirs);
     }
 }

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -14,32 +14,32 @@ use Override;
  *
  *     new ProjectConfig('/path/to/project');
  */
-final class ProjectConfig implements Config
+final readonly class ProjectConfig implements Config
 {
-    private ?Config $cache;
+    private StickyConfig $config;
 
     /** Initializes with the project root directory path. */
-    public function __construct(private readonly string $root)
+    public function __construct(private string $root)
     {
-        $this->cache = null;
+        $this->config = new StickyConfig($this->resolve(...));
     }
 
     #[Override]
     public function has(string $name): bool
     {
-        return $this->config()->has($name);
+        return $this->config->has($name);
     }
 
     #[Override]
     public function list(string $name): array
     {
-        return $this->config()->list($name);
+        return $this->config->list($name);
     }
 
     #[Override]
     public function toArray(): array
     {
-        return $this->config()->toArray();
+        return $this->config->toArray();
     }
 
     /**
@@ -47,35 +47,31 @@ final class ProjectConfig implements Config
      *
      * @throws PiquleException
      */
-    private function config(): Config
+    private function resolve(): Config
     {
-        if ($this->cache !== null) {
-            return $this->cache;
-        }
-
         $defaults = new DefaultConfig(
             [],
             [],
-            new ConfigPaths($this->root . '/composer.json'),
+            new ConfigPaths(sprintf('%s/composer.json', $this->root)),
         );
 
-        $yamlPath = $this->root . '/.piqule.yaml';
-        $phpPath = $this->root . '/.piqule.php';
+        $yamlPath = sprintf('%s/.piqule.yaml', $this->root);
+        $phpPath = sprintf('%s/.piqule.php', $this->root);
 
         if (file_exists($yamlPath)) {
-            $this->cache = new YamlConfig($yamlPath, $defaults);
-        } elseif (file_exists($phpPath)) {
+            return new YamlConfig($yamlPath, $defaults);
+        }
+
+        if (file_exists($phpPath)) {
             $loaded = require $phpPath;
 
             if (!$loaded instanceof Config) {
                 throw new PiquleException('.piqule.php must return an instance of Config');
             }
 
-            $this->cache = $loaded;
-        } else {
-            $this->cache = $defaults;
+            return $loaded;
         }
 
-        return $this->cache;
+        return $defaults;
     }
 }

--- a/src/Config/StickyConfig.php
+++ b/src/Config/StickyConfig.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Config;
+
+use Closure;
+use Override;
+use stdClass;
+
+/**
+ * Caches the result of a config-producing closure on first access.
+ *
+ * Example:
+ *
+ *     new StickyConfig(fn() => new DefaultConfig([], [], $paths));
+ */
+final readonly class StickyConfig implements Config
+{
+    private stdClass $cache;
+
+    /**
+     * Initializes with a config factory closure.
+     *
+     * @param Closure(): Config $origin
+     */
+    public function __construct(private Closure $origin)
+    {
+        $this->cache = new stdClass();
+    }
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return $this->config()->has($name);
+    }
+
+    #[Override]
+    public function list(string $name): array
+    {
+        return $this->config()->list($name);
+    }
+
+    #[Override]
+    public function toArray(): array
+    {
+        return $this->config()->toArray();
+    }
+
+    private function config(): Config
+    {
+        if (!isset($this->cache->value)) {
+            $this->cache->value = ($this->origin)();
+        }
+
+        $config = $this->cache->value;
+        assert($config instanceof Config);
+
+        return $config;
+    }
+}

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -26,36 +26,34 @@ use Symfony\Component\Yaml\Yaml;
  *         exclude:
  *             - legacy
  */
-final class YamlConfig implements Config
+final readonly class YamlConfig implements Config
 {
-    private ?Config $cache;
+    private StickyConfig $config;
 
     /**
      * Initializes with a YAML file path and default configuration.
      */
-    public function __construct(
-        private readonly string $path,
-        private readonly DefaultConfig $defaults,
-    ) {
-        $this->cache = null;
+    public function __construct(private string $path, private DefaultConfig $defaults)
+    {
+        $this->config = new StickyConfig($this->parse(...));
     }
 
     #[Override]
     public function has(string $name): bool
     {
-        return $this->config()->has($name);
+        return $this->config->has($name);
     }
 
     #[Override]
     public function list(string $name): array
     {
-        return $this->config()->list($name);
+        return $this->config->list($name);
     }
 
     #[Override]
     public function toArray(): array
     {
-        return $this->config()->toArray();
+        return $this->config->toArray();
     }
 
     /**
@@ -63,12 +61,8 @@ final class YamlConfig implements Config
      *
      * @throws PiquleException
      */
-    private function config(): Config
+    private function parse(): Config
     {
-        if ($this->cache !== null) {
-            return $this->cache;
-        }
-
         try {
             $data = Yaml::parseFile($this->path);
         } catch (YamlParseException $e) {
@@ -97,7 +91,7 @@ final class YamlConfig implements Config
         $pathKeys = new YamlPathKeys($overrides, $appends, $this->defaults);
         $remaining = ['exclude', 'php.src'];
 
-        $this->cache = new AppendConfig(
+        return new AppendConfig(
             new OverrideConfig(
                 new DefaultConfig(
                     $pathKeys->phpSrc(),
@@ -108,7 +102,5 @@ final class YamlConfig implements Config
             ),
             array_diff_key($appends, array_flip($remaining)),
         );
-
-        return $this->cache;
     }
 }

--- a/src/File/PrefixedFile.php
+++ b/src/File/PrefixedFile.php
@@ -22,7 +22,7 @@ final readonly class PrefixedFile implements File
 
         return $prefix === ''
             ? $name
-            : $prefix . '/' . $name;
+            : "{$prefix}/{$name}";
     }
 
     #[Override]

--- a/src/Formula/Actions/ParsedActions.php
+++ b/src/Formula/Actions/ParsedActions.php
@@ -13,6 +13,8 @@ use Override;
  */
 final readonly class ParsedActions implements Actions
 {
+    private const int ARGS_MATCH_INDEX = 2;
+
     /**
      * Initializes with a DSL expression and available action factories.
      *
@@ -39,7 +41,7 @@ final readonly class ParsedActions implements Actions
                 );
             }
 
-            return ($this->actions[$name])($m[2]);
+            return ($this->actions[$name])($m[self::ARGS_MATCH_INDEX]);
         }, $matches);
     }
 }

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -13,6 +13,8 @@ use Override;
  */
 final readonly class ParsedArgs implements Args
 {
+    private const int JSON_MAX_DEPTH = 512;
+
     /** Initializes with the args containing a JSON list literal. */
     public function __construct(private Args $origin) {}
 
@@ -76,7 +78,7 @@ final readonly class ParsedArgs implements Args
             $decoded = json_decode(
                 $raw,
                 true,
-                512,
+                self::JSON_MAX_DEPTH,
                 JSON_THROW_ON_ERROR,
             );
         } catch (JsonException) {

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -13,6 +13,10 @@ use Override;
  */
 final readonly class UnquotedArgs implements Args
 {
+    private const int MIN_QUOTED_LENGTH = 2;
+
+    private const int STRIP_LAST_CHAR = -1;
+
     /** Initializes with the args to unquote. */
     public function __construct(private Args $origin) {}
 
@@ -31,7 +35,7 @@ final readonly class UnquotedArgs implements Args
     {
         $length = strlen($text);
 
-        if ($length < 2) {
+        if ($length < self::MIN_QUOTED_LENGTH) {
             return $text;
         }
 
@@ -42,7 +46,7 @@ final readonly class UnquotedArgs implements Args
             ($first === '"' && $last === '"')
             || ($first === "'" && $last === "'")
         ) {
-            return substr($text, 1, -1);
+            return substr($text, 1, self::STRIP_LAST_CHAR);
         }
 
         return $text;

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -41,7 +41,7 @@ final readonly class AppendingStorage implements Storage
 
         $merged = new TextFile(
             $path,
-            $current . "\n" . $file->contents(),
+            "{$current}\n{$file->contents()}",
             $this->origin->mode($path),
         );
         $newOrigin = $this->origin->write($merged);

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -17,6 +17,8 @@ use function assert;
  */
 final readonly class DiskStorage implements Storage
 {
+    private const int FULL_PERMISSIONS = 0o777;
+
     /** Initializes storage rooted at the given directory path. */
     public function __construct(private string $root) {}
 
@@ -57,14 +59,14 @@ final readonly class DiskStorage implements Storage
 
             if ($item->isFile()) {
                 yield ltrim(
-                    $location . '/' . $item->getFilename(),
+                    "{$location}/{$item->getFilename()}",
                     '/',
                 );
             }
 
             if ($item->isDir()) {
                 yield from $this->entries(
-                    ltrim($location . '/' . $item->getFilename(), '/'),
+                    ltrim("{$location}/{$item->getFilename()}", '/'),
                 );
             }
         }
@@ -84,7 +86,7 @@ final readonly class DiskStorage implements Storage
         $directory = dirname($path);
 
         if (!is_dir($directory)
-            && !mkdir($directory, 0o777, true)
+            && !mkdir($directory, self::FULL_PERMISSIONS, true)
             && !is_dir($directory)
         ) {
             throw new PiquleException("Unable to create directory: $directory");
@@ -116,7 +118,7 @@ final readonly class DiskStorage implements Storage
             throw new PiquleException("Unable to read permissions: $location");
         }
 
-        return $perms & 0o777;
+        return $perms & self::FULL_PERMISSIONS;
     }
 
     /**

--- a/src/Storage/InMemoryStorage.php
+++ b/src/Storage/InMemoryStorage.php
@@ -64,7 +64,7 @@ final readonly class InMemoryStorage implements Storage
             return $keys;
         }
 
-        $prefix = rtrim($location, '/') . '/';
+        $prefix = sprintf('%s/', rtrim($location, '/'));
         $entries = [];
 
         foreach ($keys as $key) {

--- a/src/Storage/SafePath.php
+++ b/src/Storage/SafePath.php
@@ -41,6 +41,6 @@ final readonly class SafePath
             $parts[] = $part;
         }
 
-        return rtrim($this->root, '/') . '/' . implode('/', $parts);
+        return sprintf('%s/%s', rtrim($this->root, '/'), implode('/', $parts));
     }
 }


### PR DESCRIPTION
## Summary

- Widen `haspadar/phpstan-rules` constraint from `^0.30.1` to `>=0.30.1 <1.0.0` and update to v0.31.0
- Fix all 42+ PHPStan errors from 3 new rules:
  - **haspadar.immutable**: `ProjectConfig`, `YamlConfig`, `DefaultConfig` → fully `readonly` via `stdClass` cache + new `StickyConfig` decorator
  - **haspadar.constantUsage**: extract magic numbers into named constants (SECONDS_PER_MINUTE, FULL_PERMISSIONS, etc.)
  - **haspadar.stringConcat**: replace `.` concatenation with `sprintf()` / string interpolation across 15 files

## Test plan

- [ ] `bin/piqule check` passes all 14 checks (phpstan, psalm, phpunit, phpcs, php-cs-fixer, etc.)
- [ ] Existing tests pass without modifications