### PR TITLE
Settings Contract With Patch Decorator

### DIFF
--- a/src/Settings/Patch.php
+++ b/src/Settings/Patch.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings;
+
+use Haspadar\Piqule\Settings\Value\Value;
+
+/**
+ * One operation derived from .piqule.yaml that modifies a configuration value.
+ */
+interface Patch
+{
+    /**
+     * Returns the configuration key targeted by this patch.
+     */
+    public function key(): string;
+
+    /**
+     * Returns a new value produced by applying this patch to the base value.
+     */
+    public function applied(Value $base): Value;
+}

--- a/src/Settings/PatchedSettings.php
+++ b/src/Settings/PatchedSettings.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings;
+
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+
+/**
+ * Settings decorated with one Patch applied to its targeted key.
+ *
+ * Example:
+ *
+ *     new PatchedSettings(new DefaultSettings(), $patch);
+ */
+final readonly class PatchedSettings implements Settings
+{
+    /**
+     * Initializes with the base settings and the patch to apply.
+     *
+     * @param Settings $base Underlying settings exposing the original value
+     * @param Patch $patch Operation applied to the value at the patch key
+     */
+    public function __construct(private Settings $base, private Patch $patch) {}
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return $this->base->has($name);
+    }
+
+    #[Override]
+    public function value(string $name): Value
+    {
+        return $name === $this->patch->key()
+            ? $this->patch->applied($this->base->value($name))
+            : $this->base->value($name);
+    }
+}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings;
+
+use Haspadar\Piqule\Settings\Value\Value;
+
+/**
+ * Read-only access to configuration values keyed by flat dot-notated names.
+ */
+interface Settings
+{
+    /**
+     * Returns true if the key is declared in this configuration.
+     */
+    public function has(string $name): bool;
+
+    /**
+     * Returns the configuration value bound to the given key.
+     */
+    public function value(string $name): Value;
+}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -18,6 +18,8 @@ interface Settings
 
     /**
      * Returns the configuration value bound to the given key.
+     *
+     * Throws when the key is not declared.
      */
     public function value(string $name): Value;
 }

--- a/tests/Fake/Settings/EchoPatch.php
+++ b/tests/Fake/Settings/EchoPatch.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fake\Settings;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\Value;
+
+final readonly class EchoPatch implements Patch
+{
+    public function __construct(private string $key) {}
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    public function applied(Value $base): Value
+    {
+        return $base;
+    }
+}

--- a/tests/Fake/Settings/FakePatch.php
+++ b/tests/Fake/Settings/FakePatch.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fake\Settings;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\Value;
+
+final readonly class FakePatch implements Patch
+{
+    public function __construct(private string $key, private Value $result) {}
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    public function applied(Value $base): Value
+    {
+        return $this->result;
+    }
+}

--- a/tests/Fake/Settings/FakeSettings.php
+++ b/tests/Fake/Settings/FakeSettings.php
@@ -8,7 +8,7 @@ use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Settings\Settings;
 use Haspadar\Piqule\Settings\Value\Value;
 
-final class FakeSettings implements Settings
+final readonly class FakeSettings implements Settings
 {
     /**
      * @param array<string, Value> $values

--- a/tests/Fake/Settings/FakeSettings.php
+++ b/tests/Fake/Settings/FakeSettings.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Fake\Settings;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Settings;
+use Haspadar\Piqule\Settings\Value\Value;
+
+final class FakeSettings implements Settings
+{
+    /**
+     * @param array<string, Value> $values
+     */
+    public function __construct(private array $values) {}
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->values);
+    }
+
+    public function value(string $name): Value
+    {
+        if (!$this->has($name)) {
+            throw new PiquleException(sprintf('Unknown config key "%s"', $name));
+        }
+
+        return $this->values[$name];
+    }
+}

--- a/tests/Unit/Settings/PatchedSettingsTest.php
+++ b/tests/Unit/Settings/PatchedSettingsTest.php
@@ -72,4 +72,18 @@ final class PatchedSettingsTest extends TestCase
             'PatchedSettings must delegate has() to the base settings',
         );
     }
