### PR TITLE
Cover php_cs_fixer.disabled_rules template rendering end-to-end

### DIFF
--- a/tests/Unit/File/ConfiguredFileTest.php
+++ b/tests/Unit/File/ConfiguredFileTest.php
@@ -389,6 +389,27 @@ final class ConfiguredFileTest extends TestCase
     }
 
     #[Test]
+    public function rendersDisabledPhpCsFixerRulesAsFalseEntries(): void
+    {
+        $config = new OverrideConfig(
+            new DefaultConfig(),
+            ['php_cs_fixer.disabled_rules' => ['phpdoc_scalar', 'phpdoc_types']],
+        );
+
+        self::assertThat(
+            new ConfiguredFile(
+                new TextFile(
+                    'php-cs-fixer.php',
+                    '<< config(php_cs_fixer.disabled_rules)|format_each("        \'%s\' => false,")|join("\n") >>',
+                ),
+                $this->actions($config),
+            ),
+            new HasFileContents("        'phpdoc_scalar' => false,\n        'phpdoc_types' => false,"),
+            'disabled_rules template formula must render each rule as => false entry',
+        );
+    }
+
+    #[Test]
     public function preservesOriginMode(): void
     {
         $file = new ConfiguredFile(


### PR DESCRIPTION
## Summary

Follow-up to #645 (CodeRabbit nitpick). Integration tests for `php_cs_fixer.disabled_rules` only exercise the config layer — a broken template placeholder would pass them while silently producing invalid output in the generated `php-cs-fixer.php`.

Adds a unit test in `ConfiguredFileTest` that feeds the exact template formula (`config(php_cs_fixer.disabled_rules)|format_each|join`) through `ConfiguredFile` and asserts the rendered output contains the `'rule' => false,` entries.