### PR TITLE
Override Patches For Scalars And Deep-Merged Trees

### DIFF
--- a/src/Settings/Patch/OverrideScalar.php
+++ b/src/Settings/Patch/OverrideScalar.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\ScalarValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+
+/**
+ * Replaces a scalar configuration value at the given key.
+ *
+ * Example:
+ *
+ *     new OverrideScalar('phpstan.level', new IntValue(8));
+ */
+final readonly class OverrideScalar implements Patch
+{
+    /**
+     * Initializes with the target key and the replacement scalar value.
+     *
+     * @param string $key Configuration key whose scalar value is replaced
+     * @param ScalarValue $value Scalar replacing the base value at the key
+     */
+    public function __construct(private string $key, private ScalarValue $value) {}
+
+    #[Override]
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    #[Override]
+    public function applied(Value $base): Value
+    {
+        return $this->value;
+    }
+}

--- a/src/Settings/Patch/OverrideTree.php
+++ b/src/Settings/Patch/OverrideTree.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\MergedTree;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+use TypeError;
+
+/**
+ * Deep-merges an override tree into the base tree at the given key.
+ *
+ * Example:
+ *
+ *     new OverrideTree('phpstan.parameters', new TreeValue([
+ *         'haspadar' => new TreeValue([
+ *             'afferentCoupling' => new TreeValue([
+ *                 'ignoreAbstract' => new BoolValue(true),
+ *             ]),
+ *         ]),
+ *     ]));
+ */
+final readonly class OverrideTree implements Patch
+{
+    /**
+     * Initializes with the target key and the override tree to merge in.
+     *
+     * @param string $key Configuration key whose tree value is merged
+     * @param TreeValue $value Tree carrying the entries to override on the base
+     */
+    public function __construct(private string $key, private TreeValue $value) {}
+
+    #[Override]
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    #[Override]
+    public function applied(Value $base): Value
+    {
+        if (!$base instanceof TreeValue) {
+            throw new TypeError(
+                sprintf('OverrideTree expects TreeValue at "%s"', $this->key),
+            );
+        }
+
+        return (new MergedTree($base, $this->value))->value();
+    }
+}

--- a/src/Settings/Value/MergedTree.php
+++ b/src/Settings/Value/MergedTree.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Value;
+
+/**
+ * Tree produced by deep-merging an override tree onto a base tree.
+ *
+ * Override entries replace base entries at every leaf. When both sides hold
+ * a TreeValue at the same key, the merge recurses into the nested trees.
+ *
+ * Example:
+ *
+ *     (new MergedTree($base, $override))->value();
+ */
+final readonly class MergedTree
+{
+    /**
+     * Initializes with the base tree and the tree carrying the overrides.
+     *
+     * @param TreeValue $base Tree whose entries are taken when the override leaves them untouched
+     * @param TreeValue $override Tree whose entries replace or recurse into matching base entries
+     */
+    public function __construct(private TreeValue $base, private TreeValue $override) {}
+
+    /** Returns the merged tree where override entries win over base entries. */
+    public function value(): TreeValue
+    {
+        $entries = $this->base->entries;
+
+        foreach ($this->override->entries as $key => $value) {
+            $entries[$key] = array_key_exists($key, $entries)
+                ? $this->resolved($entries[$key], $value)
+                : $value;
+        }
+
+        return new TreeValue($entries);
+    }
+
+    private function resolved(Value $base, Value $override): Value
+    {
+        return $base instanceof TreeValue && $override instanceof TreeValue
+            ? (new self($base, $override))->value()
+            : $override;
+    }
+}

--- a/tests/Unit/Settings/Patch/OverrideScalarTest.php
+++ b/tests/Unit/Settings/Patch/OverrideScalarTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch\OverrideScalar;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OverrideScalarTest extends TestCase
+{
+    #[Test]
+    public function exposesTargetKey(): void
+    {
+        self::assertSame(
+            'phpstan.level',
+            (new OverrideScalar('phpstan.level', new IntValue(8)))->key(),
+            'OverrideScalar must expose the configuration key it targets',
+        );
+    }
+
+    #[Test]
+    public function replacesBaseWithReplacementValue(): void
+    {
+        self::assertEquals(
+            new IntValue(8),
+            (new OverrideScalar('phpstan.level', new IntValue(8)))->applied(new IntValue(9)),
+            'OverrideScalar must replace the base value with the replacement scalar',
+        );
+    }
+}

--- a/tests/Unit/Settings/Patch/OverrideScalarTest.php
+++ b/tests/Unit/Settings/Patch/OverrideScalarTest.php
@@ -6,6 +6,7 @@ namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
 
 use Haspadar\Piqule\Settings\Patch\OverrideScalar;
 use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -28,6 +29,16 @@ final class OverrideScalarTest extends TestCase
             new IntValue(8),
             (new OverrideScalar('phpstan.level', new IntValue(8)))->applied(new IntValue(9)),
             'OverrideScalar must replace the base value with the replacement scalar',
