### PR TITLE
Bump haspadar/phpstan-rules to 0.42.1

### DIFF
--- a/.piqule/sonar/command.sh
+++ b/.piqule/sonar/command.sh
@@ -37,7 +37,7 @@ else
 fi
 
 PROJECT_ROOT="$(pwd)"
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:c8bba3dd36290d89d3c8f7cfad24071b3435fa447050ff70251bf053cea6a28c}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:5dc15e7dba7dbb8ec6060d01e40858947dcaa902e5af8b64921beef3fe63611f}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.38.1",
+            "version": "v0.42.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "30ced28f65329d146dd02eb378aa11764b2771e9"
+                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/30ced28f65329d146dd02eb378aa11764b2771e9",
-                "reference": "30ced28f65329d146dd02eb378aa11764b2771e9",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/bc3aa5840c0b52b6208ea399ab94987f79463050",
+                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.38.1"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.42.1"
             },
-            "time": "2026-04-22T11:33:48+00:00"
+            "time": "2026-04-23T12:56:16+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/src/Check/CheckReport.php
+++ b/src/Check/CheckReport.php
@@ -13,10 +13,20 @@ final readonly class CheckReport
 {
     private const int TITLE_WIDTH = 20;
 
-    /** Initializes with output channel and total check count. */
+    /**
+     * Initializes with output channel and total check count.
+     *
+     * @param Output $output Channel to write progress messages to
+     * @param int $total Total number of checks in the run
+     */
     public function __construct(private Output $output, private int $total) {}
 
-    /** Reports a check starting. */
+    /**
+     * Reports a check starting.
+     *
+     * @param string $name Human-readable check name
+     * @param int $number One-based ordinal of this check within the run
+     */
     public function started(string $name, int $number): void
     {
         $this->output->muted(
@@ -26,7 +36,12 @@ final readonly class CheckReport
         );
     }
 
-    /** Reports a check that passed. */
+    /**
+     * Reports a check that passed.
+     *
+     * @param string $name Human-readable check name
+     * @param float $elapsed Wall-clock duration in seconds
+     */
     public function passed(string $name, float $elapsed): void
     {
         $this->output->success(
@@ -34,7 +49,12 @@ final readonly class CheckReport
         );
     }
 
-    /** Reports a check that failed. */
+    /**
+     * Reports a check that failed.
+     *
+     * @param string $name Human-readable check name
+     * @param float $elapsed Wall-clock duration in seconds
+     */
     public function failed(string $name, float $elapsed): void
     {
         $this->output->error(

--- a/src/Check/CheckResult.php
+++ b/src/Check/CheckResult.php
@@ -9,7 +9,13 @@ namespace Haspadar\Piqule\Check;
  */
 final readonly class CheckResult
 {
-    /** Initializes with exit status, captured output, and elapsed time. */
+    /**
+     * Initializes with exit status, captured output, and elapsed time.
+     *
+     * @param int $status Process exit status (0 means success)
+     * @param string $output Captured stdout and stderr combined
+     * @param float $elapsed Wall-clock duration in seconds
+     */
     public function __construct(
         private int $status,
         private string $output,

--- a/src/Check/CheckRun.php
+++ b/src/Check/CheckRun.php
@@ -11,7 +11,12 @@ use Haspadar\Piqule\PiquleException;
  */
 final readonly class CheckRun
 {
-    /** Initializes with the check to run and verbosity flag. */
+    /**
+     * Initializes with the check to run and verbosity flag.
+     *
+     * @param Check $check Check definition to execute
+     * @param CliOption $verbose When enabled, streams output instead of capturing
+     */
     public function __construct(private Check $check, private CliOption $verbose) {}
 
     /**

--- a/src/Check/ConfigCheck.php
+++ b/src/Check/ConfigCheck.php
@@ -15,7 +15,12 @@ use Override;
  */
 final readonly class ConfigCheck implements Check
 {
-    /** Initializes with the check name and project root path. */
+    /**
+     * Initializes with the check name and project root path.
+     *
+     * @param string $name Tool name matching the .piqule subdirectory
+     * @param string $root Absolute path to the project root directory
+     */
     public function __construct(private string $name, private string $root) {}
 
     #[Override]

--- a/src/Check/ConfigChecks.php
+++ b/src/Check/ConfigChecks.php
@@ -14,7 +14,12 @@ final readonly class ConfigChecks implements Checks
 {
     private const string CLI_SUFFIX = '.cli';
 
-    /** Initializes with project configuration and root path. */
+    /**
+     * Initializes with project configuration and root path.
+     *
+     * @param Config $config Configuration providing the set of ".cli" keys
+     * @param string $root Absolute path to the project root directory
+     */
     public function __construct(private Config $config, private string $root) {}
 
     #[Override]

--- a/src/Check/ConfigDefault.php
+++ b/src/Check/ConfigDefault.php
@@ -12,7 +12,12 @@ use Override;
  */
 final readonly class ConfigDefault implements CliOption
 {
-    /** Initializes with project configuration and the config key. */
+    /**
+     * Initializes with project configuration and the config key.
+     *
+     * @param Config $config Configuration to read the boolean value from
+     * @param string $key Dot-separated config key holding the boolean default
+     */
     public function __construct(private Config $config, private string $key) {}
 
     #[Override]

--- a/src/Check/ConfigOption.php
+++ b/src/Check/ConfigOption.php
@@ -11,7 +11,13 @@ use Override;
  */
 final readonly class ConfigOption implements CliOption
 {
-    /** Initializes with positive flag, negative flag, and default. */
+    /**
+     * Initializes with positive flag, negative flag, and default.
+     *
+     * @param CliOption $yes Flag that explicitly enables the option
+     * @param CliOption $off Flag that explicitly disables the option (wins over $yes)
+     * @param CliOption $default Fallback used when neither flag is set
+     */
     public function __construct(
         private CliOption $yes,
         private CliOption $off,

--- a/src/Check/ElapsedTime.php
+++ b/src/Check/ElapsedTime.php
@@ -11,7 +11,11 @@ final readonly class ElapsedTime
 {
     private const int SECONDS_PER_MINUTE = 60;
 
-    /** Initializes with elapsed seconds. */
+    /**
+     * Initializes with elapsed seconds.
+     *
+     * @param float $seconds Wall-clock duration to format
+     */
     public function __construct(private float $seconds) {}
 
     /** Formats as "1.2s" or "2m05s". */

--- a/src/Check/EnabledChecks.php
+++ b/src/Check/EnabledChecks.php
@@ -12,7 +12,12 @@ use Override;
  */
 final readonly class EnabledChecks implements Checks
 {
-    /** Initializes with a check collection and project configuration. */
+    /**
+     * Initializes with a check collection and project configuration.
+     *
+     * @param Checks $origin Underlying collection to filter
+     * @param Config $config Configuration holding the "<tool>.cli" toggles
+     */
     public function __construct(private Checks $origin, private Config $config) {}
 
     #[Override]

--- a/src/Check/FastChecks.php
+++ b/src/Check/FastChecks.php
@@ -12,7 +12,12 @@ use Override;
  */
 final readonly class FastChecks implements Checks
 {
-    /** Initializes with a check collection and project configuration. */
+    /**
+     * Initializes with a check collection and project configuration.
+     *
+     * @param Checks $origin Underlying collection to filter
+     * @param Config $config Configuration holding the "check.slow" key
+     */
     public function __construct(private Checks $origin, private Config $config) {}
 
     #[Override]

--- a/src/Check/ParallelRun.php
+++ b/src/Check/ParallelRun.php
@@ -23,7 +23,13 @@ final readonly class ParallelRun implements Runnable
         'infection' => ['phpunit'],
     ];
 
-    /** Initializes with checks, output channel, and verbosity option. */
+    /**
+     * Initializes with checks, output channel, and verbosity option.
+     *
+     * @param Checks $checks Checks to execute in parallel
+     * @param Output $output Channel to stream progress messages to
+     * @param CliOption $verbose When enabled, each check's output is streamed live
+     */
     public function __construct(
         private Checks $checks,
         private Output $output,
@@ -65,7 +71,9 @@ final readonly class ParallelRun implements Runnable
     /**
      * Launches a batch of checks and collects results.
      *
-     * @param list<Check> $checks
+     * @param list<Check> $checks Checks to launch together
+     * @param int $offset Ordinal offset of the first check in the overall run
+     * @param CheckReport $report Reporter used to announce starts and outcomes
      * @throws PiquleException
      */
     private function batch(array $checks, int $offset, CheckReport $report): bool
@@ -89,7 +97,8 @@ final readonly class ParallelRun implements Runnable
     /**
      * Collects results from running processes and reports each one.
      *
-     * @param list<array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float}> $handles
+     * @param list<array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float}> $handles Running process records produced by spawn()
+     * @param CheckReport $report Reporter used to announce outcomes
      * @throws PiquleException
      */
     private function collect(array $handles, CheckReport $report): bool
@@ -119,6 +128,7 @@ final readonly class ParallelRun implements Runnable
     /**
      * Spawns a check process.
      *
+     * @param Check $check Check to launch as a background process
      * @return array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float}|false
      */
     private function spawn(Check $check): array|false

--- a/src/Check/ProcessPool.php
+++ b/src/Check/ProcessPool.php
@@ -16,7 +16,7 @@ final readonly class ProcessPool
     /**
      * Waits for all processes to finish and yields each result.
      *
-     * @param list<array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float}> $handles
+     * @param list<array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float}> $handles Running process records to drain
      * @return iterable<array{check: Check, result: CheckResult, elapsed: float}>
      */
     public function results(array $handles): iterable
@@ -45,7 +45,9 @@ final readonly class ProcessPool
     /**
      * Closes a finished process and returns its result.
      *
-     * @param array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float} $handle
+     * @param array{proc: resource, stdout: resource, stderr: resource, check: Check, start: float} $handle Process record to finalize
+     * @param int $code Reported exit code (negative means unknown)
+     * @param float $elapsed Wall-clock duration in seconds
      * @return array{check: Check, result: CheckResult, elapsed: float}
      */
     private function collect(array $handle, int $code, float $elapsed): array

--- a/src/Check/RequestedCheck.php
+++ b/src/Check/RequestedCheck.php
@@ -18,7 +18,7 @@ final readonly class RequestedCheck
     /**
      * Initializes with the CLI argument list.
      *
-     * @param list<string> $argv
+     * @param list<string> $argv Raw CLI argument vector, including the script name
      */
     public function __construct(private array $argv) {}
 

--- a/src/Check/SequentialRun.php
+++ b/src/Check/SequentialRun.php
@@ -14,7 +14,13 @@ use Override;
  */
 final readonly class SequentialRun implements Runnable
 {
-    /** Initializes with checks, output channel, and verbosity option. */
+    /**
+     * Initializes with checks, output channel, and verbosity option.
+     *
+     * @param Checks $checks Checks to execute in order
+     * @param Output $output Channel to stream progress messages to
+     * @param CliOption $verbose When enabled, each check's output is streamed live
+     */
     public function __construct(
         private Checks $checks,
         private Output $output,

--- a/src/Check/SingleCheck.php
+++ b/src/Check/SingleCheck.php
@@ -11,7 +11,12 @@ use Override;
  */
 final readonly class SingleCheck implements Checks
 {
-    /** Initializes with the check name and project root path. */
+    /**
+     * Initializes with the check name and project root path.
+     *
+     * @param string $name Tool name matching the .piqule subdirectory
+     * @param string $root Absolute path to the project root directory
+     */
     public function __construct(private string $name, private string $root) {}
 
     #[Override]

--- a/src/Check/ToggleOption.php
+++ b/src/Check/ToggleOption.php
@@ -14,8 +14,8 @@ final readonly class ToggleOption implements CliOption
     /**
      * Initializes with CLI arguments and flag variants.
      *
-     * @param list<string> $argv
-     * @param list<string> $flags
+     * @param list<string> $argv Raw CLI argument vector, including the script name
+     * @param list<string> $flags Flag aliases that activate this option when present in $argv
      */
     public function __construct(private array $argv, private array $flags) {}
 

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -22,7 +22,8 @@ final readonly class AppendConfig implements Config
     /**
      * Initializes with a base config and values to append.
      *
-     * @param array<string, mixed> $appends
+     * @param Config $defaults Underlying configuration to extend
+     * @param array<string, mixed> $appends Values to append to each matching list key
      */
     public function __construct(private Config $defaults, private array $appends) {}
 

--- a/src/Config/ComposerRootNamespace.php
+++ b/src/Config/ComposerRootNamespace.php
@@ -9,7 +9,11 @@ namespace Haspadar\Piqule\Config;
  */
 final readonly class ComposerRootNamespace
 {
-    /** Initializes with the composer.json file path. */
+    /**
+     * Initializes with the composer.json file path.
+     *
+     * @param string $path Absolute path to the composer.json file
+     */
     public function __construct(private string $path) {}
 
     /** Returns the first PSR-4 root namespace as a string. */

--- a/src/Config/ConfigPaths.php
+++ b/src/Config/ConfigPaths.php
@@ -9,7 +9,12 @@ namespace Haspadar\Piqule\Config;
  */
 final readonly class ConfigPaths
 {
-    /** Initializes with optional custom paths for composer.json and config.yaml. */
+    /**
+     * Initializes with optional custom paths for composer.json and config.yaml.
+     *
+     * @param string $composer Path to the project composer.json (empty means none)
+     * @param string $config Path to the piqule defaults YAML file
+     */
     public function __construct(
         private string $composer = '',
         private string $config = __DIR__ . '/../../templates/always/.piqule/config.yaml',

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -31,8 +31,9 @@ final readonly class DefaultConfig implements Config
     /**
      * Initializes with source directories, exclusions, and config paths.
      *
-     * @param list<string> $source
-     * @param list<string> $exclude
+     * @param list<string> $source PHP source directories (empty falls back to YAML defaults)
+     * @param list<string> $exclude Directories to exclude from analysis
+     * @param ConfigPaths $paths File locations for composer.json and defaults YAML
      */
     public function __construct(
         private array $source = [],

--- a/src/Config/Dirs/GlobDirs.php
+++ b/src/Config/Dirs/GlobDirs.php
@@ -14,7 +14,7 @@ final readonly class GlobDirs implements Dirs
     /**
      * Initializes with directory paths to transform.
      *
-     * @param list<string> $dirs
+     * @param list<string> $dirs Directory paths to suffix with /* glob
      */
     public function __construct(private array $dirs) {}
 

--- a/src/Config/Dirs/NegatedGlobDirs.php
+++ b/src/Config/Dirs/NegatedGlobDirs.php
@@ -14,7 +14,7 @@ final readonly class NegatedGlobDirs implements Dirs
     /**
      * Initializes with directory paths to negate.
      *
-     * @param list<string> $dirs
+     * @param list<string> $dirs Directory paths to wrap as !dir/** negated globs
      */
     public function __construct(private array $dirs) {}
 

--- a/src/Config/Dirs/ProjectDirs.php
+++ b/src/Config/Dirs/ProjectDirs.php
@@ -14,7 +14,7 @@ final readonly class ProjectDirs implements Dirs
     /**
      * Initializes with directory paths to prefix.
      *
-     * @param list<string> $dirs
+     * @param list<string> $dirs Directory paths to prefix with ../../ for tool subdirectory
      */
     public function __construct(private array $dirs) {}
 

--- a/src/Config/Dirs/TrailingGlobDirs.php
+++ b/src/Config/Dirs/TrailingGlobDirs.php
@@ -14,7 +14,7 @@ final readonly class TrailingGlobDirs implements Dirs
     /**
      * Initializes with directory paths to transform.
      *
-     * @param list<string> $dirs
+     * @param list<string> $dirs Directory paths to suffix with /** recursive glob
      */
     public function __construct(private array $dirs) {}
 

--- a/src/Config/Dirs/TrailingSlashDirs.php
+++ b/src/Config/Dirs/TrailingSlashDirs.php
@@ -14,7 +14,7 @@ final readonly class TrailingSlashDirs implements Dirs
     /**
      * Initializes with directory paths to transform.
      *
-     * @param list<string> $dirs
+     * @param list<string> $dirs Directory paths to suffix with trailing slash
      */
     public function __construct(private array $dirs) {}
 

--- a/src/Config/OverrideConfig.php
+++ b/src/Config/OverrideConfig.php
@@ -15,7 +15,8 @@ final readonly class OverrideConfig implements Config
     /**
      * Initializes with a base config and override values.
      *
-     * @param array<string, mixed> $overrides
+     * @param Config $defaults Underlying configuration to override
+     * @param array<string, mixed> $overrides Values that replace the matching defaults
      */
     public function __construct(private Config $defaults, private array $overrides) {}
 

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -18,7 +18,11 @@ final readonly class ProjectConfig implements Config
 {
     private StickyConfig $config;
 
-    /** Initializes with the project root directory path. */
+    /**
+     * Initializes with the project root directory path.
+     *
+     * @param string $root Absolute path to the project root directory
+     */
     public function __construct(private string $root)
     {
         $this->config = new StickyConfig($this->resolve(...));

--- a/src/Config/StickyConfig.php
+++ b/src/Config/StickyConfig.php
@@ -22,7 +22,7 @@ final readonly class StickyConfig implements Config
     /**
      * Initializes with a config factory closure.
      *
-     * @param Closure(): Config $origin
+     * @param Closure(): Config $origin Factory invoked on first access to produce the cached config
      */
     public function __construct(private Closure $origin)
     {

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -32,6 +32,9 @@ final readonly class YamlConfig implements Config
 
     /**
      * Initializes with a YAML file path and default configuration.
+     *
+     * @param string $path Path to the .piqule.yaml project configuration file
+     * @param DefaultConfig $defaults Base configuration providing built-in key defaults
      */
     public function __construct(private string $path, private DefaultConfig $defaults)
     {

--- a/src/Config/YamlPathKeys.php
+++ b/src/Config/YamlPathKeys.php
@@ -16,8 +16,9 @@ final readonly class YamlPathKeys
     /**
      * Initializes with override and append maps alongside the base defaults.
      *
-     * @param array<string, mixed> $overrides
-     * @param array<string, mixed> $appends
+     * @param array<string, mixed> $overrides Values that replace the matching defaults
+     * @param array<string, mixed> $appends Values to append to matching list defaults
+     * @param DefaultConfig $defaults Base configuration providing built-in key defaults
      */
     public function __construct(
         private array $overrides,

--- a/src/EnvVar/EnvVars.php
+++ b/src/EnvVar/EnvVars.php
@@ -12,7 +12,7 @@ final readonly class EnvVars
     /**
      * Initializes with a list of environment variables.
      *
-     * @param list<EnvVar> $items
+     * @param list<EnvVar> $items Environment variable entries included in this collection
      */
     public function __construct(private array $items) {}
 

--- a/src/Envs/YamlEnvs.php
+++ b/src/Envs/YamlEnvs.php
@@ -14,7 +14,11 @@ use Symfony\Component\Yaml\Yaml;
  */
 final readonly class YamlEnvs implements Envs
 {
-    /** Initializes with the path to a .piqule.yaml file. */
+    /**
+     * Initializes with the path to a .piqule.yaml file.
+     *
+     * @param string $path Absolute path to the .piqule.yaml file to read
+     */
     public function __construct(private string $path) {}
 
     #[Override]

--- a/src/File/ConfiguredFile.php
+++ b/src/File/ConfiguredFile.php
@@ -20,7 +20,8 @@ final readonly class ConfiguredFile implements File
     /**
      * Wraps a file with a set of named action factories for placeholder resolution.
      *
-     * @param array<string, callable(string): Action> $actions
+     * @param File $origin File whose contents may contain DSL placeholders
+     * @param array<string, callable(string): Action> $actions Action factories keyed by DSL action name
      */
     public function __construct(private File $origin, private array $actions) {}
 

--- a/src/File/PrefixedFile.php
+++ b/src/File/PrefixedFile.php
@@ -11,7 +11,12 @@ use Override;
  */
 final readonly class PrefixedFile implements File
 {
-    /** Initializes with a path prefix and the file to decorate. */
+    /**
+     * Initializes with a path prefix and the file to decorate.
+     *
+     * @param string $prefix Path segment to prepend to the file name
+     * @param File $origin File whose name will be prefixed
+     */
     public function __construct(private string $prefix, private File $origin) {}
 
     #[Override]

--- a/src/File/ReplacedFile.php
+++ b/src/File/ReplacedFile.php
@@ -11,7 +11,13 @@ use Override;
  */
 final readonly class ReplacedFile implements File
 {
-    /** Initializes with the original file and replacement pair. */
+    /**
+     * Initializes with the original file and replacement pair.
+     *
+     * @param File $origin File whose contents are subject to replacement
+     * @param string $search Literal substring to search for
+     * @param string $replace Literal substring to substitute for each match
+     */
     public function __construct(
         private File $origin,
         private string $search,

--- a/src/File/TextFile.php
+++ b/src/File/TextFile.php
@@ -11,7 +11,13 @@ use Override;
  */
 final readonly class TextFile implements File
 {
-    /** Initializes with a file name, contents, and optional permission mode. */
+    /**
+     * Initializes with a file name, contents, and optional permission mode.
+     *
+     * @param string $name Relative file path used as the file's identity
+     * @param string $contents Raw text content of the file
+     * @param int $mode POSIX permission bits to apply when the file is written
+     */
     public function __construct(
         private string $name,
         private string $contents,

--- a/src/Files/CombinedFiles.php
+++ b/src/Files/CombinedFiles.php
@@ -14,7 +14,7 @@ final readonly class CombinedFiles implements Files
     /**
      * Initializes with multiple file sources to merge.
      *
-     * @param list<Files> $sources
+     * @param list<Files> $sources File collections concatenated in the order given
      */
     public function __construct(private array $sources) {}
 

--- a/src/Files/EachFile.php
+++ b/src/Files/EachFile.php
@@ -18,7 +18,7 @@ final readonly class EachFile implements Runnable
      * Initializes with a file collection and an action to apply.
      *
      * @param Files $files File collection to iterate
-     * @param Closure(File): void $action
+     * @param Closure(File): void $action Side-effectful callback invoked once per file
      */
     public function __construct(private Files $files, private Closure $action) {}
 

--- a/src/Files/FilteredFiles.php
+++ b/src/Files/FilteredFiles.php
@@ -16,7 +16,8 @@ final readonly class FilteredFiles implements Files
     /**
      * Initializes with a file collection and a filtering predicate.
      *
-     * @param Closure(File): bool $predicate
+     * @param Files $origin Underlying file collection to filter
+     * @param Closure(File): bool $predicate Callback returning true for files to keep
      */
     public function __construct(private Files $origin, private Closure $predicate) {}
 

--- a/src/Files/MappedFiles.php
+++ b/src/Files/MappedFiles.php
@@ -16,7 +16,8 @@ final readonly class MappedFiles implements Files
     /**
      * Initializes with a file collection and a transformation closure.
      *
-     * @param Closure(File): File $map
+     * @param Files $origin Underlying file collection to transform
+     * @param Closure(File): File $map Transformation applied to each file in $origin
      */
     public function __construct(private Files $origin, private Closure $map) {}
 

--- a/src/Files/TextFiles.php
+++ b/src/Files/TextFiles.php
@@ -15,7 +15,7 @@ final readonly class TextFiles implements Files
     /**
      * Initializes with a map of file paths to their contents.
      *
-     * @param array<string, string> $files
+     * @param array<string, string> $files Relative file paths mapped to their text contents
      */
     public function __construct(private array $files) {}
 

--- a/src/Formula/Action/ConfigAction.php
+++ b/src/Formula/Action/ConfigAction.php
@@ -15,7 +15,12 @@ use Override;
  */
 final readonly class ConfigAction implements Action
 {
-    /** Initializes with a configuration source and a key to look up. */
+    /**
+     * Initializes with a configuration source and a key to look up.
+     *
+     * @param Config $config Configuration to read the value from
+     * @param string $key Dot-separated key identifying the configuration entry
+     */
     public function __construct(private Config $config, private string $key) {}
 
     #[Override]

--- a/src/Formula/Action/EnvsAction.php
+++ b/src/Formula/Action/EnvsAction.php
@@ -16,7 +16,12 @@ use Override;
  */
 final readonly class EnvsAction implements Action
 {
-    /** Initializes with environment variables and YAML indentation prefix. */
+    /**
+     * Initializes with environment variables and YAML indentation prefix.
+     *
+     * @param Envs $envs Environment variables to export in the rendered step
+     * @param string $indent Raw indentation prefix used for nested YAML output
+     */
     public function __construct(private Envs $envs, private string $indent) {}
 
     #[Override]

--- a/src/Formula/Action/FormatAction.php
+++ b/src/Formula/Action/FormatAction.php
@@ -25,7 +25,11 @@ final readonly class FormatAction implements Action
         '\\t' => "\t",
     ];
 
-    /** Initializes with the raw sprintf template string. */
+    /**
+     * Initializes with the raw sprintf template string.
+     *
+     * @param string $raw Raw sprintf template, including any quoting
+     */
     public function __construct(private string $raw) {}
 
     #[Override]

--- a/src/Formula/Action/FormatEachAction.php
+++ b/src/Formula/Action/FormatEachAction.php
@@ -15,7 +15,11 @@ use Override;
  */
 final readonly class FormatEachAction implements Action
 {
-    /** Initializes with the raw sprintf template string. */
+    /**
+     * Initializes with the raw sprintf template string.
+     *
+     * @param string $raw Raw sprintf template, including any quoting
+     */
     public function __construct(private string $raw) {}
 
     #[Override]

--- a/src/Formula/Action/JoinAction.php
+++ b/src/Formula/Action/JoinAction.php
@@ -14,7 +14,11 @@ use Override;
  */
 final readonly class JoinAction implements Action
 {
-    /** Initializes with a raw delimiter string. */
+    /**
+     * Initializes with a raw delimiter string.
+     *
+     * @param string $raw Raw delimiter string, including any quoting and escape sequences
+     */
     public function __construct(private string $raw) {}
 
     #[Override]

--- a/src/Formula/Action/ReplaceAction.php
+++ b/src/Formula/Action/ReplaceAction.php
@@ -26,7 +26,11 @@ final readonly class ReplaceAction implements Action
 
     private const int PAIR_COUNT = 2;
 
-    /** Initializes with the raw "search, replace" argument string. */
+    /**
+     * Initializes with the raw "search, replace" argument string.
+     *
+     * @param string $raw Raw two-argument string in the form "search, replace"
+     */
     public function __construct(private string $raw) {}
 
     #[Override]

--- a/src/Formula/Actions/ParsedActions.php
+++ b/src/Formula/Actions/ParsedActions.php
@@ -18,7 +18,8 @@ final readonly class ParsedActions implements Actions
     /**
      * Initializes with a DSL expression and available action factories.
      *
-     * @param array<string, callable(string): Action> $actions
+     * @param string $expression Raw DSL expression to parse into actions
+     * @param array<string, callable(string): Action> $actions Action factories keyed by DSL action name
      */
     public function __construct(private string $expression, private array $actions) {}
 

--- a/src/Formula/Args/ListArgs.php
+++ b/src/Formula/Args/ListArgs.php
@@ -14,7 +14,7 @@ final readonly class ListArgs implements Args
     /**
      * Initializes with a plain list of scalar values.
      *
-     * @param list<int|float|string|bool> $values
+     * @param list<int|float|string|bool> $values Scalar values exposed as formula arguments
      */
     public function __construct(private array $values) {}
 

--- a/src/Formula/Args/ParsedArgs.php
+++ b/src/Formula/Args/ParsedArgs.php
@@ -15,7 +15,11 @@ final readonly class ParsedArgs implements Args
 {
     private const int JSON_MAX_DEPTH = 512;
 
-    /** Initializes with the args containing a JSON list literal. */
+    /**
+     * Initializes with the args containing a JSON list literal.
+     *
+     * @param Args $origin Args carrying a single JSON list literal to decode
+     */
     public function __construct(private Args $origin) {}
 
     #[Override]

--- a/src/Formula/Args/StringifiedArgs.php
+++ b/src/Formula/Args/StringifiedArgs.php
@@ -11,7 +11,11 @@ use Override;
  */
 final readonly class StringifiedArgs implements Args
 {
-    /** Initializes with the args to stringify. */
+    /**
+     * Initializes with the args to stringify.
+     *
+     * @param Args $origin Args whose scalar values will be converted to strings
+     */
     public function __construct(private Args $origin) {}
 
     #[Override]

--- a/src/Formula/Args/TrimmedArgs.php
+++ b/src/Formula/Args/TrimmedArgs.php
@@ -11,7 +11,11 @@ use Override;
  */
 final readonly class TrimmedArgs implements Args
 {
-    /** Initializes with the args to trim. */
+    /**
+     * Initializes with the args to trim.
+     *
+     * @param Args $origin Args whose string values will be whitespace-trimmed
+     */
     public function __construct(private Args $origin) {}
 
     #[Override]

--- a/src/Formula/Args/UnquotedArgs.php
+++ b/src/Formula/Args/UnquotedArgs.php
@@ -17,7 +17,11 @@ final readonly class UnquotedArgs implements Args
 
     private const int STRIP_LAST_CHAR = -1;
 
-    /** Initializes with the args to unquote. */
+    /**
+     * Initializes with the args to unquote.
+     *
+     * @param Args $origin Args whose string values may carry matching outer quotes
+     */
     public function __construct(private Args $origin) {}
 
     #[Override]

--- a/src/Formula/ExecutedFormula.php
+++ b/src/Formula/ExecutedFormula.php
@@ -14,7 +14,11 @@ use Override;
  */
 final readonly class ExecutedFormula implements Formula
 {
-    /** Initializes with a sequence of actions to evaluate. */
+    /**
+     * Initializes with a sequence of actions to evaluate.
+     *
+     * @param Actions $actions Ordered actions applied in a pipeline to reduce to a scalar
+     */
     public function __construct(private Actions $actions) {}
 
     #[Override]

--- a/src/Formula/NormalizedFormula.php
+++ b/src/Formula/NormalizedFormula.php
@@ -11,7 +11,11 @@ use Override;
  */
 final readonly class NormalizedFormula implements Formula
 {
-    /** Initializes with a raw DSL expression string. */
+    /**
+     * Initializes with a raw DSL expression string.
+     *
+     * @param string $expression Raw DSL expression whose pipe whitespace will be normalized
+     */
     public function __construct(private string $expression) {}
 
     #[Override]

--- a/src/Output/Message.php
+++ b/src/Output/Message.php
@@ -9,7 +9,11 @@ namespace Haspadar\Piqule\Output;
  */
 final readonly class Message
 {
-    /** Initializes with the message text. */
+    /**
+     * Initializes with the message text.
+     *
+     * @param string $body Raw message text
+     */
     public function __construct(private string $body) {}
 
     /** Returns the message text. */

--- a/src/Secret/Secrets.php
+++ b/src/Secret/Secrets.php
@@ -12,7 +12,7 @@ final readonly class Secrets
     /**
      * Initializes with a list of CI secrets.
      *
-     * @param list<Secret> $items
+     * @param list<Secret> $items CI secrets included in this collection
      */
     public function __construct(private array $items) {}
 

--- a/src/Storage/AppendingStorage.php
+++ b/src/Storage/AppendingStorage.php
@@ -14,7 +14,13 @@ use Override;
  */
 final readonly class AppendingStorage implements Storage
 {
-    /** Initializes with underlying storage, a reaction, and a duplicate marker. */
+    /**
+     * Initializes with underlying storage, a reaction, and a duplicate marker.
+     *
+     * @param Storage $origin Underlying storage to append to
+     * @param StorageReaction $reaction Receives created and updated notifications
+     * @param string $marker Marker string whose presence in the file skips the append
+     */
     public function __construct(
         private Storage $origin,
         private StorageReaction $reaction,

--- a/src/Storage/DiffingStorage.php
+++ b/src/Storage/DiffingStorage.php
@@ -13,7 +13,12 @@ use Override;
  */
 final readonly class DiffingStorage implements Storage
 {
-    /** Initializes with underlying storage and a change reaction. */
+    /**
+     * Initializes with underlying storage and a change reaction.
+     *
+     * @param Storage $origin Underlying storage to write through
+     * @param StorageReaction $reaction Receives created, updated, and skipped notifications
+     */
     public function __construct(private Storage $origin, private StorageReaction $reaction) {}
 
     #[Override]

--- a/src/Storage/DiskStorage.php
+++ b/src/Storage/DiskStorage.php
@@ -19,7 +19,11 @@ final readonly class DiskStorage implements Storage
 {
     private const int FULL_PERMISSIONS = 0o777;
 
-    /** Initializes storage rooted at the given directory path. */
+    /**
+     * Initializes storage rooted at the given directory path.
+     *
+     * @param string $root Absolute filesystem path used as the storage root
+     */
     public function __construct(private string $root) {}
 
     #[Override]

--- a/src/Storage/OnceStorage.php
+++ b/src/Storage/OnceStorage.php
@@ -13,7 +13,12 @@ use Override;
  */
 final readonly class OnceStorage implements Storage
 {
-    /** Initializes with underlying storage and a creation reaction. */
+    /**
+     * Initializes with underlying storage and a creation reaction.
+     *
+     * @param Storage $origin Underlying storage to write through
+     * @param StorageReaction $reaction Receives a created notification on the first write
+     */
     public function __construct(private Storage $origin, private StorageReaction $reaction) {}
 
     #[Override]

--- a/src/Storage/Reaction/ReportingStorageReaction.php
+++ b/src/Storage/Reaction/ReportingStorageReaction.php
@@ -12,7 +12,11 @@ use Override;
  */
 final readonly class ReportingStorageReaction implements StorageReaction
 {
-    /** Initializes with the output channel for reporting. */
+    /**
+     * Initializes with the output channel for reporting.
+     *
+     * @param Output $output Channel to write storage event messages to
+     */
     public function __construct(private Output $output) {}
 
     #[Override]

--- a/src/Storage/Reaction/StorageReactions.php
+++ b/src/Storage/Reaction/StorageReactions.php
@@ -14,7 +14,7 @@ final readonly class StorageReactions implements StorageReaction
     /**
      * Initializes with a list of reactions to broadcast to.
      *
-     * @param list<StorageReaction> $reactions
+     * @param list<StorageReaction> $reactions Reactions that receive each event in order
      */
     public function __construct(private array $reactions) {}
 

--- a/src/Storage/SafePath.php
+++ b/src/Storage/SafePath.php
@@ -11,12 +11,17 @@ use Haspadar\Piqule\PiquleException;
  */
 final readonly class SafePath
 {
-    /** Initializes with the storage root directory. */
+    /**
+     * Initializes with the storage root directory.
+     *
+     * @param string $root Absolute filesystem path used as the storage root
+     */
     public function __construct(private string $root) {}
 
     /**
      * Returns the safe absolute path for a relative location.
      *
+     * @param string $location Relative location under the storage root
      * @throws PiquleException
      */
     public function resolve(string $location): string


### PR DESCRIPTION
## Summary

- Bump `haspadar/phpstan-rules` from `v0.38.1` to `v0.42.1`, pulling in the new `NoNullAssignment`, `NoNullableProperty`, `PhpDocMissingParam`, `PhpDocParamDescription`, and `PhpDocParamOrder` rules.
- Describe every constructor/method parameter in `src/` so the new PHPDoc rules have clean coverage. No logic changes.

## Notes

- Renovate PR #639 (v0.41.0) is superseded and can be closed once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation & Internal Updates

* **Documentation**
  * Enhanced PHPDoc documentation across numerous classes by adding explicit parameter descriptions and type annotations for constructors and methods, improving code clarity and maintainability.

* **Chores**
  * Updated default Docker image digest for internal scanning tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->