### PR TITLE
Separate Infra Linter Excludes From PHP Tool Configuration

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -1,5 +1,4 @@
 override:
-  phpstan.parameter_number.max_parameters: 4
   phpmetrics.coupling.max_afferent: 18
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]

--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -1,4 +1,5 @@
 override:
+  phpstan.parameter_number.max_parameters: 4
   phpmetrics.coupling.max_afferent: 18
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
@@ -21,5 +22,5 @@ override:
   phpstan.afferent_coupling.excluded_classes: ['\Haspadar\Piqule\PiquleException']
 
 append:
-  exclude:
+  infra.exclude:
     - templates

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -6,8 +6,8 @@
 #     override:
 #         phpstan.level: 8
 #     append:
-#         php.exclude:
-#             - legacy
+#         infra.exclude:
+#             - dist
 
 defaults:
   php.src: ["src"]

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -6,12 +6,12 @@
 #     override:
 #         phpstan.level: 8
 #     append:
-#         exclude:
+#         php.exclude:
 #             - legacy
 
 defaults:
   php.src: ["src"]
-  exclude: ["vendor", "tests", ".git"]
+  infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
 
   check.full: false
@@ -114,7 +114,7 @@ defaults:
   psalm.error_level: 1
   psalm.project.directories: ["../../src"]
   psalm.project.files: []
-  psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
+  psalm.project.ignore: []
   psalm.suppress.possibly_unused: []
 
   infection.cli: true

--- a/.piqule/php-cs-fixer/php-cs-fixer.project.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.project.php
@@ -10,7 +10,7 @@ $rules = require __DIR__ . '/php-cs-fixer.php';
 $rules->setFinder(
     Finder::create()
         ->in([__DIR__ . '/../..'])
-        ->exclude(['vendor','tests','.git','templates']),
+        ->exclude(['vendor','tests','.git']),
 )->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
 
 return $rules;

--- a/.piqule/phpcs/phpcs.xml
+++ b/.piqule/phpcs/phpcs.xml
@@ -7,7 +7,6 @@
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>tests/*</exclude-pattern>
     <exclude-pattern>.git/*</exclude-pattern>
-    <exclude-pattern>templates/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>

--- a/.piqule/phpmetrics/config.json
+++ b/.piqule/phpmetrics/config.json
@@ -6,8 +6,7 @@
   "excludes": [
     "vendor",
     "tests",
-    ".git",
-    "templates"
+    ".git"
   ],
   "extensions": [
     "php"

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -15,10 +15,7 @@
         <file name="../../bin/piqule-sync" />
         <file name="../../bin/piqule-tokens-check" />
         <ignoreFiles>
-            <directory name="../../vendor" />
-            <directory name="../../tests" />
-            <directory name="../../.git" />
-            <directory name="../../templates" />
+
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>

--- a/src/Config/AppendConfig.php
+++ b/src/Config/AppendConfig.php
@@ -14,7 +14,7 @@ use Override;
  *
  *     new AppendConfig(new DefaultConfig(), [
  *         'phpstan.neon_includes' => ['../../rules.neon'],
- *         'exclude' => ['legacy'],
+ *         'infra.exclude' => ['legacy'],
  *     ]);
  */
 final readonly class AppendConfig implements Config

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Config;
 
-use Haspadar\Piqule\Config\Dirs\GlobDirs;
 use Haspadar\Piqule\Config\Dirs\NegatedGlobDirs;
 use Haspadar\Piqule\Config\Dirs\ProjectDirs;
 use Haspadar\Piqule\Config\Dirs\TrailingGlobDirs;
