### PR TITLE
Override Patch For Lists

### DIFF
--- a/src/Settings/Patch/OverrideList.php
+++ b/src/Settings/Patch/OverrideList.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+
+/**
+ * Replaces a list configuration value at the given key in full.
+ *
+ * Example:
+ *
+ *     new OverrideList('phpstan.paths', new ListValue([new StringValue('lib')]));
+ */
+final readonly class OverrideList implements Patch
+{
+    /**
+     * Initializes with the target key and the replacement list value.
+     *
+     * @param string $key Configuration key whose list value is replaced
+     * @param ListValue $value List replacing the base value at the key
+     */
+    public function __construct(private string $key, private ListValue $value) {}
+
+    #[Override]
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    #[Override]
+    public function applied(Value $base): Value
+    {
+        return $this->value;
+    }
+}

--- a/tests/Unit/Settings/Patch/OverrideListTest.php
+++ b/tests/Unit/Settings/Patch/OverrideListTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\Settings\Patch\OverrideList;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OverrideListTest extends TestCase
+{
+    #[Test]
+    public function exposesTargetKey(): void
+    {
+        self::assertSame(
+            'phpstan.paths',
+            (new OverrideList('phpstan.paths', new ListValue([])))->key(),
+            'OverrideList must expose the configuration key it targets',
+        );
+    }
+
+    #[Test]
+    public function replacesBaseWithReplacementList(): void
+    {
+        $replacement = new ListValue([new StringValue('lib')]);
+        $base = new ListValue([new StringValue('src'), new StringValue('tests')]);
+
+        self::assertEquals(
+            $replacement,
+            (new OverrideList('phpstan.paths', $replacement))->applied($base),
+            'OverrideList must replace the base list with the replacement list',
+        );
+    }
+
+    #[Test]
+    public function ignoresBaseEntriesEntirely(): void
+    {
+        self::assertEquals(
+            new ListValue([]),
+            (new OverrideList('phpstan.paths', new ListValue([])))
+                ->applied(new ListValue([new StringValue('src')])),
+            'OverrideList must replace the base list with an empty list when the override is empty',
+        );
+    }
+}


### PR DESCRIPTION
- Added OverrideList that replaces a list configuration value at the targeted key in full

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new settings patch mechanism that enables complete replacement of configuration list values.

* **Tests**
  * Added comprehensive test coverage validating the override functionality, including key exposure and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->