### PR TITLE
Silent Quality Checks On Empty Source Tree

### DIFF
--- a/.piqule/_skip_if_empty.sh
+++ b/.piqule/_skip_if_empty.sh
@@ -1,19 +1,16 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
 DIR="${1:-}"
 GLOB="${2:-}"
 TOOL="${3:-}"
 KIND="${4:-PHP source files}"
 
 if [ -z "$DIR" ] || [ -z "$GLOB" ] || [ -z "$TOOL" ]; then
-  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
+  echo "Usage: . .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
   exit 2
 fi
 
 if [ ! -d "$DIR" ] || [ -z "$(find "$DIR" -name "$GLOB" -print -quit)" ]; then
   echo "No $KIND found, skipping $TOOL"
-  exit 1
+  exit 0
 fi
 
-exit 0
+return 0

--- a/.piqule/_skip_if_empty.sh
+++ b/.piqule/_skip_if_empty.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="${1:-}"
+GLOB="${2:-}"
+TOOL="${3:-}"
+KIND="${4:-PHP source files}"
+
+if [ -z "$DIR" ] || [ -z "$GLOB" ] || [ -z "$TOOL" ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
+  exit 2
+fi
+
+if [ ! -d "$DIR" ] || [ -z "$(find "$DIR" -name "$GLOB" -print -quit)" ]; then
+  echo "No $KIND found, skipping $TOOL"
+  exit 1
+fi
+
+exit 0

--- a/.piqule/_skip_if_empty.sh
+++ b/.piqule/_skip_if_empty.sh
@@ -1,10 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 DIR="${1:-}"
 GLOB="${2:-}"
 TOOL="${3:-}"
-KIND="${4:-PHP source files}"
 
 if [ -z "$DIR" ] || [ -z "$GLOB" ] || [ -z "$TOOL" ]; then
-  echo "Usage: . .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
+  exit 2
+fi
+
+shift 3
+
+KIND="PHP source files"
+if [ $# -gt 0 ] && [ "$1" != "--" ]; then
+  KIND="$1"
+  shift
+fi
+
+if [ $# -eq 0 ] || [ "$1" != "--" ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
+  exit 2
+fi
+shift
+
+if [ $# -eq 0 ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
   exit 2
 fi
 
@@ -13,4 +34,4 @@ if [ ! -d "$DIR" ] || [ -z "$(find "$DIR" -name "$GLOB" -print -quit)" ]; then
   exit 0
 fi
 
-return 0
+exec "$@"

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -8,11 +8,10 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' Infection
-
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
-XDEBUG_MODE=coverage \
+exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
+  env XDEBUG_MODE=coverage \
   "$INFECTION_BIN" \
   --configuration="$CONFIG" \
   --threads=max

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping Infection"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' Infection || exit 0
 
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' Infection || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' Infection
 
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping Infection"
   exit 0
 fi

--- a/.piqule/php-cs-fixer/command.sh
+++ b/.piqule/php-cs-fixer/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer" || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer"
 
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 

--- a/.piqule/php-cs-fixer/command.sh
+++ b/.piqule/php-cs-fixer/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHP CS Fixer"
   exit 0
 fi

--- a/.piqule/php-cs-fixer/command.sh
+++ b/.piqule/php-cs-fixer/command.sh
@@ -8,11 +8,10 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer"
-
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 
-"$BIN" fix \
+exec .piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer" -- \
+  "$BIN" fix \
   --config="$CONFIG" \
   --dry-run \
   --diff

--- a/.piqule/php-cs-fixer/command.sh
+++ b/.piqule/php-cs-fixer/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHP CS Fixer"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer" || exit 0
 
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 

--- a/.piqule/php-cs-fixer/command.sh
+++ b/.piqule/php-cs-fixer/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHP CS Fixer"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 
 "$BIN" fix \

--- a/.piqule/phpcs/command.sh
+++ b/.piqule/phpcs/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPCS"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPCS || exit 0
 
 BIN="$(.piqule/_composer.sh phpcs)"
 

--- a/.piqule/phpcs/command.sh
+++ b/.piqule/phpcs/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPCS"
   exit 0
 fi

--- a/.piqule/phpcs/command.sh
+++ b/.piqule/phpcs/command.sh
@@ -8,8 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPCS
-
 BIN="$(.piqule/_composer.sh phpcs)"
 
-"$BIN" --standard="$CONFIG"
+exec .piqule/_skip_if_empty.sh src '*.php' PHPCS -- \
+  "$BIN" --standard="$CONFIG"

--- a/.piqule/phpcs/command.sh
+++ b/.piqule/phpcs/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPCS || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPCS
 
 BIN="$(.piqule/_composer.sh phpcs)"
 

--- a/.piqule/phpcs/command.sh
+++ b/.piqule/phpcs/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPCS"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpcs)"
 
 "$BIN" --standard="$CONFIG"

--- a/.piqule/phpmd/command.sh
+++ b/.piqule/phpmd/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPMD"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPMD || exit 0
 
 BIN="$(.piqule/_composer.sh phpmd)"
 

--- a/.piqule/phpmd/command.sh
+++ b/.piqule/phpmd/command.sh
@@ -8,11 +8,10 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPMD
-
 BIN="$(.piqule/_composer.sh phpmd)"
 
-"$BIN" \
+exec .piqule/_skip_if_empty.sh src '*.php' PHPMD -- \
+  "$BIN" \
 src \
-text \
-"$CONFIG"
+  text \
+  "$CONFIG"

--- a/.piqule/phpmd/command.sh
+++ b/.piqule/phpmd/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPMD"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpmd)"
 
 "$BIN" \

--- a/.piqule/phpmd/command.sh
+++ b/.piqule/phpmd/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPMD"
   exit 0
 fi

--- a/.piqule/phpmd/command.sh
+++ b/.piqule/phpmd/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPMD || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPMD
 
 BIN="$(.piqule/_composer.sh phpmd)"
 

--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -9,10 +9,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPMetrics"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPMetrics || exit 0
 
 BIN="$(.piqule/_composer.sh phpmetrics)"
 

--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -9,15 +9,13 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPMetrics
-
 BIN="$(.piqule/_composer.sh phpmetrics)"
 
-php -d error_reporting='E_ALL & ~E_DEPRECATED' \
+.piqule/_skip_if_empty.sh src '*.php' PHPMetrics -- \
+  php -d error_reporting='E_ALL & ~E_DEPRECATED' \
   "$BIN" \
   --config="$CONFIG"
 
 if [ -f "$VERIFY" ]; then
   php "$VERIFY"
 fi
-

--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -9,7 +9,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPMetrics || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPMetrics
 
 BIN="$(.piqule/_composer.sh phpmetrics)"
 

--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -9,6 +9,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPMetrics"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpmetrics)"
 
 php -d error_reporting='E_ALL & ~E_DEPRECATED' \

--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -9,7 +9,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPMetrics"
   exit 0
 fi

--- a/.piqule/phpstan/command.sh
+++ b/.piqule/phpstan/command.sh
@@ -8,8 +8,8 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ]; then
-  echo "No src directory found, skipping PHPStan"
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPStan"
   exit 0
 fi
 

--- a/.piqule/phpstan/command.sh
+++ b/.piqule/phpstan/command.sh
@@ -8,10 +8,9 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPStan
-
 BIN="$(.piqule/_composer.sh phpstan)"
 
-"$BIN" analyse \
+exec .piqule/_skip_if_empty.sh src '*.php' PHPStan -- \
+  "$BIN" analyse \
   -c "$CONFIG" \
   --memory-limit=1G

--- a/.piqule/phpstan/command.sh
+++ b/.piqule/phpstan/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPStan"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPStan || exit 0
 
 BIN="$(.piqule/_composer.sh phpstan)"
 

--- a/.piqule/phpstan/command.sh
+++ b/.piqule/phpstan/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPStan"
   exit 0
 fi

--- a/.piqule/phpstan/command.sh
+++ b/.piqule/phpstan/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPStan || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPStan
 
 BIN="$(.piqule/_composer.sh phpstan)"
 

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" || exit 0
+. .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests"
 
 SEED="${PHPUNIT_SEED:-}"
 

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -print -quit)" ]; then
-  echo "No PHP tests found, skipping PHPUnit"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" || exit 0
 
 SEED="${PHPUNIT_SEED:-}"
 

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -print -quit)" ]; then
   echo "No PHP tests found, skipping PHPUnit"
   exit 0
 fi

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -8,8 +8,6 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests"
-
 SEED="${PHPUNIT_SEED:-}"
 
 BIN="$(.piqule/_composer.sh phpunit)"
@@ -44,4 +42,6 @@ fi
 
 PHP_OPTIONS="-d memory_limit=1G"
 export XDEBUG_MODE
-php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"
+
+exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \
+  php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -8,8 +8,8 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "tests" ]; then
-  echo "No tests directory found, skipping PHPUnit"
+if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP tests found, skipping PHPUnit"
   exit 0
 fi
 

