### PR TITLE
Install piqule rules into agent files

### DIFF
--- a/bin/piqule
+++ b/bin/piqule
@@ -26,8 +26,11 @@ case "$COMMAND" in
     "$(dirname "$0")/piqule-${COMMAND}" "$@"
     "$(dirname "$0")/piqule-tokens-check"
     ;;
+  agent-rules-install)
+    "$(dirname "$0")/piqule-agent-rules-install" "$@"
+    ;;
   *)
-    echo "Usage: piqule [sync|check|fix]"
+    echo "Usage: piqule [sync|check|fix|agent-rules-install]"
     exit 1
     ;;
 esac

--- a/bin/piqule
+++ b/bin/piqule
@@ -19,12 +19,14 @@ case "$COMMAND" in
     "$(dirname "$0")/piqule-sync" "$@"
     "$(dirname "$0")/piqule-pin"
     "$(dirname "$0")/piqule-tokens-check"
+    "$(dirname "$0")/piqule-agent-rules-check"
     ;;
   check|fix)
     ensure_project_root
     "$(dirname "$0")/piqule-verify"
     "$(dirname "$0")/piqule-${COMMAND}" "$@"
     "$(dirname "$0")/piqule-tokens-check"
+    "$(dirname "$0")/piqule-agent-rules-check"
     ;;
   agent-rules-install)
     "$(dirname "$0")/piqule-agent-rules-install" "$@"

--- a/bin/piqule-agent-rules-check
+++ b/bin/piqule-agent-rules-check
@@ -1,0 +1,39 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Haspadar\Piqule\Output\Console;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Storage\DiskStorage;
+
+require_once __DIR__ . '/bootstrap-autoload.php';
+
+const AGENT_MARKER = '<!-- piqule:begin -->';
+const AGENT_FILES = ['CLAUDE.md', 'AGENTS.md'];
+
+$output = new Console();
+
+$projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
+
+try {
+    $disk = new DiskStorage($projectRoot);
+
+    foreach (AGENT_FILES as $name) {
+        if (!$disk->exists($name)) {
+            continue;
+        }
+
+        if (str_contains($disk->read($name), AGENT_MARKER)) {
+            continue;
+        }
+
+        $output->info(sprintf(
+            '[AGENT] %s has no piqule section. Run: vendor/bin/piqule agent-rules-install',
+            $name,
+        ));
+    }
+} catch (PiquleException $e) {
+    $output->error($e->getMessage());
+    exit(1);
+}

--- a/bin/piqule-agent-rules-check
+++ b/bin/piqule-agent-rules-check
@@ -14,9 +14,10 @@ const AGENT_FILES = ['CLAUDE.md', 'AGENTS.md'];
 
 $output = new Console();
 