@@ -29,15 +28,15 @@ final readonly class DefaultConfig implements Config
     private stdClass $cache;
 
     /**
-     * Initializes with source directories, exclusions, and config paths.
+     * Initializes with source directories, infra exclusions, and config paths.
      *
      * @param list<string> $source PHP source directories (empty falls back to YAML defaults)
-     * @param list<string> $exclude Directories to exclude from analysis
+     * @param list<string> $infra Directories skipped by infrastructure linters (empty falls back to YAML defaults)
      * @param ConfigPaths $paths File locations for composer.json and defaults YAML
      */
     public function __construct(
         private array $source = [],
-        private array $exclude = [],
+        private array $infra = [],
         private ConfigPaths $paths = new ConfigPaths(),
     ) {
         $this->cache = new stdClass();
@@ -76,6 +75,23 @@ final readonly class DefaultConfig implements Config
     }
 
     /**
+     * Resolves source and infra-exclude lists from constructor overrides and YAML base.
+     *
+     * @param array<string, mixed> $base Raw YAML defaults section
+     * @return array{list<string>, list<string>}
+     */
+    private function resolve(array $base): array
+    {
+        /** @var list<string> $source */
+        $source = $this->source !== [] ? $this->source : ($base['php.src'] ?? []);
+
+        /** @var list<string> $infra */
+        $infra = $this->infra !== [] ? $this->infra : ($base['infra.exclude'] ?? []);
+
+        return [$source, $infra];
+    }
+
+    /**
      * Parses YAML and computes all defaults with dynamic path derivations.
      *
      * @throws PiquleException
@@ -107,18 +123,13 @@ final readonly class DefaultConfig implements Config
         /** @var array<string, mixed> $base */
         $base = $yaml['defaults'];
 
-        /** @var list<string> $resolvedSource */
-        $resolvedSource = $this->source !== []
-            ? $this->source
-            : ($base['php.src'] ?? []);
-
-        /** @var list<string> $resolvedExclude */
-        $resolvedExclude = $this->exclude !== []
-            ? $this->exclude
-            : ($base['exclude'] ?? []);
+        [$resolvedSource, $resolvedInfra] = $this->resolve($base);
 
         /** @var array<string, scalar|list<scalar>> $defaults */
-        $defaults = array_merge($base, $this->dynamic($resolvedSource, $resolvedExclude));
+        $defaults = array_merge(
+            $base,
+            $this->dynamic($resolvedSource, $resolvedInfra),
+        );
         $this->cache->value = $defaults;
 
         return $defaults;
@@ -127,40 +138,36 @@ final readonly class DefaultConfig implements Config
     /**
      * Reads dynamic defaults derived from composer.json paths and directory lists.
      *
-     * @param list<string> $source
-     * @param list<string> $exclude
+     * @param list<string> $source Project source directories
+     * @param list<string> $infra Directories skipped by infrastructure linters
      * @return array<string, scalar|list<scalar>>
      */