--- a/.piqule/psalm/command.sh
+++ b/.piqule/psalm/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping Psalm"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' Psalm || exit 0
 
 BIN="$(.piqule/_composer.sh psalm)"
 

--- a/.piqule/psalm/command.sh
+++ b/.piqule/psalm/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping Psalm"
   exit 0
 fi

--- a/.piqule/psalm/command.sh
+++ b/.piqule/psalm/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping Psalm"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh psalm)"
 
 "$BIN" \

--- a/.piqule/psalm/command.sh
+++ b/.piqule/psalm/command.sh
@@ -8,11 +8,10 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' Psalm
-
 BIN="$(.piqule/_composer.sh psalm)"
 
-"$BIN" \
+exec .piqule/_skip_if_empty.sh src '*.php' Psalm -- \
+  "$BIN" \
   --root=. \
   --config="$CONFIG" \
   --no-cache

--- a/.piqule/psalm/command.sh
+++ b/.piqule/psalm/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' Psalm || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' Psalm
 
 BIN="$(.piqule/_composer.sh psalm)"
 

--- a/templates/always/.piqule/_skip_if_empty.sh
+++ b/templates/always/.piqule/_skip_if_empty.sh
@@ -1,19 +1,16 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
 DIR="${1:-}"
 GLOB="${2:-}"
 TOOL="${3:-}"
 KIND="${4:-PHP source files}"
 
 if [ -z "$DIR" ] || [ -z "$GLOB" ] || [ -z "$TOOL" ]; then