-$projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
-
 try {
+    $projectRoot = getcwd()
+        ?: throw new PiquleException('Cannot determine current working directory');
+
     $disk = new DiskStorage($projectRoot);
 
     foreach (AGENT_FILES as $name) {

--- a/bin/piqule-agent-rules-install
+++ b/bin/piqule-agent-rules-install
@@ -1,0 +1,63 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Composer\InstalledVersions;
+use Haspadar\Piqule\File\TextFile;
+use Haspadar\Piqule\Output\Console;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Storage\AppendingStorage;
+use Haspadar\Piqule\Storage\DiskStorage;
+use Haspadar\Piqule\Storage\Reaction\ReportingStorageReaction;
+use Haspadar\Piqule\Storage\Reaction\StorageReactions;
+
+require_once __DIR__ . '/bootstrap-autoload.php';
+
+const AGENT_MARKER = '<!-- piqule:begin -->';
+const AGENT_FILES = ['CLAUDE.md', 'AGENTS.md'];
+
+$output = new Console();
+
+try {
+    $projectRoot = getcwd()
+        ?: throw new PiquleException('Cannot determine current working directory');
+
+    $installPath = InstalledVersions::getInstallPath('haspadar/piqule');
+
+    if ($installPath === null || $installPath === '') {
+        throw new PiquleException('Cannot determine piqule install path');
+    }
+
+    $sectionPath = $installPath . '/templates/agent/section.md';
+    $section = file_get_contents($sectionPath);
+
+    if ($section === false) {
+        throw new PiquleException("Unable to read section template: {$sectionPath}");
+    }
+
+    $disk = new DiskStorage($projectRoot);
+    $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
+    $storage = new AppendingStorage($disk, $reactions, AGENT_MARKER);
+
+    $touched = 0;
+
+    foreach (AGENT_FILES as $name) {
+        if (!$disk->exists($name)) {
+            continue;
+        }
+
+        $storage->write(new TextFile($name, $section, $disk->mode($name)));
+        $touched += 1;
+    }
+
+    if ($touched === 0) {
+        $output->info(
+            'No agent files found (CLAUDE.md, AGENTS.md). '
+            . 'Create one of these manually and re-run `piqule agent-rules-install`.',
+        );
+    }
+} catch (PiquleException $e) {
+    $output->error($e->getMessage());
+    exit(1);
+}

--- a/templates/agent/section.md
+++ b/templates/agent/section.md
@@ -1,0 +1,5 @@
+<!-- piqule:begin -->
+## Piqule
+
+Quality tooling is managed by [piqule](https://github.com/haspadar/piqule). Run `vendor/bin/piqule check` before commits and `vendor/bin/piqule fix` for auto-fixes. Do not edit generated files in `.piqule/` and `.github/workflows/`. Rules live in `vendor/haspadar/piqule/DEV.md`.
+<!-- piqule:end -->

--- a/tests/Integration/AgentRules/AgentRulesCheckTest.php
+++ b/tests/Integration/AgentRules/AgentRulesCheckTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Integration\AgentRules;
+
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function proc_close;
+use function proc_open;
+
+final class AgentRulesCheckTest extends TestCase
+{
+    private const string SCRIPT = __DIR__ . '/../../../bin/piqule-agent-rules-check';
+
+    private const string MARKER = '<!-- piqule:begin -->';
+
+    #[Test]
+    public function staysSilentWhenNoAgentFilePresent(): void
+    {
+        $folder = new TempFolder();
+
+        try {
+            self::assertSame(
+                '',
+                $this->runStdout($folder->path()),
+                'no output must be produced when no agent files exist',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function hintsWhenClaudeExistsWithoutMarker(): void
+    {
+        $folder = (new TempFolder())->withFile('CLAUDE.md', "# Project rules\n");
+
+        try {
+            self::assertStringContainsString(
+                'piqule agent-rules-install',
+                $this->runStdout($folder->path()),
+                'hint to run agent-rules-install must be printed when CLAUDE.md has no piqule marker',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function namesFileInHintWhenMarkerMissing(): void
+    {
+        $folder = (new TempFolder())->withFile('AGENTS.md', "# Agents\n");
+
+        try {
+            self::assertStringContainsString(
+                'AGENTS.md',
+                $this->runStdout($folder->path()),
+                'hint must reference the specific agent file missing the marker',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function staysSilentWhenMarkerAlreadyPresent(): void
+    {
+        $content = "# Project rules\n" . self::MARKER . "\n<!-- piqule:end -->\n";
+        $folder = (new TempFolder())->withFile('CLAUDE.md', $content);
+
+        try {
+            self::assertSame(
+                '',
+                $this->runStdout($folder->path()),
+                'no hint must be printed when piqule marker is already present',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    private function runStdout(string $cwd): string
+    {
+        $proc = proc_open(
+            [PHP_BINARY, self::SCRIPT],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $cwd,
+        );
+
+        if (!is_resource($proc)) {
+            self::fail('Failed to start piqule-agent-rules-check subprocess');
+        }
+
+        fclose($pipes[0]);
+        $stdout = (string) stream_get_contents($pipes[1]);
+        stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($proc);
+
+        return preg_replace('/\033\[[0-9;]*m/', '', $stdout) ?? $stdout;
+    }
+}

--- a/tests/Integration/AgentRules/AgentRulesInstallTest.php
+++ b/tests/Integration/AgentRules/AgentRulesInstallTest.php
@@ -18,22 +18,6 @@ final class AgentRulesInstallTest extends TestCase
     private const string MARKER = '<!-- piqule:begin -->';
 
     #[Test]
-    public function skipsWhenNoAgentFilePresent(): void
-    {
-        $folder = new TempFolder();
-
-        try {
-            self::assertSame(
-                0,
-                $this->runScript($folder->path()),
-                'exit code must be 0 when no agent files exist in project root',
-            );
-        } finally {
-            $folder->close();
-        }
-    }
-
-    #[Test]
     public function leavesDirectoryUntouchedWhenNoAgentFilePresent(): void
     {
         $folder = new TempFolder();
@@ -123,7 +107,7 @@ final class AgentRulesInstallTest extends TestCase
         }
     }
 
-    private function runScript(string $cwd): int
+    private function runScript(string $cwd): void
     {
         $proc = proc_open(
             [PHP_BINARY, self::SCRIPT],
@@ -138,10 +122,17 @@ final class AgentRulesInstallTest extends TestCase
 
         fclose($pipes[0]);
         stream_get_contents($pipes[1]);
-        stream_get_contents($pipes[2]);
+        $stderr = (string) stream_get_contents($pipes[2]);
         fclose($pipes[1]);
         fclose($pipes[2]);
+        $exitCode = proc_close($proc);
 
-        return proc_close($proc);
+        if ($exitCode !== 0) {
+            self::fail(sprintf(
+                'piqule-agent-rules-install exited with code %d: %s',
+                $exitCode,
+                $stderr,
+            ));
+        }
     }
 }

--- a/tests/Integration/AgentRules/AgentRulesInstallTest.php
+++ b/tests/Integration/AgentRules/AgentRulesInstallTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Integration\AgentRules;
+
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function proc_close;
+use function proc_open;
+
+final class AgentRulesInstallTest extends TestCase
+{
+    private const string SCRIPT = __DIR__ . '/../../../bin/piqule-agent-rules-install';
+
+    private const string MARKER = '<!-- piqule:begin -->';
+
+    #[Test]
+    public function skipsWhenNoAgentFilePresent(): void
+    {
+        $folder = new TempFolder();
+
+        try {
+            self::assertSame(
+                0,
+                $this->runScript($folder->path()),
+                'exit code must be 0 when no agent files exist in project root',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function leavesDirectoryUntouchedWhenNoAgentFilePresent(): void
+    {
+        $folder = new TempFolder();
+
+        try {
+            $this->runScript($folder->path());
+
+            self::assertFalse(
+                file_exists($folder->path() . '/CLAUDE.md'),
+                'CLAUDE.md must not be created when the user has no agent file',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function appendsSectionToClaudeWhenMarkerAbsent(): void
+    {
+        $folder = (new TempFolder())->withFile('CLAUDE.md', "# Project rules\nKeep tests green.\n");
+
+        try {
+            $this->runScript($folder->path());
+
+            self::assertStringContainsString(
+                self::MARKER,
+                (string) file_get_contents($folder->path() . '/CLAUDE.md'),
+                'piqule section must be appended to CLAUDE.md when marker is missing',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function preservesUserContentWhenAppendingToClaude(): void
+    {
+        $folder = (new TempFolder())->withFile('CLAUDE.md', "# Project rules\nKeep tests green.\n");
+
+        try {
+            $this->runScript($folder->path());
+
+            self::assertStringContainsString(
+                '# Project rules',
+                (string) file_get_contents($folder->path() . '/CLAUDE.md'),
+                'existing user content must be preserved when section is appended',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function leavesClaudeUnchangedWhenMarkerAlreadyPresent(): void
+    {
+        $original = "# Project rules\n" . self::MARKER . "\nstale content\n<!-- piqule:end -->\n";
+        $folder = (new TempFolder())->withFile('CLAUDE.md', $original);
+
+        try {
+            $this->runScript($folder->path());
+
+            self::assertSame(
+                $original,
+                (string) file_get_contents($folder->path() . '/CLAUDE.md'),
+                'CLAUDE.md must stay untouched when piqule marker is already present',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function appendsSectionToAgentsWhenMarkerAbsent(): void
+    {
+        $folder = (new TempFolder())->withFile('AGENTS.md', "# Agents\n");
+
+        try {
+            $this->runScript($folder->path());
+
+            self::assertStringContainsString(
+                self::MARKER,
+                (string) file_get_contents($folder->path() . '/AGENTS.md'),
+                'piqule section must be appended to AGENTS.md when marker is missing',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    private function runScript(string $cwd): int
+    {
+        $proc = proc_open(
+            [PHP_BINARY, self::SCRIPT],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $cwd,
+        );
+
+        if (!is_resource($proc)) {
+            self::fail('Failed to start piqule-agent-rules-install subprocess');
+        }
+
+        fclose($pipes[0]);
+        stream_get_contents($pipes[1]);
+        stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return proc_close($proc);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `piqule agent-rules-install` — embeds a small piqule section into an existing `CLAUDE.md` or `AGENTS.md`. Never creates the file itself.
- Add `piqule agent-rules-check` — run after `sync`/`check`/`fix`, prints a hint when an agent file exists without the piqule section. Silent otherwise.
- Ship a short section template pointing to `vendor/haspadar/piqule/DEV.md` for the full rules.

Consumers can now surface piqule's workflow rules to their AI agents without copy-pasting from the README.

## Test plan

- [x] `bin/piqule check` — all 14 checks green locally
- [x] `bin/piqule check infection` — mutation testing green
- [x] Integration tests cover: no agent file (skip), marker absent (append), marker present (no-op), `AGENTS.md` path
- [x] Manual sandbox run: first install appends section, re-run is a no-op, check stays silent when marker is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `agent-rules-install` command to set up agent configuration files.
  * Added automatic `agent-rules-check` execution during sync and check/fix workflows.
  * Added template documentation for agent rules configuration.

* **Tests**
  * Added integration tests for agent rules commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->