-    private function dynamic(array $source, array $exclude): array
+    private function dynamic(array $source, array $infra): array
     {
         $projectIncludes = (new ProjectDirs($source))->toList();
 
         return [
             'php.src' => $source,
-            'exclude' => $exclude,
-            'hadolint.ignore' => $exclude,
+            'infra.exclude' => $infra,
+            'hadolint.ignore' => $infra,
             'jsonlint.patterns' => array_merge(
                 ['**/*.json', '**/*.json5', '**/*.jsonc'],
-                (new NegatedGlobDirs($exclude))->toList(),
+                (new NegatedGlobDirs($infra))->toList(),
             ),
-            'markdownlint.ignores' => (new TrailingGlobDirs($exclude))->toList(),
-            'php_cs_fixer.exclude' => $exclude,
-            'phpcs.excludes' => (new GlobDirs($exclude))->toList(),
+            'markdownlint.ignores' => (new TrailingGlobDirs($infra))->toList(),
             'phpcs.files' => $projectIncludes,
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
             'phpmd.paths' => $source,
             'phpmetrics.includes' => $projectIncludes,
-            'phpmetrics.excludes' => $exclude,
             'phpstan.paths' => $projectIncludes,
             'phpunit.source.include' => $projectIncludes,
             'psalm.project.directories' => $projectIncludes,
-            'psalm.project.ignore' => (new ProjectDirs($exclude))->toList(),
             'infection.source.directories' => $projectIncludes,
-            'shellcheck.ignore_dirs' => $exclude,
+            'shellcheck.ignore_dirs' => $infra,
             'sonar.sources' => $source,
-            'typos.exclude' => (new TrailingSlashDirs($exclude))->toList(),
+            'typos.exclude' => (new TrailingSlashDirs($infra))->toList(),
             'yamllint.ignore' => array_merge(
-                (new TrailingGlobDirs($exclude))->toList(),
+                (new TrailingGlobDirs($infra))->toList(),
                 ['.piqule/**/html/**', '.piqule/**/coverage-report/**'],
             ),
         ];

--- a/src/Config/YamlConfig.php
+++ b/src/Config/YamlConfig.php
@@ -23,8 +23,8 @@ use Symfony\Component\Yaml\Yaml;
  *     append:
  *         phpstan.neon_includes:
  *             - ../../rules.neon
- *         exclude:
- *             - legacy
+ *         infra.exclude:
+ *             - dist
  */
 final readonly class YamlConfig implements Config
 {
@@ -92,13 +92,13 @@ final readonly class YamlConfig implements Config
             : [];
 
         $pathKeys = new YamlPathKeys($overrides, $appends, $this->defaults);
-        $remaining = ['exclude', 'php.src'];
+        $remaining = ['infra.exclude', 'php.src'];
 
         return new AppendConfig(
             new OverrideConfig(
                 new DefaultConfig(
                     $pathKeys->phpSrc(),
-                    $pathKeys->exclude(),
+                    $pathKeys->infraExclude(),
                     $this->defaults->configPaths(),
                 ),
                 array_diff_key($overrides, array_flip($remaining)),

--- a/src/Config/YamlPathKeys.php
+++ b/src/Config/YamlPathKeys.php
@@ -47,19 +47,19 @@ final readonly class YamlPathKeys
     }
 
     /**
-     * Resolves the effective exclude patterns after overrides and appends.
+     * Resolves the effective infrastructure exclude patterns after overrides and appends.
      *
      * @throws PiquleException
      * @return list<string>
      */
-    public function exclude(): array
+    public function infraExclude(): array
     {
-        $result = array_key_exists('exclude', $this->overrides) && is_array($this->overrides['exclude'])
-            ? $this->toStringList(array_values($this->overrides['exclude']), 'override.exclude')
-            : $this->toStringList($this->defaults->list('exclude'), 'exclude');
+        $result = array_key_exists('infra.exclude', $this->overrides) && is_array($this->overrides['infra.exclude'])
+            ? $this->toStringList(array_values($this->overrides['infra.exclude']), 'override.infra.exclude')
+            : $this->toStringList($this->defaults->list('infra.exclude'), 'infra.exclude');
 
-        if (array_key_exists('exclude', $this->appends) && is_array($this->appends['exclude'])) {
-            $extra = $this->toStringList(array_values($this->appends['exclude']), 'append.exclude');
+        if (array_key_exists('infra.exclude', $this->appends) && is_array($this->appends['infra.exclude'])) {
+            $extra = $this->toStringList(array_values($this->appends['infra.exclude']), 'append.infra.exclude');
             $result = array_values(array_unique(array_merge($result, $extra)));
         }
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -6,8 +6,8 @@
 #     override:
 #         phpstan.level: 8
 #     append:
-#         php.exclude:
-#             - legacy
+#         infra.exclude:
+#             - dist
 
 defaults:
   php.src: ["src"]

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -6,12 +6,12 @@
 #     override:
 #         phpstan.level: 8
 #     append:
-#         exclude:
+#         php.exclude:
 #             - legacy
 
 defaults:
   php.src: ["src"]
-  exclude: ["vendor", "tests", ".git"]
+  infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
 
   check.full: false
@@ -114,7 +114,7 @@ defaults:
   psalm.error_level: 1
   psalm.project.directories: ["../../src"]
   psalm.project.files: []
-  psalm.project.ignore: ["../../vendor", "../../tests", "../../.git"]
+  psalm.project.ignore: []
   psalm.suppress.possibly_unused: []
 
   infection.cli: true

--- a/tests/Integration/Config/ConfigYamlTemplateTest.php
+++ b/tests/Integration/Config/ConfigYamlTemplateTest.php
@@ -43,18 +43,18 @@ final class ConfigYamlTemplateTest extends TestCase
     }
 
     #[Test]
-    public function appendAddsNewValueToExclude(): void
+    public function appendAddsNewValueToInfraExclude(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
-            "append:\n    exclude:\n        - legacy\n",
+            "append:\n    infra.exclude:\n        - dist\n",
         );
 
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.piqule.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('exclude', ['vendor', 'tests', '.git', 'legacy']),
-                'Append must add "legacy" to the exclude list',
+                new HasConfigYamlKey('infra.exclude', ['vendor', 'tests', '.git', 'dist']),
+                'Append must add "dist" to infra.exclude',
             );
         } finally {
             $folder->close();
@@ -62,18 +62,37 @@ final class ConfigYamlTemplateTest extends TestCase
     }
 
     #[Test]
-    public function overrideExcludeCascadesToDerivedKeys(): void
+    public function overrideInfraExcludeCascadesToDerivedKeys(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
-            "override:\n    exclude:\n        - build\n",
+            "override:\n    infra.exclude:\n        - dist\n",
         );
 
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.piqule.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('shellcheck.ignore_dirs', ['build']),
-                'Override exclude must cascade to shellcheck.ignore_dirs',
+                new HasConfigYamlKey('shellcheck.ignore_dirs', ['dist']),
+                'Override infra.exclude must cascade to shellcheck.ignore_dirs',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
+
+    #[Test]
+    public function appendInfraExcludeCascadesToDerivedKeys(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "append:\n    infra.exclude:\n        - dist\n",
+        );
+
+        try {
+            self::assertThat(
+                new YamlConfig($folder->path() . '/.piqule.yaml', new DefaultConfig()),
+                new HasConfigYamlKey('shellcheck.ignore_dirs', ['vendor', 'tests', '.git', 'dist']),
+                'Append infra.exclude must cascade to shellcheck.ignore_dirs',
             );
         } finally {
             $folder->close();

--- a/tests/Integration/Config/ConfigYamlTemplateTest.php
+++ b/tests/Integration/Config/ConfigYamlTemplateTest.php
@@ -24,6 +24,16 @@ final class ConfigYamlTemplateTest extends TestCase
     }
 
     #[Test]
+    public function psalmProjectIgnoreIsEmptyByDefault(): void
+    {
+        self::assertThat(
+            new DefaultConfig(),
+            new HasConfigYamlKey('psalm.project.ignore', []),
+            'psalm.project.ignore must be empty so .git is never passed as a <directory> to psalm',
+        );
+    }
+
+    #[Test]
     public function overrideReplacesConfigValue(): void
     {
         $folder = (new TempFolder())->withFile(

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -102,12 +102,12 @@ final class DefaultConfigTest extends TestCase
     }
 
     #[Test]
-    public function defaultsExcludeToVendorTestsGit(): void
+    public function defaultsInfraExcludeToVendorTestsGit(): void
     {
         self::assertSame(
             ['vendor', 'tests', '.git'],
-            (new DefaultConfig())->list('exclude'),
-            'exclude must default to vendor, tests, .git',
+            (new DefaultConfig())->list('infra.exclude'),
+            'infra.exclude must default to vendor, tests, and .git',
         );
     }
 

--- a/tests/Unit/Config/YamlPathKeysTest.php
+++ b/tests/Unit/Config/YamlPathKeysTest.php
@@ -23,23 +23,23 @@ final class YamlPathKeysTest extends TestCase
     }
 
     #[Test]
-    public function throwsWhenOverrideExcludeContainsNonString(): void
+    public function throwsWhenOverrideInfraExcludeContainsNonString(): void
     {
         $this->expectException(PiquleException::class);
-        $this->expectExceptionMessageMatches('/override\.exclude/');
+        $this->expectExceptionMessageMatches('/override\.infra\.exclude/');
 
-        $keys = new YamlPathKeys(['exclude' => [true]], [], new DefaultConfig());
-        $keys->exclude();
+        $keys = new YamlPathKeys(['infra.exclude' => [true]], [], new DefaultConfig());
+        $keys->infraExclude();
     }
 
     #[Test]
-    public function throwsWhenAppendExcludeContainsNonString(): void
+    public function throwsWhenAppendInfraExcludeContainsNonString(): void
     {
         $this->expectException(PiquleException::class);
-        $this->expectExceptionMessageMatches('/append\.exclude/');
+        $this->expectExceptionMessageMatches('/append\.infra\.exclude/');
 
-        $keys = new YamlPathKeys([], ['exclude' => [null]], new DefaultConfig());
-        $keys->exclude();
+        $keys = new YamlPathKeys([], ['infra.exclude' => [null]], new DefaultConfig());
+        $keys->infraExclude();
     }
 
     #[Test]
@@ -69,18 +69,18 @@ final class YamlPathKeysTest extends TestCase
     }
 
     #[Test]
-    public function deduplicatesAppendedExcludeEntries(): void
+    public function deduplicatesAppendedInfraExcludeEntries(): void
     {
         $keys = new YamlPathKeys(
-            ['exclude' => ['vendor']],
-            ['exclude' => ['vendor', 'tests']],
+            ['infra.exclude' => ['.git']],
+            ['infra.exclude' => ['.git', 'dist']],
             new DefaultConfig(),
         );
 
         self::assertSame(
-            ['vendor', 'tests'],
-            $keys->exclude(),
-            'Appended exclude entries must be deduplicated',
+            ['.git', 'dist'],
+            $keys->infraExclude(),
+            'Appended infra.exclude entries must be deduplicated',
         );
     }
 
@@ -101,18 +101,18 @@ final class YamlPathKeysTest extends TestCase
     }
 
     #[Test]
