### PR TITLE
Neon Renderers Wired To YAML-Backed Settings

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -1,5 +1,5 @@
 override:
-  phpmetrics.coupling.max_afferent: 18
+  phpmetrics.coupling.max_afferent: 20
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
   ci.pr.max_lines_changed: 2000

--- a/.piqule/phpmetrics/rules.php
+++ b/.piqule/phpmetrics/rules.php
@@ -23,7 +23,7 @@ return [
         'max_methods_per_class' => 10,
     ],
     'coupling' => [
-        'max_afferent' => 18,
+        'max_afferent' => 20,
         'max_efferent' => 25,
     ],
 ];

--- a/src/Chain/Op.php
+++ b/src/Chain/Op.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain;
+
+/**
+ * One step in a template chain that produces a string for substitution.
+ */
+interface Op
+{
+    /**
+     * Returns the rendered string this step contributes to the template.
+     */
+    public function rendered(): string;
+}

--- a/src/Chain/Render/Neon/NeonBool.php
+++ b/src/Chain/Render/Neon/NeonBool.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Rendered;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Override;
+
+/**
+ * Renders a BoolValue as a neon `true` or `false` literal.
+ *
+ * Example:
+ *
+ *     (new NeonBool(new BoolValue(true)))->rendered(); // "true"
+ */
+final readonly class NeonBool implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param BoolValue $value Boolean payload rendered as a neon literal
+     */
+    public function __construct(private BoolValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return $this->value->raw
+            ? 'true'
+            : 'false';
+    }
+}

--- a/src/Chain/Render/Neon/NeonFloat.php
+++ b/src/Chain/Render/Neon/NeonFloat.php
@@ -27,6 +27,10 @@ final readonly class NeonFloat implements Rendered
     #[Override]
     public function rendered(): string
     {
-        return (string) $this->value->raw;
+        $rendered = (string) $this->value->raw;
+
+        return str_contains($rendered, '.')
+            ? $rendered
+            : sprintf('%s.0', $rendered);
     }
 }

--- a/src/Chain/Render/Neon/NeonFloat.php
+++ b/src/Chain/Render/Neon/NeonFloat.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Rendered;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use Override;
+
+/**
+ * Renders a FloatValue as a neon floating-point literal.
+ *
+ * Example:
+ *
+ *     (new NeonFloat(new FloatValue(0.5)))->rendered(); // "0.5"
+ */
+final readonly class NeonFloat implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param FloatValue $value Float payload rendered as a neon literal
+     */
+    public function __construct(private FloatValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return (string) $this->value->raw;
+    }
+}

--- a/src/Chain/Render/Neon/NeonFloat.php
+++ b/src/Chain/Render/Neon/NeonFloat.php
@@ -7,6 +7,7 @@ namespace Haspadar\Piqule\Chain\Render\Neon;
 use Haspadar\Piqule\Chain\Rendered;
 use Haspadar\Piqule\Settings\Value\FloatValue;
 use Override;
+use UnexpectedValueException;
 
 /**
  * Renders a FloatValue as a neon floating-point literal.
@@ -27,6 +28,12 @@ final readonly class NeonFloat implements Rendered
     #[Override]
     public function rendered(): string
     {
+        if (!is_finite($this->value->raw)) {
+            throw new UnexpectedValueException(
+                sprintf('NeonFloat cannot render non-finite payload: %s', (string) $this->value->raw),
+            );
+        }
+
         $rendered = (string) $this->value->raw;
 
         return str_contains($rendered, '.')

--- a/src/Chain/Render/Neon/NeonInt.php
+++ b/src/Chain/Render/Neon/NeonInt.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Rendered;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Override;
+
+/**
+ * Renders an IntValue as a neon integer literal.
+ *
+ * Example:
+ *
+ *     (new NeonInt(new IntValue(8)))->rendered(); // "8"
+ */
+final readonly class NeonInt implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param IntValue $value Integer payload rendered as a neon literal
+     */
+    public function __construct(private IntValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return (string) $this->value->raw;
+    }
+}

--- a/src/Chain/Render/Neon/NeonList.php
+++ b/src/Chain/Render/Neon/NeonList.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Rendered;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+
+/**
+ * Renders a ListValue as a neon flow-style sequence.
+ *
+ * Example:
+ *
+ *     (new NeonList(new ListValue([new StringValue('src')])))->rendered();
+ *     // [ "src" ]
+ */
+final readonly class NeonList implements Rendered
+{
+    /**
+     * Initializes with the list to render.
+     *
+     * @param ListValue $value List payload rendered as a neon flow sequence
+     */
+    public function __construct(private ListValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        if ($this->value->children === []) {
+            return '[]';
+        }
+
+        $parts = array_map(
+            static fn(Value $child): string => (new NeonOf($child))->renderer()->rendered(),
+            $this->value->children,
+        );
+
+        return sprintf('[%s]', implode(', ', $parts));
+    }
+}

