### PR TITLE
Add phpcs.disabled_rules and drop RequireExplicitAssertion

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -61,6 +61,7 @@ defaults:
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
+  phpcs.disabled_rules: []
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""

--- a/.piqule/phpcs/phpcs.xml
+++ b/.piqule/phpcs/phpcs.xml
@@ -20,4 +20,5 @@
     <rule ref=".piqule/phpcs/slevomat-flow.xml"/>
     <rule ref=".piqule/phpcs/slevomat-style.xml"/>
 
+
 </ruleset>

--- a/.piqule/phpcs/slevomat-style.xml
+++ b/.piqule/phpcs/slevomat-style.xml
@@ -18,7 +18,6 @@
     <rule ref="SlevomatCodingStandard.PHP.DisallowReference"/>
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
     <rule ref="SlevomatCodingStandard.PHP.ReferenceSpacing"/>
-    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
     <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc"/>
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>

--- a/DEV.md
+++ b/DEV.md
@@ -445,6 +445,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | Key | Default | Description |
 |-----|---------|-------------|
 | `phpcs.cli` | `true` | Enable PHP_CodeSniffer |
+| `phpcs.disabled_rules` | `[]` | Rule names rendered as `<rule ref="..."><severity>0</severity></rule>` to silence them (overrides rules inherited from referenced rulesets) |
 | `phpcs.excludes` | `["vendor/*", "tests/*", ".git/*"]` | Excluded patterns |
 | `phpcs.files` | `["../../src"]` | Files/directories to check |
 | `phpcs.root_namespace` | `""` | Root namespace for PSR-4 check |

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ append:
         - legacy
     php_cs_fixer.disabled_rules:
         - phpdoc_scalar
+    phpcs.disabled_rules:
+        - SlevomatCodingStandard.PHP.RequireExplicitAssertion
 ```
 
-`php_cs_fixer.disabled_rules` turns off individual PHP CS Fixer rules — useful when a rule clashes with project code (for example, a class named `Scalar` being lowercased by `phpdoc_scalar`).
+`php_cs_fixer.disabled_rules` and `phpcs.disabled_rules` turn off individual rules — useful when a rule clashes with project code (for example, a class named `Scalar` being lowercased by `phpdoc_scalar`).
 
 Use `override` to replace individual keys:
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -61,6 +61,7 @@ defaults:
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
+  phpcs.disabled_rules: []
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""

--- a/templates/always/.piqule/phpcs/phpcs.xml
+++ b/templates/always/.piqule/phpcs/phpcs.xml
@@ -22,4 +22,5 @@
     <rule ref=".piqule/phpcs/slevomat-flow.xml"/>
     <rule ref=".piqule/phpcs/slevomat-style.xml"/>
 
+<< config(phpcs.disabled_rules)|format_each('    <rule ref="%s"><severity>0</severity></rule>')|join("\n") >>
 </ruleset>

--- a/templates/always/.piqule/phpcs/slevomat-style.xml
+++ b/templates/always/.piqule/phpcs/slevomat-style.xml
@@ -18,7 +18,6 @@
     <rule ref="SlevomatCodingStandard.PHP.DisallowReference"/>
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
     <rule ref="SlevomatCodingStandard.PHP.ReferenceSpacing"/>
-    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
     <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc"/>
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>

--- a/tests/Integration/Config/ConfigYamlTemplateTest.php
+++ b/tests/Integration/Config/ConfigYamlTemplateTest.php
@@ -185,4 +185,33 @@ final class ConfigYamlTemplateTest extends TestCase
             $folder->close();
         }
     }
+
+    #[Test]
+    public function phpcsDisabledRulesIsEmptyByDefault(): void
+    {
+        self::assertThat(
+            new DefaultConfig(),
+            new HasConfigYamlKey('phpcs.disabled_rules', []),
+            'phpcs.disabled_rules must be empty so no rule overrides are emitted by default',
+        );
+    }
+
+    #[Test]
+    public function appendPhpcsDisabledRulesAddsRuleNames(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "append:\n    phpcs.disabled_rules:\n        - SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly\n",
+        );
+
+        try {
+            self::assertThat(
+                new YamlConfig($folder->path() . '/.piqule.yaml', new DefaultConfig()),
+                new HasConfigYamlKey('phpcs.disabled_rules', ['SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly']),
+                'Append must add rule name to phpcs.disabled_rules',
+            );
+        } finally {
+            $folder->close();
+        }
+    }
 }

--- a/tests/Unit/File/ConfiguredFileTest.php
+++ b/tests/Unit/File/ConfiguredFileTest.php
@@ -410,6 +410,35 @@ final class ConfiguredFileTest extends TestCase
     }
 
     #[Test]
+    public function rendersDisabledPhpcsRulesAsSilencedEntries(): void
+    {
+        $config = new OverrideConfig(
+            new DefaultConfig(),
+            [
+                'phpcs.disabled_rules' => [
+                    'SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly',
+                    'SlevomatCodingStandard.PHP.RequireExplicitAssertion',
+                ],
+            ],
+        );
+
+        self::assertThat(
+            new ConfiguredFile(
+                new TextFile(
+                    'phpcs.xml',
+                    '<< config(phpcs.disabled_rules)|format_each(\'    <rule ref="%s"><severity>0</severity></rule>\')|join("\n") >>',
+                ),
+                $this->actions($config),
+            ),
+            new HasFileContents(
+                '    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"><severity>0</severity></rule>' . "\n"
+                . '    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"><severity>0</severity></rule>',
+            ),
+            'phpcs.disabled_rules template formula must render each rule as a silenced ruleset entry',
+        );
+    }
+
+    #[Test]
     public function preservesOriginMode(): void
     {
         $file = new ConfiguredFile(


### PR DESCRIPTION
## Summary

Mirrors `php_cs_fixer.disabled_rules` from #645, with one rule removed from the default ruleset.

- **`phpcs.disabled_rules`** — new config key; listed rule names render as `<rule ref="..."><severity>0</severity></rule>` at the end of the generated `phpcs.xml`, silencing entries inherited from the referenced `slevomat-*.xml` rulesets without editing them. Closes the only remaining escape hatch (hand-editing regenerated files).
- **Drop `SlevomatCodingStandard.PHP.RequireExplicitAssertion`** from the default ruleset. It forces `assert(\$x instanceof Y)` in place of natural early returns and `if` guards, conflicting with typical piqule-style code. Projects that still want it can re-add via their own phpcs config.
- `SlevomatCodingStandard.PHP.ReferenceThrowableOnly` stays in the default ruleset — it prevents a real bug (`catch (\Exception)` misses `\Error`). Projects that deliberately want to catch only `\Exception` can now silence it via `phpcs.disabled_rules`.

## Usage

```yaml
append:
    phpcs.disabled_rules:
        - SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly
```