-  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
+  echo "Usage: . .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
   exit 2
 fi
 
 if [ ! -d "$DIR" ] || [ -z "$(find "$DIR" -name "$GLOB" -print -quit)" ]; then
   echo "No $KIND found, skipping $TOOL"
-  exit 1
+  exit 0
 fi
 
-exit 0
+return 0

--- a/templates/always/.piqule/_skip_if_empty.sh
+++ b/templates/always/.piqule/_skip_if_empty.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="${1:-}"
+GLOB="${2:-}"
+TOOL="${3:-}"
+KIND="${4:-PHP source files}"
+
+if [ -z "$DIR" ] || [ -z "$GLOB" ] || [ -z "$TOOL" ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
+  exit 2
+fi
+
+if [ ! -d "$DIR" ] || [ -z "$(find "$DIR" -name "$GLOB" -print -quit)" ]; then
+  echo "No $KIND found, skipping $TOOL"
+  exit 1
+fi
+
+exit 0

--- a/templates/always/.piqule/_skip_if_empty.sh
+++ b/templates/always/.piqule/_skip_if_empty.sh
@@ -1,10 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 DIR="${1:-}"
 GLOB="${2:-}"
 TOOL="${3:-}"
-KIND="${4:-PHP source files}"
 
 if [ -z "$DIR" ] || [ -z "$GLOB" ] || [ -z "$TOOL" ]; then
-  echo "Usage: . .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>]" >&2
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
+  exit 2
+fi
+
+shift 3
+
+KIND="PHP source files"
+if [ $# -gt 0 ] && [ "$1" != "--" ]; then
+  KIND="$1"
+  shift
+fi
+
+if [ $# -eq 0 ] || [ "$1" != "--" ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
+  exit 2
+fi
+shift
+
+if [ $# -eq 0 ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
   exit 2
 fi
 
@@ -13,4 +34,4 @@ if [ ! -d "$DIR" ] || [ -z "$(find "$DIR" -name "$GLOB" -print -quit)" ]; then
   exit 0
 fi
 
-return 0
+exec "$@"

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -8,11 +8,10 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' Infection
-
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
-XDEBUG_MODE=coverage \
+exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
+  env XDEBUG_MODE=coverage \
   "$INFECTION_BIN" \
   --configuration="$CONFIG" \
   --threads=max

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping Infection"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' Infection || exit 0
 
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' Infection || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' Infection
 
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping Infection"
   exit 0
 fi

--- a/templates/always/.piqule/php-cs-fixer/command.sh
+++ b/templates/always/.piqule/php-cs-fixer/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer" || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer"
 
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 

--- a/templates/always/.piqule/php-cs-fixer/command.sh
+++ b/templates/always/.piqule/php-cs-fixer/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHP CS Fixer"
   exit 0
 fi

--- a/templates/always/.piqule/php-cs-fixer/command.sh
+++ b/templates/always/.piqule/php-cs-fixer/command.sh
@@ -8,11 +8,10 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer"
-
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 
-"$BIN" fix \
+exec .piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer" -- \
+  "$BIN" fix \
   --config="$CONFIG" \
   --dry-run \
   --diff

--- a/templates/always/.piqule/php-cs-fixer/command.sh
+++ b/templates/always/.piqule/php-cs-fixer/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHP CS Fixer"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer" || exit 0
 
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 

--- a/templates/always/.piqule/php-cs-fixer/command.sh
+++ b/templates/always/.piqule/php-cs-fixer/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHP CS Fixer"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh php-cs-fixer)"
 
 "$BIN" fix \

--- a/templates/always/.piqule/phpcs/command.sh
+++ b/templates/always/.piqule/phpcs/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPCS"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPCS || exit 0
 
 BIN="$(.piqule/_composer.sh phpcs)"
 

--- a/templates/always/.piqule/phpcs/command.sh
+++ b/templates/always/.piqule/phpcs/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPCS"
   exit 0
 fi

--- a/templates/always/.piqule/phpcs/command.sh
+++ b/templates/always/.piqule/phpcs/command.sh
@@ -8,8 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPCS
-
 BIN="$(.piqule/_composer.sh phpcs)"
 
-"$BIN" --standard="$CONFIG"
+exec .piqule/_skip_if_empty.sh src '*.php' PHPCS -- \
+  "$BIN" --standard="$CONFIG"

--- a/templates/always/.piqule/phpcs/command.sh
+++ b/templates/always/.piqule/phpcs/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPCS || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPCS
 
 BIN="$(.piqule/_composer.sh phpcs)"
 

--- a/templates/always/.piqule/phpcs/command.sh
+++ b/templates/always/.piqule/phpcs/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPCS"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpcs)"
 
 "$BIN" --standard="$CONFIG"

--- a/templates/always/.piqule/phpmd/command.sh
+++ b/templates/always/.piqule/phpmd/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPMD"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPMD || exit 0
 
 BIN="$(.piqule/_composer.sh phpmd)"
 

--- a/templates/always/.piqule/phpmd/command.sh
+++ b/templates/always/.piqule/phpmd/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPMD"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpmd)"
 
 "$BIN" \

--- a/templates/always/.piqule/phpmd/command.sh
+++ b/templates/always/.piqule/phpmd/command.sh
@@ -8,13 +8,12 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPMD
-
 BIN="$(.piqule/_composer.sh phpmd)"
 
-"$BIN" \
+exec .piqule/_skip_if_empty.sh src '*.php' PHPMD -- \
+  "$BIN" \
 << config(phpmd.paths)
    |join(" ")
 >> \
-text \
-"$CONFIG"
+  text \
+  "$CONFIG"

--- a/templates/always/.piqule/phpmd/command.sh
+++ b/templates/always/.piqule/phpmd/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPMD"
   exit 0
 fi

--- a/templates/always/.piqule/phpmd/command.sh
+++ b/templates/always/.piqule/phpmd/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPMD || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPMD
 
 BIN="$(.piqule/_composer.sh phpmd)"
 

--- a/templates/always/.piqule/phpmetrics/command.sh
+++ b/templates/always/.piqule/phpmetrics/command.sh
@@ -9,10 +9,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPMetrics"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPMetrics || exit 0
 
 BIN="$(.piqule/_composer.sh phpmetrics)"
 

--- a/templates/always/.piqule/phpmetrics/command.sh
+++ b/templates/always/.piqule/phpmetrics/command.sh
@@ -9,15 +9,13 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPMetrics
-
 BIN="$(.piqule/_composer.sh phpmetrics)"
 
-php -d error_reporting='E_ALL & ~E_DEPRECATED' \
+.piqule/_skip_if_empty.sh src '*.php' PHPMetrics -- \
+  php -d error_reporting='E_ALL & ~E_DEPRECATED' \
   "$BIN" \
   --config="$CONFIG"
 
 if [ -f "$VERIFY" ]; then
   php "$VERIFY"
 fi
-

--- a/templates/always/.piqule/phpmetrics/command.sh
+++ b/templates/always/.piqule/phpmetrics/command.sh
@@ -9,7 +9,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPMetrics || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPMetrics
 
 BIN="$(.piqule/_composer.sh phpmetrics)"
 

--- a/templates/always/.piqule/phpmetrics/command.sh
+++ b/templates/always/.piqule/phpmetrics/command.sh
@@ -9,6 +9,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPMetrics"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh phpmetrics)"
 
 php -d error_reporting='E_ALL & ~E_DEPRECATED' \

--- a/templates/always/.piqule/phpmetrics/command.sh
+++ b/templates/always/.piqule/phpmetrics/command.sh
@@ -9,7 +9,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPMetrics"
   exit 0
 fi

--- a/templates/always/.piqule/phpstan/command.sh
+++ b/templates/always/.piqule/phpstan/command.sh
@@ -8,8 +8,8 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ]; then
-  echo "No src directory found, skipping PHPStan"
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping PHPStan"
   exit 0
 fi
 

--- a/templates/always/.piqule/phpstan/command.sh
+++ b/templates/always/.piqule/phpstan/command.sh
@@ -8,10 +8,9 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' PHPStan
-
 BIN="$(.piqule/_composer.sh phpstan)"
 
-"$BIN" analyse \
+exec .piqule/_skip_if_empty.sh src '*.php' PHPStan -- \
+  "$BIN" analyse \
   -c "$CONFIG" \
   --memory-limit=<< config(phpstan.memory) >>

--- a/templates/always/.piqule/phpstan/command.sh
+++ b/templates/always/.piqule/phpstan/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping PHPStan"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' PHPStan || exit 0
 
 BIN="$(.piqule/_composer.sh phpstan)"
 

--- a/templates/always/.piqule/phpstan/command.sh
+++ b/templates/always/.piqule/phpstan/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping PHPStan"
   exit 0
 fi

--- a/templates/always/.piqule/phpstan/command.sh
+++ b/templates/always/.piqule/phpstan/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' PHPStan || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' PHPStan
 
 BIN="$(.piqule/_composer.sh phpstan)"
 

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" || exit 0
+. .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests"
 
 SEED="${PHPUNIT_SEED:-}"
 

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -print -quit)" ]; then
-  echo "No PHP tests found, skipping PHPUnit"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" || exit 0
 
 SEED="${PHPUNIT_SEED:-}"
 

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -8,8 +8,6 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests"
-
 SEED="${PHPUNIT_SEED:-}"
 
 BIN="$(.piqule/_composer.sh phpunit)"
@@ -44,4 +42,6 @@ fi
 
 PHP_OPTIONS="<< config(phpunit.php_options) >>"
 export XDEBUG_MODE
-php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"
+
+exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \
+  php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -print -quit)" ]; then
   echo "No PHP tests found, skipping PHPUnit"
   exit 0
 fi

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -8,8 +8,8 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "tests" ]; then
-  echo "No tests directory found, skipping PHPUnit"
+if [ ! -d "tests" ] || [ -z "$(find tests -name '*Test.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP tests found, skipping PHPUnit"
   exit 0
 fi
 

--- a/templates/always/.piqule/psalm/command.sh
+++ b/templates/always/.piqule/psalm/command.sh
@@ -8,10 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
-  echo "No PHP source files found, skipping Psalm"
-  exit 0
-fi
+.piqule/_skip_if_empty.sh src '*.php' Psalm || exit 0
 
 BIN="$(.piqule/_composer.sh psalm)"
 

--- a/templates/always/.piqule/psalm/command.sh
+++ b/templates/always/.piqule/psalm/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -print -quit)" ]; then
   echo "No PHP source files found, skipping Psalm"
   exit 0
 fi

