### PR TITLE
JSON-Safe Interpolation Filter

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -127,6 +127,7 @@ The DSL operates in stages:
    - `first` — picks the first element
    - `format_each`
    - `shell_quote` — wraps each item in POSIX single quotes
+   - `json_escape` — escapes each item for a JSON string literal
 3. `join` reduces the list to a single value
 4. Conditional guards (optional, placed after `join`):
    - `if_not_empty` — drops empty values, enabling conditional block rendering
@@ -153,6 +154,10 @@ Conditional block (rendered only when config key is non-empty):
 Shell argv composition (safe interpolation of arbitrary values into a shell command):
 
 `<< config(phpunit.php_options)|shell_quote()|join(' ') >>`
+
+JSON string interpolation (safe insertion of arbitrary values into a JSON string literal):
+
+`"description": "<< config(project.description)|json_escape()|join("") >>"`
 
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -113,6 +113,7 @@ Example:
 - `join(delimiter)` — reduces the list to a single scalar value; supports escape sequences (`\n`, `\t`, `\r`, `\\`)
 - `replace(search, replace)` — replaces every occurrence of `search` with `replace` in each list item; supports escape sequences (`\n`, `\t`, `\r`, `\\`); arguments are split on the first `,`, so `search` cannot contain a literal comma (any commas after the first separator are preserved as part of `replace`)
 - `shell_quote()` — wraps each list item in POSIX single-quoted form for safe interpolation into shell commands; combines with `join(' ')` to produce a list of safe argv tokens
+- `json_escape()` — escapes each list item for safe interpolation inside a JSON string literal (quotes, backslashes, control chars become escape sequences); does not add surrounding quotes
 - `if_not_empty()` — guard: empty input (`[]` or `['']`) becomes `[]`, non-empty passes through unchanged
 - `if_empty()` — inverse guard: non-empty input becomes `[]`, empty passes through unchanged
 - `format(template)` — formats a single value via `sprintf`; empty input (`[]`) passes through as `[]`; supports escape sequences (`\n`, `\t`, `\r`, `\\`)

--- a/src/Formula/Action/JsonEscapeAction.php
+++ b/src/Formula/Action/JsonEscapeAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Formula\Action;
+
+use Haspadar\Piqule\Formula\Args\Args;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Formula\Args\StringifiedArgs;
+use Override;
+
+/**
+ * Escapes each value for safe interpolation inside a JSON string literal.
+ */
+final readonly class JsonEscapeAction implements Action
+{
+    #[Override]
+    public function transformed(Args $args): Args
+    {
+        return new ListArgs(
+            array_map(
+                static fn(int|float|string|bool $item): string => (string) preg_replace(
+                    '/^"|"$/',
+                    '',
+                    (string) json_encode((string) $item, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                ),
+                (new StringifiedArgs($args))->values(),
+            ),
+        );
+    }
+}

--- a/src/Formula/Action/JsonEscapeAction.php
+++ b/src/Formula/Action/JsonEscapeAction.php
@@ -7,6 +7,8 @@ namespace Haspadar\Piqule\Formula\Action;
 use Haspadar\Piqule\Formula\Args\Args;
 use Haspadar\Piqule\Formula\Args\ListArgs;
 use Haspadar\Piqule\Formula\Args\StringifiedArgs;
+use InvalidArgumentException;
+use JsonException;
 use Override;
 
 /**
@@ -17,15 +19,26 @@ final readonly class JsonEscapeAction implements Action
     #[Override]
     public function transformed(Args $args): Args
     {
-        return new ListArgs(
-            array_map(
-                static fn(int|float|string|bool $item): string => (string) preg_replace(
-                    '/^"|"$/',
-                    '',
-                    (string) json_encode((string) $item, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        try {
+            return new ListArgs(
+                array_map(
+                    static fn(int|float|string|bool $item): string => (string) preg_replace(
+                        '/^"|"$/',
+                        '',
+                        json_encode(
+                            (string) $item,
+                            JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
+                        ),
+                    ),
+                    (new StringifiedArgs($args))->values(),
                 ),
-                (new StringifiedArgs($args))->values(),
-            ),
-        );
+            );
+        } catch (JsonException $exception) {
+            throw new InvalidArgumentException(
+                sprintf('Cannot JSON-encode value: %s', $exception->getMessage()),
+                0,
+                $exception,
+            );
+        }
     }
 }

--- a/src/Formula/Actions/FormulaActions.php
+++ b/src/Formula/Actions/FormulaActions.php
@@ -15,6 +15,7 @@ use Haspadar\Piqule\Formula\Action\FormatEachAction;
 use Haspadar\Piqule\Formula\Action\IfEmptyAction;
 use Haspadar\Piqule\Formula\Action\IfNotEmptyAction;
 use Haspadar\Piqule\Formula\Action\JoinAction;
+use Haspadar\Piqule\Formula\Action\JsonEscapeAction;
 use Haspadar\Piqule\Formula\Action\ReplaceAction;
 use Haspadar\Piqule\Formula\Action\ShellQuoteAction;
 use Haspadar\Piqule\PiquleException;
@@ -61,6 +62,10 @@ final readonly class FormulaActions
                 default => throw new PiquleException('Action "if_not_empty" does not accept arguments'),
             },
             'join' => static fn(string $raw): Action => new JoinAction($raw),
+            'json_escape' => static fn(string $raw): Action => match (trim($raw)) {
+                '' => new JsonEscapeAction(),
+                default => throw new PiquleException('Action "json_escape" does not accept arguments'),
+            },
             'replace' => static fn(string $raw): Action => new ReplaceAction($raw),
             'shell_quote' => static fn(string $raw): Action => match (trim($raw)) {
                 '' => new ShellQuoteAction(),

--- a/tests/Integration/Formula/Action/JsonEscapeActionTest.php
+++ b/tests/Integration/Formula/Action/JsonEscapeActionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Integration\Formula\Action;
+
+use Haspadar\Piqule\Formula\Action\JsonEscapeAction;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class JsonEscapeActionTest extends TestCase
+{
+    /** @return iterable<string, array{string}> */
+    public static function payloads(): iterable
+    {
+        yield 'plain value' => ['hello'];
+        yield 'value with spaces' => ['hello world'];
+        yield 'value with double quotes' => ['say "hi"'];
+        yield 'value with backslash' => ['a\\b'];
+        yield 'value with newline' => ["line1\nline2"];
+        yield 'value with tab' => ["a\tb"];
+        yield 'value with control char' => ["bell\x07here"];
+        yield 'non-ASCII value' => ['привет'];
+        yield 'forward slash' => ['path/to/file'];
+        yield 'empty string' => [''];
+    }
+
+    #[Test]
+    #[DataProvider('payloads')]
+    public function roundTripsThroughJsonDecoder(string $original): void
+    {
+        $escaped = (new JsonEscapeAction())
+            ->transformed(new ListArgs([$original]))
+            ->values()[0];
+
+        $decoded = json_decode(sprintf('"%s"', $escaped), false, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_string($decoded)) {
+            throw new RuntimeException('Decoded JSON value must be a string');
+        }
+
+        self::assertSame(
+            $original,
+            $decoded,
+            'Escaped value wrapped in double quotes must json_decode back to the original',
+        );
+    }
+}