--- a/src/Chain/Render/Neon/NeonOf.php
+++ b/src/Chain/Render/Neon/NeonOf.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Rendered;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use TypeError;
+
+/**
+ * Picks the matching Neon renderer for a configuration value.
+ *
+ * Example:
+ *
+ *     (new NeonOf(new BoolValue(true)))->renderer()->rendered(); // "true"
+ */
+final readonly class NeonOf
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param Value $value Configuration value resolved into a neon-format renderer
+     */
+    public function __construct(private Value $value) {}
+
+    /**
+     * Returns the Rendered op that knows how to render this value as neon.
+     *
+     * @throws TypeError
+     */
+    public function renderer(): Rendered
+    {
+        return match (true) {
+            $this->value instanceof BoolValue => new NeonBool($this->value),
+            $this->value instanceof IntValue => new NeonInt($this->value),
+            $this->value instanceof FloatValue => new NeonFloat($this->value),
+            $this->value instanceof StringValue => new NeonString($this->value),
+            $this->value instanceof ListValue => new NeonList($this->value),
+            $this->value instanceof TreeValue => new NeonTree($this->value),
+            default => throw new TypeError(
+                sprintf('Unsupported Value subtype: %s', $this->value::class),
+            ),
+        };
+    }
+}

--- a/src/Chain/Render/Neon/NeonString.php
+++ b/src/Chain/Render/Neon/NeonString.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Rendered;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use Override;
+
+/**
+ * Renders a StringValue as a neon string literal in double quotes.
+ *
+ * Example:
+ *
+ *     (new NeonString(new StringValue('1G')))->rendered(); // "\"1G\""
+ */
+final readonly class NeonString implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param StringValue $value String payload rendered as a quoted neon literal
+     */
+    public function __construct(private StringValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return sprintf('"%s"', addcslashes($this->value->raw, '"\\'));
+    }
+}

--- a/src/Chain/Render/Neon/NeonString.php
+++ b/src/Chain/Render/Neon/NeonString.php
@@ -27,6 +27,11 @@ final readonly class NeonString implements Rendered
     #[Override]
     public function rendered(): string
     {
-        return sprintf('"%s"', addcslashes($this->value->raw, '"\\'));
+        $escaped = strtr(
+            addcslashes($this->value->raw, '"\\'),
+            ["\n" => '\\n', "\r" => '\\r', "\t" => '\\t'],
+        );
+
+        return sprintf('"%s"', $escaped);
     }
 }

--- a/src/Chain/Render/Neon/NeonTree.php
+++ b/src/Chain/Render/Neon/NeonTree.php
@@ -58,7 +58,9 @@ final readonly class NeonTree implements Rendered
     private function lineFor(Value $child): string
     {
         if ($child instanceof TreeValue) {
-            return (new self($child, $this->depth + 1))->rendered();
+            return $child->entries === []
+                ? ' {}'
+                : (new self($child, $this->depth + 1))->rendered();
         }
 
         return sprintf(' %s', (new NeonOf($child))->renderer()->rendered());

--- a/src/Chain/Render/Neon/NeonTree.php
+++ b/src/Chain/Render/Neon/NeonTree.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Rendered;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+use TypeError;
+
+/**
+ * Renders a TreeValue as a neon block-style mapping at the given indent.
+ *
+ * Example:
+ *
+ *     (new NeonTree(new TreeValue([
+ *         'haspadar' => new TreeValue(['ignoreAbstract' => new BoolValue(true)]),
+ *     ])))->rendered();
+ *     // haspadar:
+ *     // ignoreAbstract: true
+ */
+final readonly class NeonTree implements Rendered
+{
+    private const string INDENT = '    ';
+
+    /**
+     * Initializes with the tree to render and the depth at which rendering starts.
+     *
+     * @param TreeValue $value Tree payload rendered as a neon block mapping
+     * @param int $depth Indent level applied to nested entries
+     */
+    public function __construct(private TreeValue $value, private int $depth = 0) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        if ($this->value->entries === []) {
+            return '{}';
+        }
+
+        $prefix = str_repeat(self::INDENT, $this->depth + 1);
+        $lines = [];
+
+        foreach ($this->value->entries as $key => $child) {
+            $lines[] = sprintf('%s%s:%s', $prefix, $key, $this->lineFor($child));
+        }
+
+        return sprintf("\n%s", implode("\n", $lines));
+    }
+
+    /**
+     * Renders a single entry value with its leading separator.
+     *
+     * @throws TypeError
+     */
+    private function lineFor(Value $child): string
+    {
+        if ($child instanceof TreeValue) {
+            return (new self($child, $this->depth + 1))->rendered();
+        }
+
+        return sprintf(' %s', (new NeonOf($child))->renderer()->rendered());
+    }
+}

