### PR TITLE
Allow disabling individual php-cs-fixer rules via config

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -56,6 +56,7 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
+  php_cs_fixer.disabled_rules: []
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
   php_cs_fixer.paths: ["../.."]
 

--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -108,5 +108,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
+
     ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/DEV.md
+++ b/DEV.md
@@ -436,6 +436,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 |-----|---------|-------------|
 | `php-cs-fixer.cli` | `true` | Enable PHP CS Fixer |
 | `php_cs_fixer.allow_unsupported` | `["true"]` | Allow unsupported PHP versions |
+| `php_cs_fixer.disabled_rules` | `[]` | Rule names appended as `false` at the end of `setRules()` to turn them off (overrides preset and built-in entries) |
 | `php_cs_fixer.exclude` | `["vendor", "tests", ".git"]` | Excluded directories |
 | `php_cs_fixer.paths` | `["../.."]` | Paths to fix |
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ append:
         - lib
     exclude:
         - legacy
+    php_cs_fixer.disabled_rules:
+        - phpdoc_scalar
 ```
+
+`php_cs_fixer.disabled_rules` turns off individual PHP CS Fixer rules — useful when a rule clashes with project code (for example, a class named `Scalar` being lowercased by `phpdoc_scalar`).
 
 Use `override` to replace individual keys:
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -56,6 +56,7 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
+  php_cs_fixer.disabled_rules: []
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
   php_cs_fixer.paths: ["../.."]
 

--- a/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -106,5 +106,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
+<< config(php_cs_fixer.disabled_rules)|format_each("        '%s' => false,")|join("\n") >>
     ]))
     ->setUnsupportedPhpVersionAllowed(<< config(php_cs_fixer.allow_unsupported)|join("") >>);

--- a/tests/Integration/Config/ConfigYamlTemplateTest.php
+++ b/tests/Integration/Config/ConfigYamlTemplateTest.php
@@ -156,4 +156,33 @@ final class ConfigYamlTemplateTest extends TestCase
             'Custom include must cascade to phpmd.paths',
         );
     }
+
+    #[Test]
+    public function phpCsFixerDisabledRulesIsEmptyByDefault(): void
+    {
+        self::assertThat(
+            new DefaultConfig(),
+            new HasConfigYamlKey('php_cs_fixer.disabled_rules', []),
+            'php_cs_fixer.disabled_rules must be empty so no rule overrides are emitted by default',
+        );
+    }
+
+    #[Test]
+    public function appendPhpCsFixerDisabledRulesAddsRuleNames(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "append:\n    php_cs_fixer.disabled_rules:\n        - phpdoc_scalar\n",
+        );
+
+        try {
+            self::assertThat(
+                new YamlConfig($folder->path() . '/.piqule.yaml', new DefaultConfig()),
+                new HasConfigYamlKey('php_cs_fixer.disabled_rules', ['phpdoc_scalar']),
+                'Append must add "phpdoc_scalar" to php_cs_fixer.disabled_rules',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- New `php_cs_fixer.disabled_rules` config key; listed rule names are appended as `=> false` at the end of `setRules()`, turning them off — including entries inherited from `@PER-CS2.0` and `@PHPxxMigration` presets.
- Covers the case where a project class name clashes with php-cs-fixer rule semantics (e.g. a class named `Scalar` being lowercased by `phpdoc_scalar` in docblocks). Until now the only escape hatch was editing the generated file, which `piqule sync` overwrites.
- Two integration tests in `ConfigYamlTemplateTest`: default is `[]`, `append` adds rule names.
- Regenerated `.piqule/config.yaml` and `.piqule/php-cs-fixer/php-cs-fixer.php` from updated templates.
- README and DEV.md updated with key description and example.

## Usage

```yaml
append:
    php_cs_fixer.disabled_rules:
        - phpdoc_scalar
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to disable individual PHP-CS-Fixer rules, providing flexibility when formatting rules conflict with project conventions

* **Documentation**
  * Enhanced developer and user documentation with examples of how to disable specific code formatting rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->