--- a/tests/Integration/Formula/Action/JsonEscapeActionTest.php
+++ b/tests/Integration/Formula/Action/JsonEscapeActionTest.php
@@ -24,6 +24,8 @@ final class JsonEscapeActionTest extends TestCase
         yield 'value with tab' => ["a\tb"];
         yield 'value with control char' => ["bell\x07here"];
         yield 'non-ASCII value' => ['привет'];
+        yield 'line separator' => ["a\u{2028}b"];
+        yield 'paragraph separator' => ["a\u{2029}b"];
         yield 'forward slash' => ['path/to/file'];
         yield 'empty string' => [''];
     }

--- a/tests/Unit/File/ConfiguredFileTest.php
+++ b/tests/Unit/File/ConfiguredFileTest.php
@@ -274,6 +274,21 @@ final class ConfiguredFileTest extends TestCase
     }
 
     #[Test]
+    public function throwsWhenJsonEscapeReceivesArguments(): void
+    {
+        $this->expectException(PiquleException::class);
+        $this->expectExceptionMessage('Action "json_escape" does not accept arguments');
+
+        (new ConfiguredFile(
+            new TextFile(
+                'file',
+                '<< config(shellcheck.shell)|json_escape(something) >>',
+            ),
+            $this->actions(new OverrideConfig(new DefaultConfig(), [])),
+        ))->contents();
+    }
+
+    #[Test]
     public function acceptsWhitespaceOnlyArgumentForFirst(): void
     {
         self::assertThat(

--- a/tests/Unit/Formula/Action/JsonEscapeActionTest.php
+++ b/tests/Unit/Formula/Action/JsonEscapeActionTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Formula\Action;
+
+use Haspadar\Piqule\Formula\Action\JsonEscapeAction;
+use Haspadar\Piqule\Formula\Args\ListArgs;
+use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsValues;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonEscapeActionTest extends TestCase
+{
+    #[Test]
+    public function leavesPlainValueUnchanged(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(['value'])),
+            new HasArgsValues(['value']),
+            'JsonEscapeAction must leave values without special characters intact',
+        );
+    }
+
+    #[Test]
+    public function escapesDoubleQuote(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(['say "hi"'])),
+            new HasArgsValues(['say \\"hi\\"']),
+            'JsonEscapeAction must escape double quotes with backslash',
+        );
+    }
+
+    #[Test]
+    public function escapesBackslash(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(['a\\b'])),
+            new HasArgsValues(['a\\\\b']),
+            'JsonEscapeAction must double a backslash',
+        );
+    }
+
+    #[Test]
+    public function escapesNewline(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(["line1\nline2"])),
+            new HasArgsValues(['line1\\nline2']),
+            'JsonEscapeAction must convert newline to \\n escape sequence',
+        );
+    }
+
+    #[Test]
+    public function escapesTab(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(["a\tb"])),
+            new HasArgsValues(['a\\tb']),
+            'JsonEscapeAction must convert tab to \\t escape sequence',
+        );
+    }
+
+    #[Test]
+    public function escapesCarriageReturn(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(["a\rb"])),
+            new HasArgsValues(['a\\rb']),
+            'JsonEscapeAction must convert carriage return to \\r escape sequence',
+        );
+    }
+
+    #[Test]
+    public function escapesControlCharacterAsUnicodeEscape(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(["bell\x07here"])),
+            new HasArgsValues(['bell\\u0007here']),
+            'JsonEscapeAction must encode control characters as \\uXXXX',
+        );
+    }
+
+    #[Test]
+    public function preservesNonAsciiLiteral(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(['привет'])),
+            new HasArgsValues(['привет']),
+            'JsonEscapeAction must keep non-ASCII characters as valid UTF-8',
+        );
+    }
+
+    #[Test]
+    public function keepsForwardSlashLiteral(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(['path/to/file'])),
+            new HasArgsValues(['path/to/file']),
+            'JsonEscapeAction must keep forward slashes unescaped to avoid \\/ noise',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyStringForEmptyInput(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs([''])),
+            new HasArgsValues(['']),
+            'JsonEscapeAction must render empty string as empty JSON string content',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenInputIsEmpty(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs([])),
+            new HasArgsValues([]),
+            'JsonEscapeAction must return empty list when no values are provided',
+        );
+    }
+
+    #[Test]
+    public function escapesEachListElementSeparately(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(['a"b', "c\nd", 'e'])),
+            new HasArgsValues(['a\\"b', 'c\\nd', 'e']),
+            'JsonEscapeAction must escape each list element independently',
+        );
+    }
+
+    #[Test]
+    public function coercesScalarsToEscapedStrings(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs([42, true, false])),
+            new HasArgsValues(['42', 'true', 'false']),
+            'JsonEscapeAction must stringify scalars via StringifiedArgs before escaping',
+        );
+    }
+}

