### PR TITLE
Switch @throws enforcement to haspadar MissingThrowsRule

### DIFF
--- a/.piqule/phpstan/phpstan.neon
+++ b/.piqule/phpstan/phpstan.neon
@@ -16,8 +16,6 @@ parameters:
     checkDynamicProperties: true
 
     exceptions:
-        check:
-            missingCheckedExceptionInThrows: true
         checkedExceptionClasses:
             - \Throwable
 

--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.42.1",
+            "version": "v0.44.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050"
+                "reference": "94dbf1f1c1648dca9a36f919423ac58e24f7e511"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/bc3aa5840c0b52b6208ea399ab94987f79463050",
-                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/94dbf1f1c1648dca9a36f919423ac58e24f7e511",
+                "reference": "94dbf1f1c1648dca9a36f919423ac58e24f7e511",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.42.1"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.44.1"
             },
-            "time": "2026-04-23T12:56:16+00:00"
+            "time": "2026-04-24T12:59:00+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/templates/always/.piqule/phpstan/phpstan.neon
+++ b/templates/always/.piqule/phpstan/phpstan.neon
@@ -15,8 +15,6 @@ parameters:
     checkDynamicProperties: true
 
     exceptions:
-        check:
-            missingCheckedExceptionInThrows: true
         checkedExceptionClasses:
 << config(phpstan.checked_exceptions)|format_each("            - %s")|join("\n") >>
 


### PR DESCRIPTION
## Summary

- Bump `haspadar/phpstan-rules` 0.42.1 → 0.44.1.
- Drop `exceptions.check.missingCheckedExceptionInThrows: true` from the piqule phpstan template.

## Why

The built-in PHPStan check required `@throws` on every method that could throw — including methods marked `#[\Override]`. That conflicted directly with `haspadar.noPhpdocOverride`, which forbids phpdoc on overridden methods. The two could not both be satisfied on an override that propagates a checked exception.

`haspadar/phpstan-rules` 0.44.1 ships its own `MissingThrowsRule` with a `skipOverridden` toggle (default `true`). The shared `rules.neon` turns the built-in check off; the piqule template was still forcing it back on, so the override is removed.

All 14 piqule checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted code quality linting configuration to relax stricter validation requirements for exception documentation, providing developers with greater flexibility in compliance standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->