+        );
+    }
+
+    #[Test]
+    public function ignoresBaseScalarTypeWhenReplacing(): void
+    {
+        self::assertEquals(
+            new IntValue(8),
+            (new OverrideScalar('phpstan.level', new IntValue(8)))->applied(new StringValue('old')),
+            'OverrideScalar must ignore the base value entirely, even when its scalar type differs',
         );
     }
 }

--- a/tests/Unit/Settings/Patch/OverrideTreeTest.php
+++ b/tests/Unit/Settings/Patch/OverrideTreeTest.php
@@ -106,6 +106,7 @@ final class OverrideTreeTest extends TestCase
     public function rejectsBaseValueThatIsNotATree(): void
     {
         $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('phpstan.parameters');
 
         (new OverrideTree('phpstan.parameters', new TreeValue([])))->applied(new IntValue(8));
     }

--- a/tests/Unit/Settings/Patch/OverrideTreeTest.php
+++ b/tests/Unit/Settings/Patch/OverrideTreeTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch\OverrideTree;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+final class OverrideTreeTest extends TestCase
+{
+    #[Test]
+    public function exposesTargetKey(): void
+    {
+        self::assertSame(
+            'phpstan.parameters',
+            (new OverrideTree('phpstan.parameters', new TreeValue([])))->key(),
+            'OverrideTree must expose the configuration key it targets',
+        );
+    }
+
+    #[Test]
+    public function addsNewKeyWithoutTouchingBaseEntries(): void
+    {
+        $base = new TreeValue(['existing' => new IntValue(1)]);
+        $patch = new TreeValue(['added' => new BoolValue(true)]);
+
+        self::assertEquals(
+            new TreeValue([
+                'existing' => new IntValue(1),
+                'added' => new BoolValue(true),
+            ]),
+            (new OverrideTree('phpstan.parameters', $patch))->applied($base),
+            'OverrideTree must add new keys without touching existing base entries',
+        );
+    }
+
+    #[Test]
+    public function replacesExistingLeafValue(): void
+    {
+        $base = new TreeValue(['flag' => new BoolValue(false)]);
+        $patch = new TreeValue(['flag' => new BoolValue(true)]);
+
+        self::assertEquals(
+            new TreeValue(['flag' => new BoolValue(true)]),
+            (new OverrideTree('phpstan.parameters', $patch))->applied($base),
+            'OverrideTree must replace an existing leaf value with the override',
+        );
+    }
+
+    #[Test]
+    public function descendsThroughNestedTreesPreservingSiblings(): void
+    {
+        $base = new TreeValue([
+            'haspadar' => new TreeValue([
+                'afferentCoupling' => new TreeValue([
+                    'ignoreInterfaces' => new BoolValue(true),
+                    'ignoreAbstract' => new BoolValue(false),
+                ]),
+            ]),
+        ]);
+        $patch = new TreeValue([
+            'haspadar' => new TreeValue([
+                'afferentCoupling' => new TreeValue([
+                    'ignoreAbstract' => new BoolValue(true),
+                ]),
+            ]),
+        ]);
+
+        self::assertEquals(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'ignoreInterfaces' => new BoolValue(true),
+                        'ignoreAbstract' => new BoolValue(true),
+                    ]),
+                ]),
+            ]),
+            (new OverrideTree('phpstan.parameters', $patch))->applied($base),
+            'OverrideTree must descend into nested trees and keep sibling entries intact',
+        );
+    }
+
+    #[Test]
+    public function replacesEntireBranchWhenOverrideIsNotTree(): void
+    {
+        $base = new TreeValue([
+            'tag' => new TreeValue(['name' => new StringValue('old')]),
+        ]);
+        $patch = new TreeValue(['tag' => new StringValue('new')]);
+
+        self::assertEquals(
+            new TreeValue(['tag' => new StringValue('new')]),
+            (new OverrideTree('phpstan.parameters', $patch))->applied($base),
+            'OverrideTree must replace the whole base branch when override leaf is not a tree',
+        );
+    }
+
+    #[Test]
+    public function rejectsBaseValueThatIsNotATree(): void
+    {
+        $this->expectException(TypeError::class);
+
+        (new OverrideTree('phpstan.parameters', new TreeValue([])))->applied(new IntValue(8));
+    }
+}

