### PR TITLE
Skip PHPMetrics Verify When No Report Is Produced

### DIFF
--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 CONFIG=".piqule/phpmetrics/config.json"
 VERIFY=".piqule/phpmetrics/verify.php"
+REPORT=".piqule/phpmetrics/phpmetrics.json"
 
 if [ ! -f "$CONFIG" ]; then
   echo "PHPMetrics config not found: $CONFIG"
   exit 1
 fi
+
+rm -f "$REPORT"
 
 BIN="$(.piqule/_composer.sh phpmetrics)"
 
@@ -16,7 +19,6 @@ BIN="$(.piqule/_composer.sh phpmetrics)"
   "$BIN" \
   --config="$CONFIG"
 
-REPORT=".piqule/phpmetrics/phpmetrics.json"
 if [ -f "$VERIFY" ] && [ -f "$REPORT" ]; then
   php "$VERIFY"
 fi

--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -16,6 +16,7 @@ BIN="$(.piqule/_composer.sh phpmetrics)"
   "$BIN" \
   --config="$CONFIG"
 
-if [ -f "$VERIFY" ]; then
+REPORT=".piqule/phpmetrics/phpmetrics.json"
+if [ -f "$VERIFY" ] && [ -f "$REPORT" ]; then
   php "$VERIFY"
 fi

--- a/templates/always/.piqule/phpmetrics/command.sh
+++ b/templates/always/.piqule/phpmetrics/command.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 CONFIG=".piqule/phpmetrics/config.json"
 VERIFY=".piqule/phpmetrics/verify.php"
+REPORT=".piqule/phpmetrics/phpmetrics.json"
 
 if [ ! -f "$CONFIG" ]; then
   echo "PHPMetrics config not found: $CONFIG"
   exit 1
 fi
+
+rm -f "$REPORT"
 
 BIN="$(.piqule/_composer.sh phpmetrics)"
 
@@ -16,7 +19,6 @@ BIN="$(.piqule/_composer.sh phpmetrics)"
   "$BIN" \
   --config="$CONFIG"
 
-REPORT=".piqule/phpmetrics/phpmetrics.json"
 if [ -f "$VERIFY" ] && [ -f "$REPORT" ]; then
   php "$VERIFY"
 fi

--- a/templates/always/.piqule/phpmetrics/command.sh
+++ b/templates/always/.piqule/phpmetrics/command.sh
@@ -16,6 +16,7 @@ BIN="$(.piqule/_composer.sh phpmetrics)"
   "$BIN" \
   --config="$CONFIG"
 
-if [ -f "$VERIFY" ]; then
+REPORT=".piqule/phpmetrics/phpmetrics.json"
+if [ -f "$VERIFY" ] && [ -f "$REPORT" ]; then
   php "$VERIFY"
 fi


### PR DESCRIPTION
- Added a guard so the threshold verifier runs only when a PHPMetrics report exists
- Fixed a fatal error in CI when the source directory contains no PHP files
- Updated the check to clear any stale report before running so skip paths bypass verification

Closes #623