### PR TITLE
Predictable PHP Options For PHPUnit And Infection

### DIFF
--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -11,11 +11,14 @@ fi
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
 PHP_OPTIONS_STR="-d memory_limit=1G"
-read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+PHP_OPTIONS=()
+if [ -n "$PHP_OPTIONS_STR" ]; then
+  read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+fi
 
 exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
   env XDEBUG_MODE=coverage \
-  php "${PHP_OPTIONS[@]}" \
+  php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" \
   "$INFECTION_BIN" \
   --configuration="$CONFIG" \
   --threads=max

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -16,6 +16,14 @@ if [ -n "$PHP_OPTIONS_STR" ]; then
   read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 fi
 
+PHP_OPTIONS_RC=0
+PHP_OPTIONS_DIAG=$(php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(0);' 2>&1 >/dev/null) || PHP_OPTIONS_RC=$?
+if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
+  echo "Invalid infection.php_options: $PHP_OPTIONS_STR" >&2
+  [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
+  exit 1
+fi
+
 exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
   env XDEBUG_MODE=coverage \
   php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" \

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -10,8 +10,12 @@ fi
 
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
+PHP_OPTIONS_STR="-d memory_limit=1G"
+read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+
 exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
   env XDEBUG_MODE=coverage \
+  php "${PHP_OPTIONS[@]}" \
   "$INFECTION_BIN" \
   --configuration="$CONFIG" \
   --threads=max

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -30,16 +30,6 @@ if [ -n "$SEED" ]; then
   ARGS+=(--random-order-seed="$SEED")
 fi
 
-COVERAGE_FILE=".piqule/codecov/coverage.xml"
-
-if php -r 'exit(extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
-  mkdir -p "$(dirname "$COVERAGE_FILE")"
-  ARGS+=(--coverage-clover="$COVERAGE_FILE")
-  XDEBUG_MODE=coverage
-else
-  XDEBUG_MODE=off
-fi
-
 PHP_OPTIONS_STR="-d memory_limit=1G"
 PHP_OPTIONS=()
 if [ -n "$PHP_OPTIONS_STR" ]; then
@@ -52,6 +42,16 @@ if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
   echo "Invalid phpunit.php_options: $PHP_OPTIONS_STR" >&2
   [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
   exit 1
+fi
+
+COVERAGE_FILE=".piqule/codecov/coverage.xml"
+
+if php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
+  mkdir -p "$(dirname "$COVERAGE_FILE")"
+  ARGS+=(--coverage-clover="$COVERAGE_FILE")
+  XDEBUG_MODE=coverage
+else
+  XDEBUG_MODE=off
 fi
 
 export XDEBUG_MODE

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -41,8 +41,12 @@ else
 fi
 
 PHP_OPTIONS_STR="-d memory_limit=1G"
-read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+PHP_OPTIONS=()
+if [ -n "$PHP_OPTIONS_STR" ]; then
+  read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+fi
+
 export XDEBUG_MODE
 
 exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \
-  php "${PHP_OPTIONS[@]}" "$BIN" "${ARGS[@]}"
+  php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" "$BIN" "${ARGS[@]}"

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -46,6 +46,14 @@ if [ -n "$PHP_OPTIONS_STR" ]; then
   read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 fi
 
+PHP_OPTIONS_RC=0
+PHP_OPTIONS_DIAG=$(php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(0);' 2>&1 >/dev/null) || PHP_OPTIONS_RC=$?
+if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
+  echo "Invalid phpunit.php_options: $PHP_OPTIONS_STR" >&2
+  [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
+  exit 1
+fi
+
 export XDEBUG_MODE
 
 exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -40,8 +40,9 @@ else
   XDEBUG_MODE=off
 fi
 
-PHP_OPTIONS="-d memory_limit=1G"
+PHP_OPTIONS_STR="-d memory_limit=1G"
+read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 export XDEBUG_MODE
 
 exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \
-  php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"
+  php "${PHP_OPTIONS[@]}" "$BIN" "${ARGS[@]}"

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -10,7 +10,7 @@ fi
 
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
-PHP_OPTIONS_STR="<< config(infection.php_options) >>"
+PHP_OPTIONS_STR="<< config(infection.php_options)|join(' ') >>"
 read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 
 exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -10,8 +10,12 @@ fi
 
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
+PHP_OPTIONS_STR="<< config(infection.php_options) >>"
+read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+
 exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
   env XDEBUG_MODE=coverage \
+  php "${PHP_OPTIONS[@]}" \
   "$INFECTION_BIN" \
   --configuration="$CONFIG" \
   --threads=max

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -16,6 +16,14 @@ if [ -n "$PHP_OPTIONS_STR" ]; then
   read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 fi
 
+PHP_OPTIONS_RC=0
+PHP_OPTIONS_DIAG=$(php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(0);' 2>&1 >/dev/null) || PHP_OPTIONS_RC=$?
+if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
+  echo "Invalid infection.php_options: $PHP_OPTIONS_STR" >&2
+  [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
+  exit 1
+fi
+
 exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
   env XDEBUG_MODE=coverage \
   php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" \

--- a/templates/always/.piqule/infection/command.sh
+++ b/templates/always/.piqule/infection/command.sh
@@ -11,11 +11,14 @@ fi
 INFECTION_BIN="$(.piqule/_composer.sh infection)"
 
 PHP_OPTIONS_STR="<< config(infection.php_options)|join(' ') >>"
-read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+PHP_OPTIONS=()
+if [ -n "$PHP_OPTIONS_STR" ]; then
+  read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+fi
 
 exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
   env XDEBUG_MODE=coverage \
-  php "${PHP_OPTIONS[@]}" \
+  php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" \
   "$INFECTION_BIN" \
   --configuration="$CONFIG" \
   --threads=max

--- a/templates/always/.piqule/infection/infection.json5
+++ b/templates/always/.piqule/infection/infection.json5
@@ -16,7 +16,7 @@
     "configDir": "../phpunit"
   },
 
-  "initialTestsPhpOptions": "<< config(infection.php_options) >>",
+  "initialTestsPhpOptions": "<< config(infection.php_options)|join(' ') >>",
   "timeout": << config(infection.timeout) >>,
   "minMsi": << config(infection.min_msi) >>,
   "minCoveredMsi": << config(infection.min_covered_msi) >>,

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -40,8 +40,9 @@ else
   XDEBUG_MODE=off
 fi
 
-PHP_OPTIONS="<< config(phpunit.php_options) >>"
+PHP_OPTIONS_STR="<< config(phpunit.php_options) >>"
+read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 export XDEBUG_MODE
 
 exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \
-  php "$PHP_OPTIONS" "$BIN" "${ARGS[@]}"
+  php "${PHP_OPTIONS[@]}" "$BIN" "${ARGS[@]}"

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -41,8 +41,12 @@ else
 fi
 
 PHP_OPTIONS_STR="<< config(phpunit.php_options)|join(' ') >>"
-read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+PHP_OPTIONS=()
+if [ -n "$PHP_OPTIONS_STR" ]; then
+  read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+fi
+
 export XDEBUG_MODE
 
 exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \
-  php "${PHP_OPTIONS[@]}" "$BIN" "${ARGS[@]}"
+  php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" "$BIN" "${ARGS[@]}"

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -30,16 +30,6 @@ if [ -n "$SEED" ]; then
   ARGS+=(--random-order-seed="$SEED")
 fi
 
-COVERAGE_FILE=".piqule/codecov/coverage.xml"
-
-if php -r 'exit(extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
-  mkdir -p "$(dirname "$COVERAGE_FILE")"
-  ARGS+=(--coverage-clover="$COVERAGE_FILE")
-  XDEBUG_MODE=coverage
-else
-  XDEBUG_MODE=off
-fi
-
 PHP_OPTIONS_STR="<< config(phpunit.php_options)|join(' ') >>"
 PHP_OPTIONS=()
 if [ -n "$PHP_OPTIONS_STR" ]; then
@@ -52,6 +42,16 @@ if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
   echo "Invalid phpunit.php_options: $PHP_OPTIONS_STR" >&2
   [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
   exit 1
+fi
+
+COVERAGE_FILE=".piqule/codecov/coverage.xml"
+
+if php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
+  mkdir -p "$(dirname "$COVERAGE_FILE")"
+  ARGS+=(--coverage-clover="$COVERAGE_FILE")
+  XDEBUG_MODE=coverage
+else
+  XDEBUG_MODE=off
 fi
 
 export XDEBUG_MODE

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -46,6 +46,14 @@ if [ -n "$PHP_OPTIONS_STR" ]; then
   read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 fi
 
+PHP_OPTIONS_RC=0
+PHP_OPTIONS_DIAG=$(php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(0);' 2>&1 >/dev/null) || PHP_OPTIONS_RC=$?
+if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
+  echo "Invalid phpunit.php_options: $PHP_OPTIONS_STR" >&2
+  [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
+  exit 1
+fi
+
 export XDEBUG_MODE
 
 exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \

--- a/templates/always/.piqule/phpunit/command.sh
+++ b/templates/always/.piqule/phpunit/command.sh
@@ -40,7 +40,7 @@ else
   XDEBUG_MODE=off
 fi
 
-PHP_OPTIONS_STR="<< config(phpunit.php_options) >>"
+PHP_OPTIONS_STR="<< config(phpunit.php_options)|join(' ') >>"
 read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
 export XDEBUG_MODE
 


### PR DESCRIPTION
- Fixed multi-flag php_options being passed as a single argv token to PHP
- Added support for YAML-list form of php_options alongside scalar strings
- Added pre-flight validation that fails early on unknown flags or bad ini values
- Updated Infection invocation to apply configured PHP options to the parent process

Closes #627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PHP options configuration now validates settings early and provides clear error messages with diagnostics before execution.

* **Chores**
  * Updated PHP options parsing to use array-based handling for more consistent command-line argument passing across testing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->