--- a/tests/Unit/Settings/Value/MergedTreeTest.php
+++ b/tests/Unit/Settings/Value/MergedTreeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Value;
+
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\MergedTree;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MergedTreeTest extends TestCase
+{
+    #[Test]
+    public function copiesBaseEntriesWhenOverrideIsEmpty(): void
+    {
+        $base = new TreeValue(['a' => new IntValue(1)]);
+
+        self::assertEquals(
+            $base,
+            (new MergedTree($base, new TreeValue([])))->value(),
+            'MergedTree must return the base tree when the override is empty',
+        );
+    }
+
+    #[Test]
+    public function recursesIntoNestedTreesAtSharedKeys(): void
+    {
+        $base = new TreeValue([
+            'outer' => new TreeValue([
+                'kept' => new IntValue(1),
+                'replaced' => new BoolValue(false),
+            ]),
+        ]);
+        $override = new TreeValue([
+            'outer' => new TreeValue(['replaced' => new BoolValue(true)]),
+        ]);
+
+        self::assertEquals(
+            new TreeValue([
+                'outer' => new TreeValue([
+                    'kept' => new IntValue(1),
+                    'replaced' => new BoolValue(true),
+                ]),
+            ]),
+            (new MergedTree($base, $override))->value(),
+            'MergedTree must recurse into nested trees at shared keys and preserve siblings',
+        );
+    }
+}

--- a/tests/Unit/Settings/Value/MergedTreeTest.php
+++ b/tests/Unit/Settings/Value/MergedTreeTest.php
@@ -81,6 +81,19 @@ final class MergedTreeTest extends TestCase
     }
 
     #[Test]
+    public function replacesScalarBaseWithTreeOverride(): void
+    {
+        self::assertEquals(
+            new TreeValue(['tag' => new TreeValue(['name' => new StringValue('new')])]),
+            (new MergedTree(
+                new TreeValue(['tag' => new StringValue('old')]),
+                new TreeValue(['tag' => new TreeValue(['name' => new StringValue('new')])]),
+            ))->value(),
+            'MergedTree must replace a scalar base with the override tree at a shared key',
+        );
+    }
+
+    #[Test]
     public function recursesIntoNestedTreesAtSharedKeys(): void
     {
         $base = new TreeValue([

--- a/tests/Unit/Settings/Value/MergedTreeTest.php
+++ b/tests/Unit/Settings/Value/MergedTreeTest.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Tests\Unit\Settings\Value;
 use Haspadar\Piqule\Settings\Value\BoolValue;
 use Haspadar\Piqule\Settings\Value\IntValue;
 use Haspadar\Piqule\Settings\Value\MergedTree;
+use Haspadar\Piqule\Settings\Value\StringValue;
 use Haspadar\Piqule\Settings\Value\TreeValue;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +23,60 @@ final class MergedTreeTest extends TestCase
             $base,
             (new MergedTree($base, new TreeValue([])))->value(),
             'MergedTree must return the base tree when the override is empty',
+        );
+    }
+
+    #[Test]
+    public function copiesOverrideEntriesWhenBaseIsEmpty(): void
+    {
+        $override = new TreeValue(['a' => new IntValue(1)]);
+
+        self::assertEquals(
+            $override,
+            (new MergedTree(new TreeValue([]), $override))->value(),
+            'MergedTree must return the override tree when the base is empty',
+        );
+    }
+
+    #[Test]
+    public function addsKeyAbsentInBase(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'kept' => new IntValue(1),
+                'added' => new BoolValue(true),
+            ]),
+            (new MergedTree(
+                new TreeValue(['kept' => new IntValue(1)]),
+                new TreeValue(['added' => new BoolValue(true)]),
+            ))->value(),
+            'MergedTree must add a key from the override when it is absent in the base',
+        );
+    }
+
+    #[Test]
+    public function replacesLeafAtTopLevel(): void
+    {
+        self::assertEquals(
+            new TreeValue(['flag' => new BoolValue(true)]),
+            (new MergedTree(
+                new TreeValue(['flag' => new BoolValue(false)]),
+                new TreeValue(['flag' => new BoolValue(true)]),
+            ))->value(),
+            'MergedTree must replace a top-level leaf when both sides hold non-tree values',
+        );
+    }
+
+    #[Test]
+    public function replacesBaseBranchWhenOverrideIsNotTree(): void
+    {
+        self::assertEquals(
+            new TreeValue(['tag' => new StringValue('new')]),
+            (new MergedTree(
+                new TreeValue(['tag' => new TreeValue(['name' => new StringValue('old')])]),
+                new TreeValue(['tag' => new StringValue('new')]),
+            ))->value(),
+            'MergedTree must replace the base branch when the override leaf is not a tree',
         );
     }
 


### PR DESCRIPTION
- Added OverrideScalar that replaces a scalar configuration value at the targeted key
- Added OverrideTree that delegates deep-merging the override entries onto the base tree
- Added MergedTree value-helper that recurses into shared keys and replaces leaves elsewhere

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration override support for scalar settings with targeted key replacement
  * Added deep-merge capabilities for nested configuration structures with intelligent recursive merging

* **Tests**
  * Added comprehensive test coverage for configuration override and merging functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->