+
+    #[Test]
+    public function ignoresPatchKeyWhenCheckingHas(): void
+    {
+        $settings = new PatchedSettings(
+            new FakeSettings(['phpstan.level' => new IntValue(9)]),
+            new FakePatch('absent.key', new IntValue(7)),
+        );
+
+        self::assertFalse(
+            $settings->has('absent.key'),
+            'PatchedSettings must not report has() true for a key only declared by the patch',
+        );
+    }
 }

--- a/tests/Unit/Settings/PatchedSettingsTest.php
+++ b/tests/Unit/Settings/PatchedSettingsTest.php
@@ -6,6 +6,7 @@ namespace Haspadar\Piqule\Tests\Unit\Settings;
 
 use Haspadar\Piqule\Settings\PatchedSettings;
 use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Tests\Fake\Settings\EchoPatch;
 use Haspadar\Piqule\Tests\Fake\Settings\FakePatch;
 use Haspadar\Piqule\Tests\Fake\Settings\FakeSettings;
 use PHPUnit\Framework\Attributes\Test;
@@ -40,6 +41,21 @@ final class PatchedSettingsTest extends TestCase
             new IntValue(9),
             $settings->value('phpstan.level'),
             'PatchedSettings must return the base value for keys outside the patch scope',
+        );
+    }
+
+    #[Test]
+    public function passesBaseValueToPatch(): void
+    {
+        $settings = new PatchedSettings(
+            new FakeSettings(['phpstan.level' => new IntValue(9)]),
+            new EchoPatch('phpstan.level'),
+        );
+
+        self::assertEquals(
+            new IntValue(9),
+            $settings->value('phpstan.level'),
+            'PatchedSettings must pass the base value to the patch and return the patch result',
         );
     }
 

--- a/tests/Unit/Settings/PatchedSettingsTest.php
+++ b/tests/Unit/Settings/PatchedSettingsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings;
+
+use Haspadar\Piqule\Settings\PatchedSettings;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Tests\Fake\Settings\FakePatch;
+use Haspadar\Piqule\Tests\Fake\Settings\FakeSettings;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PatchedSettingsTest extends TestCase
+{
+    #[Test]
+    public function returnsPatchedValueWhenKeyMatches(): void
+    {
+        $settings = new PatchedSettings(
+            new FakeSettings(['phpstan.level' => new IntValue(9)]),
+            new FakePatch('phpstan.level', new IntValue(7)),
+        );
+
+        self::assertEquals(
+            new IntValue(7),
+            $settings->value('phpstan.level'),
+            'PatchedSettings must return the patched value for the targeted key',
+        );
+    }
+
+    #[Test]
+    public function returnsBaseValueWhenKeyDoesNotMatch(): void
+    {
+        $settings = new PatchedSettings(
+            new FakeSettings(['phpstan.level' => new IntValue(9)]),
+            new FakePatch('other.key', new IntValue(7)),
+        );
+
+        self::assertEquals(
+            new IntValue(9),
+            $settings->value('phpstan.level'),
+            'PatchedSettings must return the base value for keys outside the patch scope',
+        );
+    }
+
+    #[Test]
+    public function delegatesHasToBaseSettings(): void
+    {
+        $settings = new PatchedSettings(
+            new FakeSettings(['phpstan.level' => new IntValue(9)]),
+            new FakePatch('phpstan.level', new IntValue(7)),
+        );
+
+        self::assertTrue(
+            $settings->has('phpstan.level'),
+            'PatchedSettings must delegate has() to the base settings',
+        );
+    }
+}


### PR DESCRIPTION
- Added Settings interface with has() and value() lookup over Value-typed payloads
- Added Patch interface that names a target key and produces a new value from the base
- Added PatchedSettings decorator that routes the patch onto the matching key
- Added unit coverage for routing, fallback to base, has() delegation, and base-value forwarding

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `Settings` interface for accessing configuration values using dot-notation keys
  * Introduced patch support for applying configuration modifications through a new `Patch` interface
  * New `PatchedSettings` implementation enables decorating existing settings with individual patches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->