-    public function normalizesAssociativeOverrideExcludeKeys(): void
+    public function normalizesAssociativeOverrideInfraExcludeKeys(): void
     {
         $keys = new YamlPathKeys(
-            ['exclude' => ['x' => 'vendor', 'y' => 'tests']],
+            ['infra.exclude' => ['x' => '.git', 'y' => 'dist']],
             [],
             new DefaultConfig(),
         );
 
         self::assertSame(
-            ['vendor', 'tests'],
-            $keys->exclude(),
-            'Associative exclude overrides must be normalized to a sequential list',
+            ['.git', 'dist'],
+            $keys->infraExclude(),
+            'Associative infra.exclude overrides must be normalized to a sequential list',
         );
     }
 
@@ -133,18 +133,18 @@ final class YamlPathKeysTest extends TestCase
     }
 
     #[Test]
-    public function normalizesAssociativeAppendExcludeKeys(): void
+    public function normalizesAssociativeAppendInfraExcludeKeys(): void
     {
         $keys = new YamlPathKeys(
-            ['exclude' => ['vendor']],
-            ['exclude' => ['a' => 'tests']],
+            ['infra.exclude' => ['.git']],
+            ['infra.exclude' => ['a' => 'dist']],
             new DefaultConfig(),
         );
 
         self::assertSame(
-            ['vendor', 'tests'],
-            $keys->exclude(),
-            'Associative append exclude must be normalized before merging',
+            ['.git', 'dist'],
+            $keys->infraExclude(),
+            'Associative append infra.exclude must be normalized before merging',
         );
     }
 }


### PR DESCRIPTION
- Removed shared `exclude` key and replaced it with `infra.exclude` routed only to infrastructure linters
- Removed `exclude` fan-out from PHP static-analysis tools (phpcs, phpmetrics, php-cs-fixer, psalm)
- Added `infra.exclude` default `["vendor", "tests", ".git"]` with cascade to shellcheck, yamllint, markdownlint, hadolint, jsonlint, typos
- Added `infraExclude()` resolver to `YamlPathKeys` with override and append support
- Updated tests to cover `infra.exclude` cascade, deduplication, and associative key normalization

Closes #642

**Breaking changes:**
- `exclude` config key removed; replace with `infra.exclude` in `.piqule.yaml`
- `psalm.project.ignore` now defaults to `[]`; add explicit entries if needed