### PR TITLE
Remove Patches For Lists And Trees

### DIFF
--- a/src/Settings/Patch/RemoveList.php
+++ b/src/Settings/Patch/RemoveList.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+use TypeError;
+
+/**
+ * Removes the named entries from a list configuration value at the given key.
+ *
+ * Example:
+ *
+ *     new RemoveList('phpstan.checked_exceptions', new ListValue([new StringValue('\\Throwable')]));
+ */
+final readonly class RemoveList implements Patch
+{
+    /**
+     * Initializes with the target key and the entries to drop from the base list.
+     *
+     * @param string $key Configuration key whose list value loses the named entries
+     * @param ListValue $items Entries removed from the base list when present
+     */
+    public function __construct(private string $key, private ListValue $items) {}
+
+    #[Override]
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    #[Override]
+    public function applied(Value $base): Value
+    {
+        if (!$base instanceof ListValue) {
+            throw new TypeError(
+                sprintf('RemoveList expects ListValue at "%s"', $this->key),
+            );
+        }
+
+        $kept = array_filter(
+            $base->children,
+            fn(Value $child): bool => !$this->matches($child),
+        );
+
+        return new ListValue(array_values($kept));
+    }
+
+    private function matches(Value $child): bool
+    {
+        $signature = serialize($child);
+
+        foreach ($this->items->children as $item) {
+            if (serialize($item) === $signature) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Settings/Patch/RemoveList.php
+++ b/src/Settings/Patch/RemoveList.php
@@ -42,24 +42,13 @@ final readonly class RemoveList implements Patch
             );
         }
 
+        $blocked = array_map('serialize', $this->items->children);
+
         $kept = array_filter(
             $base->children,
-            fn(Value $child): bool => !$this->matches($child),
+            static fn(Value $child): bool => !in_array(serialize($child), $blocked, true),
         );
 
         return new ListValue(array_values($kept));
-    }
-
-    private function matches(Value $child): bool
-    {
-        $signature = serialize($child);
-
-        foreach ($this->items->children as $item) {
-            if (serialize($item) === $signature) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Settings/Patch/RemoveTree.php
+++ b/src/Settings/Patch/RemoveTree.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+use TypeError;
+
+/**
+ * Removes the named keys from a tree configuration value at the given key.
+ *
+ * Example:
+ *
+ *     new RemoveTree('phpstan.parameters', ['reportUnmatchedIgnoredErrors']);
+ */
+final readonly class RemoveTree implements Patch
+{
+    /**
+     * Initializes with the target key and the names of entries to drop.
+     *
+     * @param string $key Configuration key whose tree value loses the named entries
+     * @param list<string> $keys Names of entries removed from the base tree when present
+     */
+    public function __construct(private string $key, private array $keys) {}
+
+    #[Override]
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    #[Override]
+    public function applied(Value $base): Value
+    {
+        if (!$base instanceof TreeValue) {
+            throw new TypeError(
+                sprintf('RemoveTree expects TreeValue at "%s"', $this->key),
+            );
+        }
+
+        $entries = $base->entries;
+
+        foreach ($this->keys as $name) {
+            unset($entries[$name]);
+        }
+
+        return new TreeValue($entries);
+    }
+}

--- a/tests/Unit/Settings/Patch/RemoveListTest.php
+++ b/tests/Unit/Settings/Patch/RemoveListTest.php
@@ -71,6 +71,30 @@ final class RemoveListTest extends TestCase
     }
 
     #[Test]
+    public function returnsEmptyListWhenAllEntriesRemoved(): void
+    {
+        $base = new ListValue([new StringValue('a'), new StringValue('b')]);
+        $items = new ListValue([new StringValue('a'), new StringValue('b')]);
+
+        self::assertEquals(
+            new ListValue([]),
+            (new RemoveList('foo', $items))->applied($base),
+            'RemoveList must return an empty list when every base entry is removed',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenBaseIsEmpty(): void
+    {
+        self::assertEquals(
+            new ListValue([]),
+            (new RemoveList('foo', new ListValue([new StringValue('a')])))
+                ->applied(new ListValue([])),
+            'RemoveList must return an empty list when the base list itself is empty',
+        );
+    }
+
+    #[Test]
     public function rejectsBaseValueThatIsNotAList(): void
     {
         $this->expectException(TypeError::class);

--- a/tests/Unit/Settings/Patch/RemoveListTest.php
+++ b/tests/Unit/Settings/Patch/RemoveListTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch\RemoveList;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+final class RemoveListTest extends TestCase
+{
+    #[Test]
+    public function exposesTargetKey(): void
+    {
+        self::assertSame(
+            'phpstan.checked_exceptions',
+            (new RemoveList('phpstan.checked_exceptions', new ListValue([])))->key(),
+            'RemoveList must expose the configuration key it targets',
+        );
+    }
+
+    #[Test]
+    public function dropsMatchingEntriesFromBase(): void
+    {
+        $base = new ListValue([
+            new StringValue('\\Throwable'),
+            new StringValue('\\RuntimeException'),
+        ]);
+        $items = new ListValue([new StringValue('\\Throwable')]);
+
+        self::assertEquals(
+            new ListValue([new StringValue('\\RuntimeException')]),
+            (new RemoveList('phpstan.checked_exceptions', $items))->applied($base),
+            'RemoveList must drop entries from the base list when they match items',
+        );
+    }
+
+    #[Test]
+    public function keepsBaseEntriesAbsentFromItems(): void
+    {
+        $base = new ListValue([new StringValue('vendor'), new StringValue('tests')]);
+        $items = new ListValue([new StringValue('dist')]);
+
+        self::assertEquals(
+            $base,
+            (new RemoveList('infra.exclude', $items))->applied($base),
+            'RemoveList must keep base entries when items list does not contain them',
+        );
+    }
+
+    #[Test]
+    public function reindexesRemainingEntries(): void
+    {
+        $base = new ListValue([
+            new StringValue('a'),
+            new StringValue('b'),
+            new StringValue('c'),
+        ]);
+        $items = new ListValue([new StringValue('b')]);
+
+        self::assertEquals(
+            new ListValue([new StringValue('a'), new StringValue('c')]),
+            (new RemoveList('foo', $items))->applied($base),
+            'RemoveList must produce a list with sequential numeric keys after removal',
+        );
+    }
+
+    #[Test]
+    public function rejectsBaseValueThatIsNotAList(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('phpstan.checked_exceptions');
+
+        (new RemoveList('phpstan.checked_exceptions', new ListValue([])))
+            ->applied(new IntValue(8));
+    }
+}

--- a/tests/Unit/Settings/Patch/RemoveTreeTest.php
+++ b/tests/Unit/Settings/Patch/RemoveTreeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch\RemoveTree;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+final class RemoveTreeTest extends TestCase
+{
+    #[Test]
+    public function exposesTargetKey(): void
+    {
+        self::assertSame(
+            'phpstan.parameters',
+            (new RemoveTree('phpstan.parameters', []))->key(),
+            'RemoveTree must expose the configuration key it targets',
+        );
+    }
+
+    #[Test]
+    public function dropsNamedKeyFromBase(): void
+    {
+        $base = new TreeValue([
+            'kept' => new IntValue(1),
+            'removed' => new BoolValue(true),
+        ]);
+
+        self::assertEquals(
+            new TreeValue(['kept' => new IntValue(1)]),
+            (new RemoveTree('phpstan.parameters', ['removed']))->applied($base),
+            'RemoveTree must drop the entry whose key is listed for removal',
+        );
+    }
+
+    #[Test]
+    public function ignoresKeyAbsentInBase(): void
+    {
+        $base = new TreeValue(['kept' => new IntValue(1)]);
+
+        self::assertEquals(
+            $base,
+            (new RemoveTree('phpstan.parameters', ['absent']))->applied($base),
+            'RemoveTree must keep base entries when removal targets keys absent from base',
+        );
+    }
+
+    #[Test]
+    public function rejectsBaseValueThatIsNotATree(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('phpstan.parameters');
+
+        (new RemoveTree('phpstan.parameters', []))->applied(new IntValue(8));
+    }
+}

--- a/tests/Unit/Settings/Patch/RemoveTreeTest.php
+++ b/tests/Unit/Settings/Patch/RemoveTreeTest.php
@@ -52,6 +52,34 @@ final class RemoveTreeTest extends TestCase
     }
 
     #[Test]
+    public function dropsEveryListedKeyAtOnce(): void
+    {
+        $base = new TreeValue([
+            'kept' => new IntValue(1),
+            'first' => new BoolValue(true),
+            'second' => new BoolValue(false),
+        ]);
+
+        self::assertEquals(
+            new TreeValue(['kept' => new IntValue(1)]),
+            (new RemoveTree('phpstan.parameters', ['first', 'second']))->applied($base),
+            'RemoveTree must drop every key listed for removal in a single application',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyTreeWhenAllKeysRemoved(): void
+    {
+        $base = new TreeValue(['only' => new IntValue(1)]);
+
+        self::assertEquals(
+            new TreeValue([]),
+            (new RemoveTree('phpstan.parameters', ['only']))->applied($base),
+            'RemoveTree must return an empty tree when every base entry is removed',
+        );
+    }
+
+    #[Test]
     public function rejectsBaseValueThatIsNotATree(): void
     {
         $this->expectException(TypeError::class);


### PR DESCRIPTION
- Added RemoveList that drops base entries whose serialized payload matches the removal items
- Added RemoveTree that drops base entries whose key is listed for removal

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RemoveList patch type for removing entries from list-based configurations.
  * Added RemoveTree patch type for removing entries from tree-based configurations.

* **Tests**
  * Comprehensive unit test coverage added for RemoveList and RemoveTree patch functionality, including edge cases and type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->