### PR TITLE
Delegate CI Test Steps To Tool Command Scripts

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -129,13 +129,7 @@ jobs:
       # ------------------------------------------------------------
       - name: PHPUnit (coverage)
         if: hashFiles('.piqule/phpunit/phpunit.xml') != ''
-        run: |
-          XDEBUG_MODE=coverage \
-          php -d memory_limit=1G \
-          vendor/bin/phpunit \
-            -c .piqule/phpunit/phpunit.xml \
-            --path-coverage \
-            --coverage-clover=.piqule/codecov/coverage.xml
+        run: bash .piqule/phpunit/command.sh
 
       # ------------------------------------------------------------
       # Upload coverage to Codecov (if coverage exists)
@@ -156,9 +150,4 @@ jobs:
         if: hashFiles('.piqule/infection/infection.json5') != ''
         env:
           INFECTION_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-        run: |
-          XDEBUG_MODE=coverage \
-          php -d memory_limit=1G \
-          vendor/bin/infection \
-            --configuration=.piqule/infection/infection.json5 \
-            --threads=max
+        run: bash .piqule/infection/command.sh

--- a/templates/always/.github/workflows/piqule.yml
+++ b/templates/always/.github/workflows/piqule.yml
@@ -129,13 +129,7 @@ jobs:
       # ------------------------------------------------------------
       - name: PHPUnit (coverage)
         if: hashFiles('.piqule/phpunit/phpunit.xml') != ''
-        run: |
-          XDEBUG_MODE=coverage \
-          php -d memory_limit=1G \
-          vendor/bin/phpunit \
-            -c .piqule/phpunit/phpunit.xml \
-            --path-coverage \
-            --coverage-clover=.piqule/codecov/coverage.xml
+        run: bash .piqule/phpunit/command.sh
 
       # ------------------------------------------------------------
       # Upload coverage to Codecov (if coverage exists)
@@ -156,9 +150,4 @@ jobs:
         if: hashFiles('.piqule/infection/infection.json5') != ''
         env:
           INFECTION_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-        run: |
-          XDEBUG_MODE=coverage \
-          php -d memory_limit=1G \
-          vendor/bin/infection \
-            --configuration=.piqule/infection/infection.json5 \
-            --threads=max
+        run: bash .piqule/infection/command.sh


### PR DESCRIPTION
- Updated PHPUnit CI step to invoke the tool command script instead of calling the binary directly
- Updated Infection CI step to invoke the tool command script instead of calling the binary directly
- Removed the `--path-coverage` flag from the PHPUnit CI invocation

Closes #625

**Breaking changes:**
- Coverage report no longer includes path coverage metrics; line and branch coverage remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD workflow configuration to streamline test execution by delegating PHPUnit coverage and Infection mutation testing commands to external scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->