--- a/tests/Unit/Formula/Action/JsonEscapeActionTest.php
+++ b/tests/Unit/Formula/Action/JsonEscapeActionTest.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Tests\Unit\Formula\Action;
 use Haspadar\Piqule\Formula\Action\JsonEscapeAction;
 use Haspadar\Piqule\Formula\Args\ListArgs;
 use Haspadar\Piqule\Tests\Constraint\Formula\Args\HasArgsValues;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -175,5 +176,14 @@ final class JsonEscapeActionTest extends TestCase
             new HasArgsValues(['42', 'true', 'false']),
             'JsonEscapeAction must stringify scalars via StringifiedArgs before escaping',
         );
+    }
+
+    #[Test]
+    public function throwsWhenInputContainsMalformedUtf8(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot JSON-encode value:');
+
+        (new JsonEscapeAction())->transformed(new ListArgs(["\xB1\x31"]));
     }
 }

--- a/tests/Unit/Formula/Action/JsonEscapeActionTest.php
+++ b/tests/Unit/Formula/Action/JsonEscapeActionTest.php
@@ -90,6 +90,28 @@ final class JsonEscapeActionTest extends TestCase
     }
 
     #[Test]
+    public function escapesLineSeparatorAsUnicodeEscape(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(["a\u{2028}b"])),
+            new HasArgsValues(['a\\u2028b']),
+            'JsonEscapeAction must encode U+2028 as \\u2028 to remain safe inside JSON5 string literals',
+        );
+    }
+
+    #[Test]
+    public function escapesParagraphSeparatorAsUnicodeEscape(): void
+    {
+        self::assertThat(
+            (new JsonEscapeAction())
+                ->transformed(new ListArgs(["a\u{2029}b"])),
+            new HasArgsValues(['a\\u2029b']),
+            'JsonEscapeAction must encode U+2029 as \\u2029 to remain safe inside JSON5 string literals',
+        );
+    }
+
+    #[Test]
     public function preservesNonAsciiLiteral(): void
     {
         self::assertThat(


### PR DESCRIPTION
- Added json_escape action that escapes scalar values for JSON string literals
- Added arg rejection for json_escape in configured files
- Added round-trip integration test through JSON decoder
- Updated DEV.md with json_escape in supported actions, semantics, and examples

Closes #630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added json_escape() action to safely escape values for interpolation inside JSON string literals.

* **Documentation**
  * Updated docs with description, semantics, and an example showing json_escape usage in JSON.

* **Tests**
  * Added unit and integration tests covering escaping rules, scalar coercion, collection behavior, Unicode/control handling, and rejection of arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->