### PR TITLE
Shell-Safe DSL Action for Shell Interpolation

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -112,6 +112,7 @@ Example:
 - `format_each(template)` — formats each list item via `sprintf`
 - `join(delimiter)` — reduces the list to a single scalar value; supports escape sequences (`\n`, `\t`, `\r`, `\\`)
 - `replace(search, replace)` — replaces every occurrence of `search` with `replace` in each list item; supports escape sequences (`\n`, `\t`, `\r`, `\\`); arguments are split on the first `,`, so `search` cannot contain a literal comma (any commas after the first separator are preserved as part of `replace`)
+- `shell_quote()` — wraps each list item in POSIX single-quoted form for safe interpolation into shell commands; combines with `join(' ')` to produce a list of safe argv tokens
 - `if_not_empty()` — guard: empty input (`[]` or `['']`) becomes `[]`, non-empty passes through unchanged
 - `if_empty()` — inverse guard: non-empty input becomes `[]`, empty passes through unchanged
 - `format(template)` — formats a single value via `sprintf`; empty input (`[]`) passes through as `[]`; supports escape sequences (`\n`, `\t`, `\r`, `\\`)

--- a/DEV.md
+++ b/DEV.md
@@ -125,6 +125,7 @@ The DSL operates in stages:
 2. List-level actions:
    - `first` — picks the first element
    - `format_each`
+   - `shell_quote` — wraps each item in POSIX single quotes
 3. `join` reduces the list to a single value
 4. Conditional guards (optional, placed after `join`):
    - `if_not_empty` — drops empty values, enabling conditional block rendering
@@ -147,6 +148,10 @@ Final value formatting:
 Conditional block (rendered only when config key is non-empty):
 
 `<< config(psalm.project.files)|format_each('        <file name="%s" />')|join("\n")|if_not_empty()|format('<handler>\n%s\n</handler>') >>`
+
+Shell argv composition (safe interpolation of arbitrary values into a shell command):
+
+`<< config(phpunit.php_options)|shell_quote()|join(' ') >>`
 
 ---
 

--- a/src/Formula/Action/ShellQuoteAction.php
+++ b/src/Formula/Action/ShellQuoteAction.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Action;
+
+use Haspadar\Piqule\Formula\Args\Args;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Formula\Args\StringifiedArgs;
+use Override;
+
+/**
+ * Wraps each value in POSIX single-quoted form for safe shell interpolation.
+ */
+final readonly class ShellQuoteAction implements Action
+{
+    #[Override]
+    public function transformed(Args $args): Args
+    {
+        return new ListArgs(
+            array_map(
+                static fn(int|float|string|bool $item): string => sprintf(
+                    "'%s'",
+                    str_replace("'", "'\\''", (string) $item),
+                ),
+                (new StringifiedArgs($args))->values(),
+            ),
+        );
+    }
+}

--- a/src/Formula/Actions/FormulaActions.php
+++ b/src/Formula/Actions/FormulaActions.php
@@ -16,6 +16,7 @@ use Haspadar\Piqule\Formula\Action\IfEmptyAction;
 use Haspadar\Piqule\Formula\Action\IfNotEmptyAction;
 use Haspadar\Piqule\Formula\Action\JoinAction;
 use Haspadar\Piqule\Formula\Action\ReplaceAction;