--- a/src/Chain/Render/Neon/NeonTree.php
+++ b/src/Chain/Render/Neon/NeonTree.php
@@ -44,10 +44,17 @@ final readonly class NeonTree implements Rendered
         $lines = [];
 
         foreach ($this->value->entries as $key => $child) {
-            $lines[] = sprintf('%s%s:%s', $prefix, $key, $this->lineFor($child));
+            $lines[] = sprintf('%s%s:%s', $prefix, $this->keyLiteral($key), $this->lineFor($child));
         }
 
         return sprintf("\n%s", implode("\n", $lines));
+    }
+
+    private function keyLiteral(string $key): string
+    {
+        return preg_match('/\A[A-Za-z_][A-Za-z0-9_-]*\z/', $key) === 1
+            ? $key
+            : sprintf('"%s"', addcslashes($key, '"\\'));
     }
 
     /**

--- a/src/Chain/Rendered.php
+++ b/src/Chain/Rendered.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain;
+
+/**
+ * Marker for chain ops that act as format-specific sources.
+ *
+ * Implementations live under Chain\Render\<Format>\* and turn a Value into
+ * its native representation in that format (neon, json, xml, php).
+ */
+interface Rendered extends Op {}

--- a/src/Settings/DefaultSettings.php
+++ b/src/Settings/DefaultSettings.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Value\RawValue;
+use Haspadar\Piqule\Settings\Value\Value;
+use Override;
+use stdClass;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Settings backed by the built-in defaults declared in piqule's config.yaml.
+ *
+ * Example:
+ *
+ *     new DefaultSettings();
+ *
+ *     new DefaultSettings('/custom/path/config.yaml');
+ */
+final readonly class DefaultSettings implements Settings
+{
+    private stdClass $cache;
+
+    /**
+     * Initializes with the path to the defaults YAML file.
+     *
+     * @param string $path Filesystem path to the config.yaml that declares defaults
+     */
+    public function __construct(
+        private string $path = __DIR__ . '/../../templates/always/.piqule/config.yaml',
+    ) {
+        $this->cache = new stdClass();
+    }
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->defaults());
+    }
+
+    #[Override]
+    public function value(string $name): Value
+    {
+        if (!$this->has($name)) {
+            throw new PiquleException(sprintf('Unknown config key "%s"', $name));
+        }
+
+        return (new RawValue($this->defaults()[$name]))->value();
+    }
+
+    /**
+     * Parses the YAML file and caches the defaults map.
+     *
+     * @throws PiquleException
+     * @return array<string, mixed>
+     */
+    private function defaults(): array
+    {
+        if (isset($this->cache->value)) {
+            /** @var array<string, mixed> $cached */
+            $cached = $this->cache->value;
+
+            return $cached;
+        }
+
+        try {
+            $yaml = Yaml::parseFile($this->path);
+        } catch (ParseException $e) {
+            throw new PiquleException(
+                sprintf('Failed to parse config "%s": %s', $this->path, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        if (!is_array($yaml) || !array_key_exists('defaults', $yaml) || !is_array($yaml['defaults'])) {
+            throw new PiquleException('Missing "defaults" section in config.yaml');
+        }
+
+        /** @var array<string, mixed> $defaults */
+        $defaults = $yaml['defaults'];
+        $this->cache->value = $defaults;
+
+        return $defaults;
+    }
+}

--- a/src/Settings/Value/RawValue.php
+++ b/src/Settings/Value/RawValue.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Value;
+
+use TypeError;
+
+/**
+ * Wraps a raw PHP value parsed from YAML in the matching Value implementation.
+ *
+ * Example:
+ *
+ *     (new RawValue(true))->value(); // BoolValue
+ *     (new RawValue([1, 2]))->value(); // ListValue of IntValue
+ *     (new RawValue(['k' => 1]))->value(); // TreeValue
+ */
+final readonly class RawValue
+{
+    /**
+     * Initializes with the raw payload.
+     *
+     * @param mixed $raw Arbitrary scalar, list, or associative array from YAML
+     */
+    public function __construct(private mixed $raw) {}
+
+    /**
+     * Returns the Value implementation matching the payload's runtime type.
+     *
+     * @throws TypeError
+     */
+    public function value(): Value
+    {
+        return match (true) {
+            is_bool($this->raw) => new BoolValue($this->raw),
+            is_int($this->raw) => new IntValue($this->raw),
+            is_float($this->raw) => new FloatValue($this->raw),
+            is_string($this->raw) => new StringValue($this->raw),
+            is_array($this->raw) => $this->fromArray($this->raw),
+            default => throw new TypeError(
+                sprintf('Unsupported config value type: %s', get_debug_type($this->raw)),
+            ),
+        };
+    }
+
+    /**
+     * Wraps an array payload as a ListValue or TreeValue depending on its shape.
+     *
+     * @param array<int|string, mixed> $raw
+     * @throws TypeError
+     */
+    private function fromArray(array $raw): Value
+    {
+        if (array_is_list($raw)) {
+            return new ListValue(
+                array_map(static fn(mixed $item): Value => (new self($item))->value(), $raw),
+            );
+        }
+
+        $entries = [];
+
+        /** @var mixed $item */
+        foreach ($raw as $key => $item) {
+            $entries[(string) $key] = (new self($item))->value();
+        }
+
+        return new TreeValue($entries);
+    }
+}

--- a/src/Settings/Value/RawValue.php
+++ b/src/Settings/Value/RawValue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Settings\Value;
 
+use Haspadar\Piqule\PiquleException;
 use TypeError;
 
 /**
@@ -27,11 +28,15 @@ final readonly class RawValue
     /**
      * Returns the Value implementation matching the payload's runtime type.
      *
+     * @throws PiquleException
      * @throws TypeError
      */
     public function value(): Value
     {
         return match (true) {
+            $this->raw === null => throw new PiquleException(
+                'Null config values are not supported; declare an explicit default',
+            ),
             is_bool($this->raw) => new BoolValue($this->raw),
             is_int($this->raw) => new IntValue($this->raw),
             is_float($this->raw) => new FloatValue($this->raw),
@@ -47,6 +52,7 @@ final readonly class RawValue
      * Wraps an array payload as a ListValue or TreeValue depending on its shape.
      *
      * @param array<int|string, mixed> $raw
+     * @throws PiquleException
      * @throws TypeError
      */
     private function fromArray(array $raw): Value

--- a/tests/Unit/Chain/Render/Neon/NeonBoolTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonBoolTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Render\Neon\NeonBool;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonBoolTest extends TestCase
+{
+    #[Test]
+    public function rendersTrueAsLiteralTrue(): void
+    {
+        self::assertSame(
+            'true',
+            (new NeonBool(new BoolValue(true)))->rendered(),
+            'NeonBool must render true as the neon literal "true"',
+        );
+    }
+
+    #[Test]
+    public function rendersFalseAsLiteralFalse(): void
+    {
+        self::assertSame(
+            'false',
+            (new NeonBool(new BoolValue(false)))->rendered(),
+            'NeonBool must render false as the neon literal "false"',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Neon/NeonFloatTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonFloatTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Render\Neon\NeonFloat;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonFloatTest extends TestCase
+{
+    #[Test]
+    public function rendersFloatAsBareLiteral(): void
+    {
+        self::assertSame(
+            '0.5',
+            (new NeonFloat(new FloatValue(0.5)))->rendered(),
+            'NeonFloat must render the float payload as a bare neon literal',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Neon/NeonFloatTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonFloatTest.php
@@ -8,6 +8,7 @@ use Haspadar\Piqule\Chain\Render\Neon\NeonFloat;
 use Haspadar\Piqule\Settings\Value\FloatValue;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 final class NeonFloatTest extends TestCase
 {
@@ -29,5 +30,21 @@ final class NeonFloatTest extends TestCase
             (new NeonFloat(new FloatValue(1.0)))->rendered(),
             'NeonFloat must keep the decimal point so a whole-number float stays distinguishable from an integer',
         );
+    }
+
+    #[Test]
+    public function rejectsInfinityPayload(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        (new NeonFloat(new FloatValue(INF)))->rendered();
+    }
+
+    #[Test]
+    public function rejectsNanPayload(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        (new NeonFloat(new FloatValue(NAN)))->rendered();
     }
 }

--- a/tests/Unit/Chain/Render/Neon/NeonFloatTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonFloatTest.php
@@ -20,4 +20,14 @@ final class NeonFloatTest extends TestCase
             'NeonFloat must render the float payload as a bare neon literal',
         );
     }
+
+    #[Test]
+    public function preservesDecimalPointForWholeNumberFloats(): void
+    {
+        self::assertSame(
+            '1.0',
+            (new NeonFloat(new FloatValue(1.0)))->rendered(),
+            'NeonFloat must keep the decimal point so a whole-number float stays distinguishable from an integer',
+        );
+    }
 }

--- a/tests/Unit/Chain/Render/Neon/NeonIntTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonIntTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Render\Neon\NeonInt;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonIntTest extends TestCase
+{
+    #[Test]
+    public function rendersIntegerAsBareLiteral(): void
+    {
+        self::assertSame(
+            '8',
+            (new NeonInt(new IntValue(8)))->rendered(),
+            'NeonInt must render the integer payload as a bare neon literal',
+        );
+    }
+
+    #[Test]
+    public function preservesNegativeSign(): void
+    {
+        self::assertSame(
+            '-5',
+            (new NeonInt(new IntValue(-5)))->rendered(),
+            'NeonInt must preserve the negative sign in the rendered literal',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Neon/NeonListTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonListTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Render\Neon\NeonList;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonListTest extends TestCase
+{
+    #[Test]
+    public function rendersEmptyListAsEmptySequence(): void
+    {
+        self::assertSame(
+            '[]',
+            (new NeonList(new ListValue([])))->rendered(),
+            'NeonList must render an empty list as the neon empty-flow sequence',
+        );
+    }
+
+    #[Test]
+    public function rendersStringEntriesAsQuotedFlowSequence(): void
+    {
+        self::assertSame(
+            '["src", "tests"]',
+            (new NeonList(new ListValue([
+                new StringValue('src'),
+                new StringValue('tests'),
+            ])))->rendered(),
+            'NeonList must render string entries as a quoted flow sequence',
+        );
+    }
+
+    #[Test]
+    public function rendersMixedScalarEntries(): void
+    {
+        self::assertSame(
+            '[true, 8, "foo"]',
+            (new NeonList(new ListValue([
+                new BoolValue(true),
+                new IntValue(8),
+                new StringValue('foo'),
+            ])))->rendered(),
+            'NeonList must render each entry through its matching neon renderer',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Neon/NeonOfTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonOfTest.php
@@ -17,8 +17,10 @@ use Haspadar\Piqule\Settings\Value\IntValue;
 use Haspadar\Piqule\Settings\Value\ListValue;
 use Haspadar\Piqule\Settings\Value\StringValue;
 use Haspadar\Piqule\Settings\Value\TreeValue;
+use Haspadar\Piqule\Settings\Value\Value;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 final class NeonOfTest extends TestCase
 {
@@ -80,5 +82,16 @@ final class NeonOfTest extends TestCase
             (new NeonOf(new TreeValue([])))->renderer(),
             'NeonOf must pair TreeValue with the NeonTree renderer',
         );
+    }
+
+    #[Test]
+    public function rejectsValueSubtypeWithoutMatchingRenderer(): void
+    {
+        $this->expectException(TypeError::class);
+
+        $unknown = new class () implements Value {
+        };
+
+        (new NeonOf($unknown))->renderer();
     }
 }

--- a/tests/Unit/Chain/Render/Neon/NeonOfTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonOfTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Render\Neon\NeonBool;
+use Haspadar\Piqule\Chain\Render\Neon\NeonFloat;
+use Haspadar\Piqule\Chain\Render\Neon\NeonInt;
+use Haspadar\Piqule\Chain\Render\Neon\NeonList;
+use Haspadar\Piqule\Chain\Render\Neon\NeonOf;
+use Haspadar\Piqule\Chain\Render\Neon\NeonString;
+use Haspadar\Piqule\Chain\Render\Neon\NeonTree;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonOfTest extends TestCase
+{
+    #[Test]
+    public function pairsBoolValueWithNeonBool(): void
+    {
+        self::assertInstanceOf(
+            NeonBool::class,
+            (new NeonOf(new BoolValue(true)))->renderer(),
+            'NeonOf must pair BoolValue with the NeonBool renderer',
+        );
+    }
+
+    #[Test]
+    public function pairsIntValueWithNeonInt(): void
+    {
+        self::assertInstanceOf(
+            NeonInt::class,
+            (new NeonOf(new IntValue(8)))->renderer(),
+            'NeonOf must pair IntValue with the NeonInt renderer',
+        );
+    }
+
+    #[Test]
+    public function pairsFloatValueWithNeonFloat(): void
+    {
+        self::assertInstanceOf(
+            NeonFloat::class,
+            (new NeonOf(new FloatValue(0.5)))->renderer(),
+            'NeonOf must pair FloatValue with the NeonFloat renderer',
+        );
+    }
+
+    #[Test]
+    public function pairsStringValueWithNeonString(): void
+    {
+        self::assertInstanceOf(
+            NeonString::class,
+            (new NeonOf(new StringValue('foo')))->renderer(),
+            'NeonOf must pair StringValue with the NeonString renderer',
+        );
+    }
+
+    #[Test]
+    public function pairsListValueWithNeonList(): void
+    {
+        self::assertInstanceOf(
+            NeonList::class,
+            (new NeonOf(new ListValue([])))->renderer(),
+            'NeonOf must pair ListValue with the NeonList renderer',
+        );
+    }
+
+    #[Test]
+    public function pairsTreeValueWithNeonTree(): void
+    {
+        self::assertInstanceOf(
+            NeonTree::class,
+            (new NeonOf(new TreeValue([])))->renderer(),
+            'NeonOf must pair TreeValue with the NeonTree renderer',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Neon/NeonStringTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonStringTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Render\Neon\NeonString;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonStringTest extends TestCase
+{
+    #[Test]
+    public function rendersStringAsDoubleQuotedLiteral(): void
+    {
+        self::assertSame(
+            '"1G"',
+            (new NeonString(new StringValue('1G')))->rendered(),
+            'NeonString must render the string payload wrapped in double quotes',
+        );
+    }
+
+    #[Test]
+    public function escapesEmbeddedDoubleQuote(): void
+    {
+        self::assertSame(
+            '"a\\"b"',
+            (new NeonString(new StringValue('a"b')))->rendered(),
+            'NeonString must backslash-escape an embedded double quote',
+        );
+    }
+
+    #[Test]
+    public function escapesEmbeddedBackslash(): void
+    {
+        self::assertSame(
+            '"a\\\\b"',
+            (new NeonString(new StringValue('a\\b')))->rendered(),
+            'NeonString must backslash-escape an embedded backslash',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Neon/NeonStringTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonStringTest.php
@@ -40,4 +40,24 @@ final class NeonStringTest extends TestCase
             'NeonString must backslash-escape an embedded backslash',
         );
     }
+
+    #[Test]
+    public function escapesEmbeddedNewline(): void
+    {
+        self::assertSame(
+            '"a\\nb"',
+            (new NeonString(new StringValue("a\nb")))->rendered(),
+            'NeonString must escape newline so the literal stays on a single line of valid neon',
+        );
+    }
+
+    #[Test]
+    public function escapesEmbeddedTab(): void
+    {
+        self::assertSame(
+            '"a\\tb"',
+            (new NeonString(new StringValue("a\tb")))->rendered(),
+            'NeonString must escape tab so the literal stays well-formed neon',
+        );
+    }
 }

--- a/tests/Unit/Chain/Render/Neon/NeonTreeTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonTreeTest.php
@@ -46,4 +46,14 @@ final class NeonTreeTest extends TestCase
             'NeonTree must indent nested trees one level deeper than the parent',
         );
     }
+
+    #[Test]
+    public function rendersEmptyNestedTreeAsInlineMappingAfterKey(): void
+    {
+        self::assertSame(
+            "\n    parameters: {}",
+            (new NeonTree(new TreeValue(['parameters' => new TreeValue([])])))->rendered(),
+            'NeonTree must render an empty nested tree as "key: {}" with a space before the inline mapping',
+        );
+    }
 }

--- a/tests/Unit/Chain/Render/Neon/NeonTreeTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonTreeTest.php
@@ -56,4 +56,14 @@ final class NeonTreeTest extends TestCase
             'NeonTree must render an empty nested tree as "key: {}" with a space before the inline mapping',
         );
     }
+
+    #[Test]
+    public function quotesKeysThatAreNotBarewords(): void
+    {
+        self::assertSame(
+            "\n    \"first key\": 1",
+            (new NeonTree(new TreeValue(['first key' => new IntValue(1)])))->rendered(),
+            'NeonTree must wrap keys with characters outside the bareword alphabet in double quotes',
+        );
+    }
 }

--- a/tests/Unit/Chain/Render/Neon/NeonTreeTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonTreeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Piqule\Chain\Render\Neon\NeonTree;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonTreeTest extends TestCase
+{
+    #[Test]
+    public function rendersEmptyTreeAsEmptyMapping(): void
+    {
+        self::assertSame(
+            '{}',
+            (new NeonTree(new TreeValue([])))->rendered(),
+            'NeonTree must render an empty tree as the neon empty-flow mapping',
+        );
+    }
+
+    #[Test]
+    public function rendersFlatEntriesAsBlockMapping(): void
+    {
+        self::assertSame(
+            "\n    level: 9",
+            (new NeonTree(new TreeValue(['level' => new IntValue(9)])))->rendered(),
+            'NeonTree must render a single scalar entry as an indented block mapping line',
+        );
+    }
+
+    #[Test]
+    public function indentsNestedTreesOneLevelDeeper(): void
+    {
+        self::assertSame(
+            "\n    haspadar:\n        ignoreAbstract: true",
+            (new NeonTree(new TreeValue([
+                'haspadar' => new TreeValue([
+                    'ignoreAbstract' => new BoolValue(true),
+                ]),
+            ])))->rendered(),
+            'NeonTree must indent nested trees one level deeper than the parent',
+        );
+    }
+}

--- a/tests/Unit/Settings/DefaultSettingsTest.php
+++ b/tests/Unit/Settings/DefaultSettingsTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\DefaultSettings;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultSettingsTest extends TestCase
+{
+    #[Test]
+    public function reportsDeclaredKeyAsPresent(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.level: 9\n",
+        );
+
+        self::assertTrue(
+            (new DefaultSettings($folder->path() . '/config.yaml'))->has('phpstan.level'),
+            'DefaultSettings must report declared keys as present',
+        );
+    }
+
+    #[Test]
+    public function reportsUnknownKeyAsAbsent(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.level: 9\n",
+        );
+
+        self::assertFalse(
+            (new DefaultSettings($folder->path() . '/config.yaml'))->has('unknown.key'),
+            'DefaultSettings must report unknown keys as absent',
+        );
+    }
+
+    #[Test]
+    public function returnsIntValueForIntegerDefault(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.level: 9\n",
+        );
+
+        self::assertEquals(
+            new IntValue(9),
+            (new DefaultSettings($folder->path() . '/config.yaml'))->value('phpstan.level'),
+            'integer default must be wrapped in IntValue',
+        );
+    }
+
+    #[Test]
+    public function returnsFloatValueForFloatDefault(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  threshold: 0.5\n",
+        );
+
+        self::assertEquals(
+            new FloatValue(0.5),
+            (new DefaultSettings($folder->path() . '/config.yaml'))->value('threshold'),
+            'float default must be wrapped in FloatValue',
+        );
+    }
+
+    #[Test]
+    public function returnsBoolValueForBooleanDefault(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.cli: true\n",
+        );
+
+        self::assertEquals(
+            new BoolValue(true),
+            (new DefaultSettings($folder->path() . '/config.yaml'))->value('phpstan.cli'),
+            'boolean default must be wrapped in BoolValue',
+        );
+    }
+
+    #[Test]
+    public function returnsStringValueForStringDefault(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.memory: \"1G\"\n",
+        );
+
+        self::assertEquals(
+            new StringValue('1G'),
+            (new DefaultSettings($folder->path() . '/config.yaml'))->value('phpstan.memory'),
+            'string default must be wrapped in StringValue',
+        );
+    }
+
+    #[Test]
+    public function returnsListValueForListDefault(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.paths:\n    - src\n    - tests\n",
+        );
+
+        self::assertEquals(
+            new ListValue([new StringValue('src'), new StringValue('tests')]),
+            (new DefaultSettings($folder->path() . '/config.yaml'))->value('phpstan.paths'),
+            'list default must be wrapped in ListValue with nested string values',
+        );
+    }
+
+    #[Test]
+    public function returnsTreeValueForNestedMappingDefault(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.parameters:\n    haspadar:\n      ignoreAbstract: true\n",
+        );
+
+        self::assertEquals(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'ignoreAbstract' => new BoolValue(true),
+                ]),
+            ]),
+            (new DefaultSettings($folder->path() . '/config.yaml'))->value('phpstan.parameters'),
+            'nested mapping default must be wrapped in TreeValue',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenKeyIsUnknown(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'config.yaml',
+            "defaults:\n  phpstan.level: 9\n",
+        );
+
+        $this->expectException(PiquleException::class);
+
+        (new DefaultSettings($folder->path() . '/config.yaml'))->value('unknown.key');
+    }
+
+    #[Test]
+    public function throwsWhenDefaultsSectionIsMissing(): void
+    {
+        $folder = (new TempFolder())->withFile('config.yaml', "other: 1\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new DefaultSettings($folder->path() . '/config.yaml'))->has('phpstan.level');
+    }
+
+    #[Test]
+    public function throwsWhenYamlIsMalformed(): void
+    {
+        $folder = (new TempFolder())->withFile('config.yaml', "defaults:\n  bad: [unclosed\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new DefaultSettings($folder->path() . '/config.yaml'))->has('bad');
+    }
+}

--- a/tests/Unit/Settings/Value/RawValueTest.php
+++ b/tests/Unit/Settings/Value/RawValueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Tests\Unit\Settings\Value;
 
+use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Settings\Value\BoolValue;
 use Haspadar\Piqule\Settings\Value\FloatValue;
 use Haspadar\Piqule\Settings\Value\IntValue;
@@ -106,5 +107,13 @@ final class RawValueTest extends TestCase
         $this->expectException(TypeError::class);
 
         (new RawValue(new stdClass()))->value();
+    }
+
+    #[Test]
+    public function rejectsNullPayloadAsConfigError(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new RawValue(null))->value();
     }
 }