--- a/templates/always/.piqule/psalm/command.sh
+++ b/templates/always/.piqule/psalm/command.sh
@@ -8,6 +8,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+if [ ! -d "src" ] || [ -z "$(find src -name '*.php' -maxdepth 3 | head -1)" ]; then
+  echo "No PHP source files found, skipping Psalm"
+  exit 0
+fi
+
 BIN="$(.piqule/_composer.sh psalm)"
 
 "$BIN" \

--- a/templates/always/.piqule/psalm/command.sh
+++ b/templates/always/.piqule/psalm/command.sh
@@ -8,11 +8,10 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-. .piqule/_skip_if_empty.sh src '*.php' Psalm
-
 BIN="$(.piqule/_composer.sh psalm)"
 
-"$BIN" \
+exec .piqule/_skip_if_empty.sh src '*.php' Psalm -- \
+  "$BIN" \
   --root=. \
   --config="$CONFIG" \
   --no-cache

--- a/templates/always/.piqule/psalm/command.sh
+++ b/templates/always/.piqule/psalm/command.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-.piqule/_skip_if_empty.sh src '*.php' Psalm || exit 0
+. .piqule/_skip_if_empty.sh src '*.php' Psalm
 
 BIN="$(.piqule/_composer.sh psalm)"
 


### PR DESCRIPTION
- Added guard to Psalm, PHPCS, PHPMD, PHPMetrics and PHP CS Fixer launchers to exit with a skip message when src/ has no PHP files
- Updated PHPStan and PHPUnit guards to also trigger when src/ or tests/ exist but contain no matching PHP files
- Fixed guards to detect PHP files at any directory depth

Closes #617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a centralized pre-execution check for all PHP analysis and linting tools (Infection, PHP CS Fixer, PHPCS, PHPMD, PHPMetrics, PHPStan, Psalm, PHPUnit), including template workflows.
  * Tools now verify matching source or test files exist and print a skip message and exit cleanly when none are found, avoiding unnecessary runs and improving build efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->