### PR TITLE
Replace disabled_rules with raw extend scalar

### DIFF
--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -56,13 +56,13 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
-  php_cs_fixer.disabled_rules: []
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
+  php_cs_fixer.extend: ""
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
-  phpcs.disabled_rules: []
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
+  phpcs.extend: ""
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""
 

--- a/DEV.md
+++ b/DEV.md
@@ -436,8 +436,8 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 |-----|---------|-------------|
 | `php-cs-fixer.cli` | `true` | Enable PHP CS Fixer |
 | `php_cs_fixer.allow_unsupported` | `["true"]` | Allow unsupported PHP versions |
-| `php_cs_fixer.disabled_rules` | `[]` | Rule names appended as `false` at the end of `setRules()` to turn them off (overrides preset and built-in entries) |
 | `php_cs_fixer.exclude` | `["vendor", "tests", ".git"]` | Excluded directories |
+| `php_cs_fixer.extend` | `""` | Raw PHP fragment inserted at the end of the `setRules()` array (overrides preset and built-in entries) |
 | `php_cs_fixer.paths` | `["../.."]` | Paths to fix |
 
 ### phpcs
@@ -445,8 +445,8 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 | Key | Default | Description |
 |-----|---------|-------------|
 | `phpcs.cli` | `true` | Enable PHP_CodeSniffer |
-| `phpcs.disabled_rules` | `[]` | Rule names rendered as `<rule ref="..."><severity>0</severity></rule>` to silence them (overrides rules inherited from referenced rulesets) |
 | `phpcs.excludes` | `["vendor/*", "tests/*", ".git/*"]` | Excluded patterns |
+| `phpcs.extend` | `""` | Raw XML fragment inserted at the end of the generated `<ruleset>` (lets you silence or tune inherited sniffs) |
 | `phpcs.files` | `["../../src"]` | Files/directories to check |
 | `phpcs.root_namespace` | `""` | Root namespace for PSR-4 check |
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,7 @@ append:
         - lib
     exclude:
         - legacy
-    php_cs_fixer.disabled_rules:
-        - phpdoc_scalar
-    phpcs.disabled_rules:
-        - SlevomatCodingStandard.PHP.RequireExplicitAssertion
 ```
-
-`php_cs_fixer.disabled_rules` and `phpcs.disabled_rules` turn off individual rules — useful when a rule clashes with project code (for example, a class named `Scalar` being lowercased by `phpdoc_scalar`).
 
 Use `override` to replace individual keys:
 
@@ -51,6 +45,16 @@ override:
     php.versions: ["8.3", "8.4", "8.5"]
     ci.pr.max_lines_changed: 400
 ```
+
+Use `php_cs_fixer.extend` and `phpcs.extend` to inject native-syntax fragments at the end of the generated config. Useful when a built-in rule clashes with project code — for example, narrowing `phpdoc_types` instead of disabling it entirely:
+
+```yaml
+override:
+    php_cs_fixer.extend: "        'phpdoc_types' => ['exclude' => ['scalar']],"
+    phpcs.extend: "    <rule ref=\"Foo.Bar\"><severity>0</severity></rule>"
+```
+
+The value is passed through verbatim; piqule does not parse it. Use a YAML block scalar (`|` or `|-`) for multi-line fragments.
 
 Use `envs` to export environment variables in CI workflows. Each value is a shell command evaluated at runtime:
 

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -56,13 +56,13 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
-  php_cs_fixer.disabled_rules: []
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
+  php_cs_fixer.extend: ""
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
-  phpcs.disabled_rules: []
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
+  phpcs.extend: ""
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""
 

--- a/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/templates/always/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -106,6 +106,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
-<< config(php_cs_fixer.disabled_rules)|format_each("        '%s' => false,")|join("\n") >>
+<< config(php_cs_fixer.extend)|join("") >>
     ]))
     ->setUnsupportedPhpVersionAllowed(<< config(php_cs_fixer.allow_unsupported)|join("") >>);