--- a/tests/Unit/Settings/Value/RawValueTest.php
+++ b/tests/Unit/Settings/Value/RawValueTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Value;
+
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\RawValue;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypeError;
+
+final class RawValueTest extends TestCase
+{
+    #[Test]
+    public function wrapsBooleanInBoolValue(): void
+    {
+        self::assertEquals(
+            new BoolValue(true),
+            (new RawValue(true))->value(),
+            'RawValue must wrap a boolean payload in BoolValue',
+        );
+    }
+
+    #[Test]
+    public function wrapsIntegerInIntValue(): void
+    {
+        self::assertEquals(
+            new IntValue(8),
+            (new RawValue(8))->value(),
+            'RawValue must wrap an integer payload in IntValue',
+        );
+    }
+
+    #[Test]
+    public function wrapsFloatInFloatValue(): void
+    {
+        self::assertEquals(
+            new FloatValue(0.5),
+            (new RawValue(0.5))->value(),
+            'RawValue must wrap a float payload in FloatValue',
+        );
+    }
+
+    #[Test]
+    public function wrapsStringInStringValue(): void
+    {
+        self::assertEquals(
+            new StringValue('1G'),
+            (new RawValue('1G'))->value(),
+            'RawValue must wrap a string payload in StringValue',
+        );
+    }
+
+    #[Test]
+    public function wrapsListInListValueWithRecursivelyWrappedItems(): void
+    {
+        self::assertEquals(
+            new ListValue([new StringValue('src'), new IntValue(2)]),
+            (new RawValue(['src', 2]))->value(),
+            'RawValue must wrap a list payload in ListValue and recurse over items',
+        );
+    }
+
+    #[Test]
+    public function wrapsAssociativeArrayInTreeValue(): void
+    {
+        self::assertEquals(
+            new TreeValue(['ignoreAbstract' => new BoolValue(true)]),
+            (new RawValue(['ignoreAbstract' => true]))->value(),
+            'RawValue must wrap an associative array in TreeValue',
+        );
+    }
+
+    #[Test]
+    public function recursesIntoNestedTreeStructures(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'ignoreAbstract' => new BoolValue(true),
+                    ]),
+                ]),
+            ]),
+            (new RawValue([
+                'haspadar' => [
+                    'afferentCoupling' => [
+                        'ignoreAbstract' => true,
+                    ],
+                ],
+            ]))->value(),
+            'RawValue must recurse through nested associative arrays',
+        );
+    }
+
+    #[Test]
+    public function throwsOnUnsupportedPayloadType(): void
+    {
+        $this->expectException(TypeError::class);
+
+        (new RawValue(new stdClass()))->value();
+    }
+}


### PR DESCRIPTION
- Added Op contract and Rendered marker as the first chain layer interfaces
- Added neon renderers for every Value subtype with a single dispatcher
- Added RawValue to wrap raw yaml payloads in their matching Value implementations
- Added DefaultSettings to read built-in defaults straight from piqule's bundled config.yaml
- Updated afferent coupling limit so the new exception consumer fits the metric

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration value rendering in Neon format with support for booleans, numbers, strings, lists, and nested structures
  * Added default settings loading from YAML configuration files
  * Introduced type-safe value wrapper system for configuration data

* **Chores**
  * Adjusted code quality metric thresholds
  * Added comprehensive test coverage for new functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->