### PR TITLE
Append Patches For Lists And Trees

### DIFF
--- a/src/Settings/Patch/AppendList.php
+++ b/src/Settings/Patch/AppendList.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+use TypeError;
+
+/**
+ * Appends entries to the end of a list configuration value at the given key.
+ *
+ * Example:
+ *
+ *     new AppendList('infra.exclude', new ListValue([new StringValue('dist')]));
+ */
+final readonly class AppendList implements Patch
+{
+    /**
+     * Initializes with the target key and the list of entries to append.
+     *
+     * @param string $key Configuration key whose list value receives the extra entries
+     * @param ListValue $extra Entries appended to the end of the base list
+     */
+    public function __construct(private string $key, private ListValue $extra) {}
+
+    #[Override]
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    #[Override]
+    public function applied(Value $base): Value
+    {
+        if (!$base instanceof ListValue) {
+            throw new TypeError(
+                sprintf('AppendList expects ListValue at "%s"', $this->key),
+            );
+        }
+
+        return new ListValue([...$base->children, ...$this->extra->children]);
+    }
+}

--- a/src/Settings/Patch/AppendTree.php
+++ b/src/Settings/Patch/AppendTree.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+use TypeError;
+
+/**
+ * Adds new keys to a tree configuration value without overwriting existing entries.
+ *
+ * Example:
+ *
+ *     new AppendTree('phpstan.parameters', new TreeValue([
+ *         'reportUnmatchedIgnoredErrors' => new BoolValue(true),
+ *     ]));
+ */
+final readonly class AppendTree implements Patch
+{
+    /**
+     * Initializes with the target key and the entries to add to the base tree.
+     *
+     * @param string $key Configuration key whose tree value receives the extra entries
+     * @param TreeValue $extra Entries added to the base tree only when their key is absent
+     */
+    public function __construct(private string $key, private TreeValue $extra) {}
+
+    #[Override]
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    #[Override]
+    public function applied(Value $base): Value
+    {
+        if (!$base instanceof TreeValue) {
+            throw new TypeError(
+                sprintf('AppendTree expects TreeValue at "%s"', $this->key),
+            );
+        }
+
+        $entries = $base->entries;
+
+        foreach ($this->extra->entries as $key => $value) {
+            $entries[$key] ??= $value;
+        }
+
+        return new TreeValue($entries);
+    }
+}

--- a/tests/Unit/Settings/Patch/AppendListTest.php
+++ b/tests/Unit/Settings/Patch/AppendListTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch\AppendList;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+final class AppendListTest extends TestCase
+{
+    #[Test]
+    public function exposesTargetKey(): void
+    {
+        self::assertSame(
+            'infra.exclude',
+            (new AppendList('infra.exclude', new ListValue([])))->key(),
+            'AppendList must expose the configuration key it targets',
+        );
+    }
+
+    #[Test]
+    public function appendsExtraEntriesAfterBaseEntries(): void
+    {
+        $base = new ListValue([new StringValue('vendor'), new StringValue('tests')]);
+        $extra = new ListValue([new StringValue('dist')]);
+
+        self::assertEquals(
+            new ListValue([
+                new StringValue('vendor'),
+                new StringValue('tests'),
+                new StringValue('dist'),
+            ]),
+            (new AppendList('infra.exclude', $extra))->applied($base),
+            'AppendList must append the extra entries after the base entries',
+        );
+    }
+
+    #[Test]
+    public function returnsBaseUnchangedWhenExtraIsEmpty(): void
+    {
+        $base = new ListValue([new StringValue('vendor')]);
+
+        self::assertEquals(
+            $base,
+            (new AppendList('infra.exclude', new ListValue([])))->applied($base),
+            'AppendList must return the base list unchanged when no entries are appended',
+        );
+    }
+
+    #[Test]
+    public function rejectsBaseValueThatIsNotAList(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('infra.exclude');
+
+        (new AppendList('infra.exclude', new ListValue([])))->applied(new IntValue(8));
+    }
+}

--- a/tests/Unit/Settings/Patch/AppendTreeTest.php
+++ b/tests/Unit/Settings/Patch/AppendTreeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch\AppendTree;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+final class AppendTreeTest extends TestCase
+{
+    #[Test]
+    public function exposesTargetKey(): void
+    {
+        self::assertSame(
+            'phpstan.parameters',
+            (new AppendTree('phpstan.parameters', new TreeValue([])))->key(),
+            'AppendTree must expose the configuration key it targets',
+        );
+    }
+
+    #[Test]
+    public function addsKeyAbsentInBase(): void
+    {
+        $base = new TreeValue(['existing' => new IntValue(1)]);
+        $extra = new TreeValue(['added' => new BoolValue(true)]);
+
+        self::assertEquals(
+            new TreeValue([
+                'existing' => new IntValue(1),
+                'added' => new BoolValue(true),
+            ]),
+            (new AppendTree('phpstan.parameters', $extra))->applied($base),
+            'AppendTree must add a key from the extra tree when it is absent in the base',
+        );
+    }
+
+    #[Test]
+    public function keepsExistingKeyWhenAlsoPresentInExtra(): void
+    {
+        $base = new TreeValue(['flag' => new BoolValue(false)]);
+        $extra = new TreeValue(['flag' => new BoolValue(true)]);
+
+        self::assertEquals(
+            new TreeValue(['flag' => new BoolValue(false)]),
+            (new AppendTree('phpstan.parameters', $extra))->applied($base),
+            'AppendTree must keep the base entry when the same key is present in the extra tree',
+        );
+    }
+
+    #[Test]
+    public function returnsBaseUnchangedWhenExtraIsEmpty(): void
+    {
+        $base = new TreeValue(['existing' => new IntValue(1)]);
+
+        self::assertEquals(
+            $base,
+            (new AppendTree('phpstan.parameters', new TreeValue([])))->applied($base),
+            'AppendTree must return the base tree unchanged when no entries are appended',
+        );
+    }
+
+    #[Test]
+    public function rejectsBaseValueThatIsNotATree(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('phpstan.parameters');
+
+        (new AppendTree('phpstan.parameters', new TreeValue([])))->applied(new IntValue(8));
+    }
+}


### PR DESCRIPTION
- Added AppendList that concatenates extra entries after the base list at the targeted key
- Added AppendTree that adds new keys to the base tree and preserves entries when keys already exist

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new patch implementations to support appending entries to configuration lists and trees during settings management operations.

* **Tests**
  * Added comprehensive unit test coverage for the new configuration patching functionality, including edge cases and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->