--- a/templates/always/.piqule/phpcs/phpcs.xml
+++ b/templates/always/.piqule/phpcs/phpcs.xml
@@ -22,5 +22,5 @@
     <rule ref=".piqule/phpcs/slevomat-flow.xml"/>
     <rule ref=".piqule/phpcs/slevomat-style.xml"/>
 
-<< config(phpcs.disabled_rules)|format_each('    <rule ref="%s"><severity>0</severity></rule>')|join("\n") >>
+<< config(phpcs.extend)|join("") >>
 </ruleset>

--- a/tests/Integration/Config/ConfigYamlTemplateTest.php
+++ b/tests/Integration/Config/ConfigYamlTemplateTest.php
@@ -158,28 +158,28 @@ final class ConfigYamlTemplateTest extends TestCase
     }
 
     #[Test]
-    public function phpCsFixerDisabledRulesIsEmptyByDefault(): void
+    public function phpCsFixerExtendIsEmptyByDefault(): void
     {
         self::assertThat(
             new DefaultConfig(),
-            new HasConfigYamlKey('php_cs_fixer.disabled_rules', []),
-            'php_cs_fixer.disabled_rules must be empty so no rule overrides are emitted by default',
+            new HasConfigYamlKey('php_cs_fixer.extend', ['']),
+            'php_cs_fixer.extend must be an empty string by default',
         );
     }
 
     #[Test]
-    public function appendPhpCsFixerDisabledRulesAddsRuleNames(): void
+    public function overridePhpCsFixerExtendStoresRawString(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
-            "append:\n    php_cs_fixer.disabled_rules:\n        - phpdoc_scalar\n",
+            "override:\n    php_cs_fixer.extend: \"'phpdoc_scalar' => false,\"\n",
         );
 
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.piqule.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('php_cs_fixer.disabled_rules', ['phpdoc_scalar']),
-                'Append must add "phpdoc_scalar" to php_cs_fixer.disabled_rules',
+                new HasConfigYamlKey('php_cs_fixer.extend', ["'phpdoc_scalar' => false,"]),
+                'Override must store the extend scalar verbatim',
             );
         } finally {
             $folder->close();
@@ -187,28 +187,28 @@ final class ConfigYamlTemplateTest extends TestCase
     }
 
     #[Test]
-    public function phpcsDisabledRulesIsEmptyByDefault(): void
+    public function phpcsExtendIsEmptyByDefault(): void
     {
         self::assertThat(
             new DefaultConfig(),
-            new HasConfigYamlKey('phpcs.disabled_rules', []),
-            'phpcs.disabled_rules must be empty so no rule overrides are emitted by default',
+            new HasConfigYamlKey('phpcs.extend', ['']),
+            'phpcs.extend must be an empty string by default',
         );
     }
 
     #[Test]
-    public function appendPhpcsDisabledRulesAddsRuleNames(): void
+    public function overridePhpcsExtendStoresRawString(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
-            "append:\n    phpcs.disabled_rules:\n        - SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly\n",
+            "override:\n    phpcs.extend: \"<rule ref='Foo.Bar'><severity>0</severity></rule>\"\n",
         );
 
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.piqule.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('phpcs.disabled_rules', ['SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly']),
-                'Append must add rule name to phpcs.disabled_rules',
+                new HasConfigYamlKey('phpcs.extend', ["<rule ref='Foo.Bar'><severity>0</severity></rule>"]),
+                'Override must store the extend scalar verbatim',
             );
         } finally {
             $folder->close();

--- a/tests/Unit/File/ConfiguredFileTest.php
+++ b/tests/Unit/File/ConfiguredFileTest.php
@@ -389,52 +389,44 @@ final class ConfiguredFileTest extends TestCase
     }
 
     #[Test]