+use Haspadar\Piqule\Formula\Action\ShellQuoteAction;
 use Haspadar\Piqule\PiquleException;
 
 /**
@@ -61,6 +62,10 @@ final readonly class FormulaActions
             },
             'join' => static fn(string $raw): Action => new JoinAction($raw),
             'replace' => static fn(string $raw): Action => new ReplaceAction($raw),
+            'shell_quote' => static fn(string $raw): Action => match (trim($raw)) {
+                '' => new ShellQuoteAction(),
+                default => throw new PiquleException('Action "shell_quote" does not accept arguments'),
+            },
         ];
     }
 }

--- a/tests/Integration/Formula/Action/ShellQuoteActionTest.php
+++ b/tests/Integration/Formula/Action/ShellQuoteActionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Integration\Formula\Action;
+
+use Haspadar\Piqule\Formula\Action\ShellQuoteAction;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ShellQuoteActionTest extends TestCase
+{
+    /** @return iterable<string, array{list<string>}> */
+    public static function payloads(): iterable
+    {
+        yield 'plain values' => [['red', 'green', 'blue']];
+        yield 'values with spaces' => [['hello world', 'foo bar baz']];
+        yield 'values with single quotes' => [["it's", "'quoted'"]];
+        yield 'values with dollar signs' => [['$HOME', '${PATH}']];
+        yield 'values with backticks' => [['`whoami`']];
+        yield 'values with backslashes' => [['a\\b', 'c\\\\d']];
+        yield 'mixed metacharacters' => [["a b", "c'd", '$e`f', 'g\\h']];
+        yield 'empty string alongside values' => [['a', '', 'b']];
+    }
+
+    #[Test]
+    #[DataProvider('payloads')]
+    public function survivesShellReparse(array $originals): void
+    {
+        $quoted = (new ShellQuoteAction())
+            ->transformed(new ListArgs($originals))
+            ->values();
+
+        $joined = implode(' ', array_map(static fn(int|float|string|bool $v): string => (string) $v, $quoted));
+
+        self::assertSame(
+            $originals,
+            self::reparsedByShell($joined),
+            'Joined quoted tokens must re-parse via shell back to the original values',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function reparsedByShell(string $joinedQuoted): array
+    {
+        $script = "printf '%s\\n' " . $joinedQuoted;
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open(['/bin/sh', '-c', $script], $descriptors, $pipes);
+
+        if (!is_resource($process)) {
+            throw new RuntimeException('Failed to launch /bin/sh');
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        if ($exitCode !== 0) {
+            throw new RuntimeException(sprintf('Shell exited with %d: %s', $exitCode, (string) $stderr));
+        }
+
+        $output = (string) $stdout;
+
+        if ($output === '') {
+            return [];
+        }
+
+        $lines = explode("\n", rtrim($output, "\n"));
+
+        return array_values($lines);
+    }
+}

--- a/tests/Unit/File/ConfiguredFileTest.php
+++ b/tests/Unit/File/ConfiguredFileTest.php
@@ -259,6 +259,21 @@ final class ConfiguredFileTest extends TestCase
     }
 
     #[Test]
+    public function throwsWhenShellQuoteReceivesArguments(): void
+    {
+        $this->expectException(PiquleException::class);
+        $this->expectExceptionMessage('Action "shell_quote" does not accept arguments');
+
+        (new ConfiguredFile(
+            new TextFile(
+                'file',
+                '<< config(shellcheck.shell)|shell_quote(something) >>',
+            ),
+            $this->actions(new OverrideConfig(new DefaultConfig(), [])),
+        ))->contents();
+    }
+
+    #[Test]
     public function acceptsWhitespaceOnlyArgumentForFirst(): void
     {
         self::assertThat(

--- a/tests/Unit/Formula/Action/ShellQuoteActionTest.php
+++ b/tests/Unit/Formula/Action/ShellQuoteActionTest.php
@@ -110,4 +110,15 @@ final class ShellQuoteActionTest extends TestCase
             'ShellQuoteAction must quote each list element independently',
         );
     }
+
+    #[Test]
+    public function coercesScalarsToQuotedStrings(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs([42, true, false])),
+            new HasArgsValues(["'42'", "'true'", "'false'"]),
+            'ShellQuoteAction must stringify scalars via StringifiedArgs before quoting',
+        );
+    }
 }

--- a/tests/Unit/Formula/Action/ShellQuoteActionTest.php
+++ b/tests/Unit/Formula/Action/ShellQuoteActionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Action;
+
+use Haspadar\Piqule\Formula\Action\ShellQuoteAction;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsValues;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ShellQuoteActionTest extends TestCase
+{
+    #[Test]
+    public function quotesPlainValue(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs(['value'])),
+            new HasArgsValues(["'value'"]),
+            'ShellQuoteAction must wrap a plain value in single quotes',
+        );
+    }
+
+    #[Test]
+    public function preservesSpacesInsideQuotes(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs(['hello world'])),
+            new HasArgsValues(["'hello world'"]),
+            'ShellQuoteAction must keep spaces intact inside single quotes',
+        );
+    }
+
+    #[Test]
+    public function escapesEmbeddedSingleQuote(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs(["it's"])),
+            new HasArgsValues(["'it'\\''s'"]),
+            "ShellQuoteAction must replace embedded ' with '\\'' to keep POSIX quoting",
+        );
+    }
+
+    #[Test]
+    public function leavesDollarSignLiteral(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs(['$HOME'])),
+            new HasArgsValues(["'\$HOME'"]),
+            'ShellQuoteAction must keep $ literal because single quotes suppress expansion',
+        );
+    }
+
+    #[Test]
+    public function leavesBacktickLiteral(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs(['`pwd`'])),
+            new HasArgsValues(["'`pwd`'"]),
+            'ShellQuoteAction must keep backticks literal because single quotes suppress command substitution',
+        );
+    }
+
+    #[Test]
+    public function leavesBackslashLiteral(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs(['a\\b'])),
+            new HasArgsValues(["'a\\b'"]),
+            'ShellQuoteAction must keep a backslash literal inside single quotes',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyQuotedTokenForEmptyString(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs([''])),
+            new HasArgsValues(["''"]),
+            'ShellQuoteAction must render empty string as a quoted empty token',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenInputIsEmpty(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs([])),
+            new HasArgsValues([]),
+            'ShellQuoteAction must return empty list when no values are provided',
+        );
+    }
+
+    #[Test]
+    public function quotesEachListElementSeparately(): void
+    {
+        self::assertThat(
+            (new ShellQuoteAction())
+                ->transformed(new ListArgs(['a b', "c'd", 'e'])),
+            new HasArgsValues(["'a b'", "'c'\\''d'", "'e'"]),
+            'ShellQuoteAction must quote each list element independently',
+        );
+    }
+}


### PR DESCRIPTION
- Added ShellQuoteAction that wraps each value in POSIX single-quoted form
- Registered shell_quote in the DSL action map and documented it in DEV.md
- Added tests covering special characters, scalar coercion, and argument rejection

Closes #629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `shell_quote()` action to safely convert list values into POSIX single-quoted shell-safe strings. When combined with `join()`, it produces properly escaped command-line arguments for shell execution.

* **Documentation**
  * Added documentation for the `shell_quote()` placeholder action, detailing its behavior and use cases for shell command construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->