### PR TITLE
Update infra image digest

### DIFF
--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:c8bba3dd36290d89d3c8f7cfad24071b3435fa447050ff70251bf053cea6a28c}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:5dc15e7dba7dbb8ec6060d01e40858947dcaa902e5af8b64921beef3fe63611f}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -32,7 +32,7 @@ defaults:
   coderabbit.cloud: true
   coderabbit.cli: false
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:c8bba3dd36290d89d3c8f7cfad24071b3435fa447050ff70251bf053cea6a28c"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:5dc15e7dba7dbb8ec6060d01e40858947dcaa902e5af8b64921beef3fe63611f"
 
   actionlint.cli: true
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -32,7 +32,7 @@ defaults:
   coderabbit.cloud: true
   coderabbit.cli: false
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:c8bba3dd36290d89d3c8f7cfad24071b3435fa447050ff70251bf053cea6a28c"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:5dc15e7dba7dbb8ec6060d01e40858947dcaa902e5af8b64921beef3fe63611f"
 
   actionlint.cli: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:5dc15e7dba7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker infrastructure container images across the tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->