-    public function rendersDisabledPhpCsFixerRulesAsFalseEntries(): void
+    public function rendersPhpCsFixerExtendAsRawString(): void
     {
         $config = new OverrideConfig(
             new DefaultConfig(),
-            ['php_cs_fixer.disabled_rules' => ['phpdoc_scalar', 'phpdoc_types']],
+            ['php_cs_fixer.extend' => "        'phpdoc_types' => ['exclude' => ['scalar']],"],
         );
 
         self::assertThat(
             new ConfiguredFile(
                 new TextFile(
                     'php-cs-fixer.php',
-                    '<< config(php_cs_fixer.disabled_rules)|format_each("        \'%s\' => false,")|join("\n") >>',
+                    '<< config(php_cs_fixer.extend)|join("") >>',
                 ),
                 $this->actions($config),
             ),
-            new HasFileContents("        'phpdoc_scalar' => false,\n        'phpdoc_types' => false,"),
-            'disabled_rules template formula must render each rule as => false entry',
+            new HasFileContents("        'phpdoc_types' => ['exclude' => ['scalar']],"),
+            'php_cs_fixer.extend must pass the raw PHP fragment through to the template',
         );
     }
 
     #[Test]
-    public function rendersDisabledPhpcsRulesAsSilencedEntries(): void
+    public function rendersPhpcsExtendAsRawString(): void
     {
         $config = new OverrideConfig(
             new DefaultConfig(),
-            [
-                'phpcs.disabled_rules' => [
-                    'SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly',
-                    'SlevomatCodingStandard.PHP.RequireExplicitAssertion',
-                ],
-            ],
+            ['phpcs.extend' => '    <rule ref="Foo.Bar"><severity>0</severity></rule>'],
         );
 
         self::assertThat(
             new ConfiguredFile(
                 new TextFile(
                     'phpcs.xml',
-                    '<< config(phpcs.disabled_rules)|format_each(\'    <rule ref="%s"><severity>0</severity></rule>\')|join("\n") >>',
+                    '<< config(phpcs.extend)|join("") >>',
                 ),
                 $this->actions($config),
             ),
-            new HasFileContents(
-                '    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"><severity>0</severity></rule>' . "\n"
-                . '    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"><severity>0</severity></rule>',
-            ),
-            'phpcs.disabled_rules template formula must render each rule as a silenced ruleset entry',
+            new HasFileContents('    <rule ref="Foo.Bar"><severity>0</severity></rule>'),
+            'phpcs.extend must pass the raw XML fragment through to the template',
         );
     }
 


### PR DESCRIPTION
## Summary

- **Replaces** `php_cs_fixer.disabled_rules` and `phpcs.disabled_rules` (from #645, #647) with a single `.extend` scalar per tool. Old keys are removed.
- **Solves** the Primus case where a class named `Scalar` was lowercased by `phpdoc_scalar` — but the full rule is still useful for `boolean`/`integer` normalization. Now narrow it via `phpdoc_types.exclude: [scalar]` instead of disabling anything.
- **Zero new code in piqule.** Uses the existing `|join("")` action. Only template and config-key changes.

## Why not `rules: {...}` with nested maps

Supporting structured rule configs would have required nested map values in the Config layer, which conflicts with the flat \"scalar or list<scalar>\" contract piqule chose. The `extend` scalar keeps the Config layer flat and gives projects the full expressiveness of each tool's native rule syntax.

## Usage

```yaml
override:
    php_cs_fixer.extend: \"        'phpdoc_types' => ['exclude' => ['scalar']],\"
    phpcs.extend: |-
        <rule ref=\"SlevomatCodingStandard.PHP.RequireExplicitAssertion\">
            <severity>0</severity>
        </rule>
```

Piqule is blind to the content; php-cs-fixer and phpcs validate it at parse time and surface any errors themselves.

## Breaking change

`php_cs_fixer.disabled_rules` and `phpcs.disabled_rules` are removed. Both were merged two days ago (#645, #647), not in any release yet — not expected to affect any existing user.