### PR TITLE
Yaml Patch Parser For .piqule.yaml

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -1,5 +1,5 @@
 override:
-  phpmetrics.coupling.max_afferent: 20
+  phpmetrics.coupling.max_afferent: 25
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
   ci.pr.max_lines_changed: 2000

--- a/.piqule/phpmetrics/rules.php
+++ b/.piqule/phpmetrics/rules.php
@@ -23,7 +23,7 @@ return [
         'max_methods_per_class' => 10,
     ],
     'coupling' => [
-        'max_afferent' => 20,
+        'max_afferent' => 25,
         'max_efferent' => 25,
     ],
 ];

--- a/src/Settings/Patch/AppendPatches.php
+++ b/src/Settings/Patch/AppendPatches.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\RawValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use TypeError;
+
+/**
+ * Translates the `append` section of `.piqule.yaml` into Patch instances.
+ *
+ * Example:
+ *
+ *     (new AppendPatches([
+ *         'infra.exclude' => ['dist'],
+ *         'phpstan.parameters' => ['ignoreErrors' => ['#new#']],
+ *     ]))->patches();
+ */
+final readonly class AppendPatches
+{
+    /**
+     * Initializes with the raw `append` section from the yaml file.
+     *
+     * @param array<string, mixed> $section Raw yaml mapping under `append`
+     */
+    public function __construct(private array $section) {}
+
+    /**
+     * Returns the list of Patch objects derived from the section.
+     *
+     * @throws PiquleException
+     * @throws TypeError
+     * @return list<Patch>
+     */
+    public function patches(): array
+    {
+        $patches = [];
+
+        /** @var mixed $raw */
+        foreach ($this->section as $key => $raw) {
+            $patches[] = $this->patchOf($key, $raw);
+        }
+
+        return $patches;
+    }
+
+    /**
+     * Builds a single append patch matching the runtime type of the payload.
+     *
+     * @throws PiquleException
+     * @throws TypeError
+     */
+    private function patchOf(string $key, mixed $raw): Patch
+    {
+        $value = (new RawValue($raw))->value();
+
+        return match (true) {
+            $value instanceof ListValue => new AppendList($key, $value),
+            $value instanceof TreeValue => new AppendTree($key, $value),
+            default => throw new PiquleException(
+                sprintf('Append "%s" expects a list or mapping', $key),
+            ),
+        };
+    }
+}

--- a/src/Settings/Patch/OverridePatches.php
+++ b/src/Settings/Patch/OverridePatches.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\RawValue;
+use Haspadar\Piqule\Settings\Value\ScalarValue;
+use Haspadar\Piqule\Settings\Value\TreeValue;
+use TypeError;
+
+/**
+ * Translates the `override` section of `.piqule.yaml` into Patch instances.
+ *
+ * Example:
+ *
+ *     (new OverridePatches([
+ *         'phpstan.level' => 8,
+ *         'phpstan.parameters' => ['haspadar' => ['ignoreAbstract' => true]],
+ *     ]))->patches();
+ */
+final readonly class OverridePatches
+{
+    /**
+     * Initializes with the raw `override` section from the yaml file.
+     *
+     * @param array<string, mixed> $section Raw yaml mapping under `override`
+     */
+    public function __construct(private array $section) {}
+
+    /**
+     * Returns the list of Patch objects derived from the section.
+     *
+     * @throws PiquleException
+     * @throws TypeError
+     * @return list<Patch>
+     */
+    public function patches(): array
+    {
+        $patches = [];
+
+        /** @var mixed $raw */
+        foreach ($this->section as $key => $raw) {
+            $patches[] = $this->patchOf($key, $raw);
+        }
+
+        return $patches;
+    }
+
+    /**
+     * Builds a single override patch matching the runtime type of the payload.
+     *
+     * @throws PiquleException
+     * @throws TypeError
+     */
+    private function patchOf(string $key, mixed $raw): Patch
+    {
+        $value = (new RawValue($raw))->value();
+
+        return match (true) {
+            $value instanceof ScalarValue => new OverrideScalar($key, $value),
+            $value instanceof ListValue => new OverrideList($key, $value),
+            $value instanceof TreeValue => new OverrideTree($key, $value),
+            default => throw new PiquleException(
+                sprintf('Override "%s" expects a scalar, list, or mapping', $key),
+            ),
+        };
+    }
+}

--- a/src/Settings/Patch/RemovePatches.php
+++ b/src/Settings/Patch/RemovePatches.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings\Patch;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch;
+use Haspadar\Piqule\Settings\Value\ListValue;
+use Haspadar\Piqule\Settings\Value\RawValue;
+use TypeError;
+
+/**
+ * Translates the `remove` section of `.piqule.yaml` into Patch instances.
+ *
+ * Example:
+ *
+ *     (new RemovePatches([
+ *         'phpstan.checked_exceptions' => ['\\Throwable'],
+ *     ]))->patches();
+ */
+final readonly class RemovePatches
+{
+    /**
+     * Initializes with the raw `remove` section from the yaml file.
+     *
+     * @param array<string, mixed> $section Raw yaml mapping under `remove`
+     */
+    public function __construct(private array $section) {}
+
+    /**
+     * Returns the list of Patch objects derived from the section.
+     *
+     * @throws PiquleException
+     * @throws TypeError
+     * @return list<Patch>
+     */
+    public function patches(): array
+    {
+        $patches = [];
+
+        /** @var mixed $raw */
+        foreach ($this->section as $key => $raw) {
+            $patches[] = $this->patchOf($key, $raw);
+        }
+
+        return $patches;
+    }
+
+    /**
+     * Builds a RemoveList patch from a yaml list payload.
+     *
+     * @throws PiquleException
+     * @throws TypeError
+     */
+    private function patchOf(string $key, mixed $raw): Patch
+    {
+        $value = (new RawValue($raw))->value();
+
+        if (!$value instanceof ListValue) {
+            throw new PiquleException(
+                sprintf('Remove "%s" expects a list of items to drop', $key),
+            );
+        }
+
+        return new RemoveList($key, $value);
+    }
+}

--- a/src/Settings/Patch/RemovePatches.php
+++ b/src/Settings/Patch/RemovePatches.php
@@ -13,6 +13,11 @@ use TypeError;
 /**
  * Translates the `remove` section of `.piqule.yaml` into Patch instances.
  *
+ * Yaml input always produces RemoveList. RemoveTree (drop named keys from a
+ * tree) is constructed programmatically because the parser cannot tell a
+ * list of items from a list of key names without knowing the configured
+ * key's default type.
+ *
  * Example:
  *
  *     (new RemovePatches([

--- a/src/Settings/YamlDocument.php
+++ b/src/Settings/YamlDocument.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings;
+
+use Haspadar\Piqule\PiquleException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Reads a yaml file and exposes its top-level mapping.
+ *
+ * Example:
+ *
+ *     (new YamlDocument('/path/to/.piqule.yaml'))->section('override');
+ */
+final readonly class YamlDocument
+{
+    /**
+     * Initializes with the path to the yaml file.
+     *
+     * @param string $path Filesystem path to the yaml file
+     */
+    public function __construct(private string $path) {}
+
+    /**
+     * Returns the named top-level mapping section, or empty if absent.
+     *
+     * @param string $name Section name to read from the top-level mapping
+     * @throws PiquleException
+     * @return array<string, mixed>
+     */
+    public function section(string $name): array
+    {
+        $document = $this->mapping();
+
+        if (!array_key_exists($name, $document)) {
+            return [];
+        }
+
+        if (!is_array($document[$name])) {
+            throw new PiquleException(
+                sprintf('Section "%s" in "%s" must be a mapping', $name, $this->path),
+            );
+        }
+
+        /** @var array<string, mixed> $section */
+        $section = $document[$name];
+
+        return $section;
+    }
+
+    /**
+     * Parses the yaml file once and returns the top-level mapping.
+     *
+     * @throws PiquleException
+     * @return array<string, mixed>
+     */
+    private function mapping(): array
+    {
+        try {
+            /** @var mixed $parsed */
+            $parsed = Yaml::parseFile($this->path);
+        } catch (ParseException $e) {
+            throw new PiquleException(
+                sprintf('Failed to parse "%s": %s', $this->path, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        if ($parsed === null) {
+            return [];
+        }
+
+        if (!is_array($parsed) || ($parsed !== [] && array_is_list($parsed))) {
+            throw new PiquleException(
+                sprintf('Expected a mapping at the top of "%s"', $this->path),
+            );
+        }
+
+        /** @var array<string, mixed> $document */
+        $document = $parsed;
+
+        return $document;
+    }
+}

--- a/src/Settings/YamlDocument.php
+++ b/src/Settings/YamlDocument.php
@@ -59,6 +59,12 @@ final readonly class YamlDocument
      */
     private function mapping(): array
     {
+        if (!is_file($this->path) || !is_readable($this->path)) {
+            throw new PiquleException(
+                sprintf('Yaml file "%s" is missing or not readable', $this->path),
+            );
+        }
+
         try {
             /** @var mixed $parsed */
             $parsed = Yaml::parseFile($this->path);

--- a/src/Settings/YamlPatches.php
+++ b/src/Settings/YamlPatches.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Settings;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch\AppendPatches;
+use Haspadar\Piqule\Settings\Patch\OverridePatches;
+use Haspadar\Piqule\Settings\Patch\RemovePatches;
+use TypeError;
+
+/**
+ * Loads `.piqule.yaml` and turns its operations into a Patch list.
+ *
+ * Example:
+ *
+ *     (new YamlPatches('/path/to/.piqule.yaml'))->patches();
+ */
+final readonly class YamlPatches
+{
+    private YamlDocument $document;
+
+    /**
+     * Initializes with the path to the user yaml file.
+     *
+     * @param string $path Filesystem path to the user `.piqule.yaml`
+     */
+    public function __construct(string $path)
+    {
+        $this->document = new YamlDocument($path);
+    }
+
+    /**
+     * Returns every Patch declared by the yaml file in declaration order.
+     *
+     * @throws PiquleException
+     * @throws TypeError
+     * @return list<Patch>
+     */
+    public function patches(): array
+    {
+        return [
+            ...(new OverridePatches($this->document->section('override')))->patches(),
+            ...(new AppendPatches($this->document->section('append')))->patches(),
+            ...(new RemovePatches($this->document->section('remove')))->patches(),
+        ];
+    }
+}

--- a/tests/Unit/Settings/Patch/AppendPatchesTest.php
+++ b/tests/Unit/Settings/Patch/AppendPatchesTest.php
@@ -62,6 +62,20 @@ final class AppendPatchesTest extends TestCase
     }
 
     #[Test]
+    public function preservesTargetKeyOnTreePatch(): void
+    {
+        $patches = (new AppendPatches([
+            'phpstan.parameters' => ['ignoreErrors' => ['#new#']],
+        ]))->patches();
+
+        self::assertSame(
+            'phpstan.parameters',
+            $patches[0]->key(),
+            'AppendPatches must put the yaml key onto the produced tree patch',
+        );
+    }
+
+    #[Test]
     public function rejectsScalarPayloadAsConfigError(): void
     {
         $this->expectException(PiquleException::class);

--- a/tests/Unit/Settings/Patch/AppendPatchesTest.php
+++ b/tests/Unit/Settings/Patch/AppendPatchesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch\AppendList;
+use Haspadar\Piqule\Settings\Patch\AppendPatches;
+use Haspadar\Piqule\Settings\Patch\AppendTree;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AppendPatchesTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyListForEmptySection(): void
+    {
+        self::assertSame(
+            [],
+            (new AppendPatches([]))->patches(),
+            'AppendPatches must return no patches when the append section is empty',
+        );
+    }
+
+    #[Test]
+    public function buildsAppendListForListValue(): void
+    {
+        $patches = (new AppendPatches(['infra.exclude' => ['dist']]))->patches();
+
+        self::assertInstanceOf(
+            AppendList::class,
+            $patches[0],
+            'AppendPatches must produce AppendList for a list value',
+        );
+    }
+
+    #[Test]
+    public function buildsAppendTreeForMappingValue(): void
+    {
+        $patches = (new AppendPatches([
+            'phpstan.parameters' => ['ignoreErrors' => ['#new#']],
+        ]))->patches();
+
+        self::assertInstanceOf(
+            AppendTree::class,
+            $patches[0],
+            'AppendPatches must produce AppendTree for a mapping value',
+        );
+    }
+
+    #[Test]
+    public function preservesTargetKeyOnTheBuiltPatch(): void
+    {
+        $patches = (new AppendPatches(['infra.exclude' => ['dist']]))->patches();
+
+        self::assertSame(
+            'infra.exclude',
+            $patches[0]->key(),
+            'AppendPatches must put the yaml key onto the produced patch',
+        );
+    }
+
+    #[Test]
+    public function rejectsScalarPayloadAsConfigError(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new AppendPatches(['phpstan.level' => 8]))->patches();
+    }
+}

--- a/tests/Unit/Settings/Patch/OverridePatchesTest.php
+++ b/tests/Unit/Settings/Patch/OverridePatchesTest.php
@@ -75,6 +75,42 @@ final class OverridePatchesTest extends TestCase
     }
 
     #[Test]
+    public function buildsOverrideScalarForBooleanValue(): void
+    {
+        $patches = (new OverridePatches(['phpstan.cli' => true]))->patches();
+
+        self::assertInstanceOf(
+            OverrideScalar::class,
+            $patches[0],
+            'OverridePatches must produce OverrideScalar for a boolean value',
+        );
+    }
+
+    #[Test]
+    public function buildsOverrideScalarForFloatValue(): void
+    {
+        $patches = (new OverridePatches(['threshold' => 0.5]))->patches();
+
+        self::assertInstanceOf(
+            OverrideScalar::class,
+            $patches[0],
+            'OverridePatches must produce OverrideScalar for a float value',
+        );
+    }
+
+    #[Test]
+    public function buildsOverrideScalarForStringValue(): void
+    {
+        $patches = (new OverridePatches(['phpstan.memory' => '1G']))->patches();
+
+        self::assertInstanceOf(
+            OverrideScalar::class,
+            $patches[0],
+            'OverridePatches must produce OverrideScalar for a string value',
+        );
+    }
+
+    #[Test]
     public function rejectsNullPayloadAsConfigError(): void
     {
         $this->expectException(PiquleException::class);

--- a/tests/Unit/Settings/Patch/OverridePatchesTest.php
+++ b/tests/Unit/Settings/Patch/OverridePatchesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch\OverrideList;
+use Haspadar\Piqule\Settings\Patch\OverridePatches;
+use Haspadar\Piqule\Settings\Patch\OverrideScalar;
+use Haspadar\Piqule\Settings\Patch\OverrideTree;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OverridePatchesTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyListForEmptySection(): void
+    {
+        self::assertSame(
+            [],
+            (new OverridePatches([]))->patches(),
+            'OverridePatches must return no patches when the override section is empty',
+        );
+    }
+
+    #[Test]
+    public function buildsOverrideScalarForScalarValue(): void
+    {
+        $patches = (new OverridePatches(['phpstan.level' => 8]))->patches();
+
+        self::assertInstanceOf(
+            OverrideScalar::class,
+            $patches[0],
+            'OverridePatches must produce OverrideScalar for a scalar value',
+        );
+    }
+
+    #[Test]
+    public function buildsOverrideListForListValue(): void
+    {
+        $patches = (new OverridePatches(['phpstan.paths' => ['src', 'tests']]))->patches();
+
+        self::assertInstanceOf(
+            OverrideList::class,
+            $patches[0],
+            'OverridePatches must produce OverrideList for a list value',
+        );
+    }
+
+    #[Test]
+    public function buildsOverrideTreeForMappingValue(): void
+    {
+        $patches = (new OverridePatches([
+            'phpstan.parameters' => ['haspadar' => ['ignoreAbstract' => true]],
+        ]))->patches();
+
+        self::assertInstanceOf(
+            OverrideTree::class,
+            $patches[0],
+            'OverridePatches must produce OverrideTree for a mapping value',
+        );
+    }
+
+    #[Test]
+    public function preservesTargetKeyOnTheBuiltPatch(): void
+    {
+        $patches = (new OverridePatches(['phpstan.level' => 8]))->patches();
+
+        self::assertSame(
+            'phpstan.level',
+            $patches[0]->key(),
+            'OverridePatches must put the yaml key onto the produced patch',
+        );
+    }
+
+    #[Test]
+    public function rejectsNullPayloadAsConfigError(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new OverridePatches(['phpstan.level' => null]))->patches();
+    }
+}

--- a/tests/Unit/Settings/Patch/RemovePatchesTest.php
+++ b/tests/Unit/Settings/Patch/RemovePatchesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings\Patch;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch\RemoveList;
+use Haspadar\Piqule\Settings\Patch\RemovePatches;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RemovePatchesTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyListForEmptySection(): void
+    {
+        self::assertSame(
+            [],
+            (new RemovePatches([]))->patches(),
+            'RemovePatches must return no patches when the remove section is empty',
+        );
+    }
+
+    #[Test]
+    public function buildsRemoveListForListValue(): void
+    {
+        $patches = (new RemovePatches(['phpstan.checked_exceptions' => ['\\Throwable']]))->patches();
+
+        self::assertInstanceOf(
+            RemoveList::class,
+            $patches[0],
+            'RemovePatches must produce RemoveList for a yaml list of items to drop',
+        );
+    }
+
+    #[Test]
+    public function preservesTargetKeyOnTheBuiltPatch(): void
+    {
+        $patches = (new RemovePatches(['phpstan.checked_exceptions' => ['\\Throwable']]))->patches();
+
+        self::assertSame(
+            'phpstan.checked_exceptions',
+            $patches[0]->key(),
+            'RemovePatches must put the yaml key onto the produced patch',
+        );
+    }
+
+    #[Test]
+    public function rejectsScalarPayloadAsConfigError(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new RemovePatches(['phpstan.level' => 8]))->patches();
+    }
+
+    #[Test]
+    public function rejectsMappingPayloadAsConfigError(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new RemovePatches(['phpstan.parameters' => ['nested' => true]]))->patches();
+    }
+}

--- a/tests/Unit/Settings/YamlDocumentTest.php
+++ b/tests/Unit/Settings/YamlDocumentTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\YamlDocument;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class YamlDocumentTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptySectionForFileWithoutThatKey(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "other: 1\n");
+
+        self::assertSame(
+            [],
+            (new YamlDocument($folder->path() . '/.piqule.yaml'))->section('override'),
+            'YamlDocument must return an empty section when the key is absent',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptySectionForEmptyFile(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', '');
+
+        self::assertSame(
+            [],
+            (new YamlDocument($folder->path() . '/.piqule.yaml'))->section('override'),
+            'YamlDocument must return an empty section when the file is empty',
+        );
+    }
+
+    #[Test]
+    public function readsExistingSectionAsAssociativeArray(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "override:\n  phpstan.level: 8\n",
+        );
+
+        self::assertSame(
+            ['phpstan.level' => 8],
+            (new YamlDocument($folder->path() . '/.piqule.yaml'))->section('override'),
+            'YamlDocument must expose the named section as a string-keyed mapping',
+        );
+    }
+
+    #[Test]
+    public function rejectsMissingFile(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new YamlDocument('/nonexistent/path/.piqule.yaml'))->section('override');
+    }
+
+    #[Test]
+    public function rejectsTopLevelThatIsNotAMapping(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "- a\n- b\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new YamlDocument($folder->path() . '/.piqule.yaml'))->section('override');
+    }
+
+    #[Test]
+    public function rejectsSectionThatIsNotAMapping(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "override: 8\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new YamlDocument($folder->path() . '/.piqule.yaml'))->section('override');
+    }
+
+    #[Test]
+    public function rejectsMalformedYaml(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "override:\n  bad: [unclosed\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new YamlDocument($folder->path() . '/.piqule.yaml'))->section('override');
+    }
+}

--- a/tests/Unit/Settings/YamlPatchesTest.php
+++ b/tests/Unit/Settings/YamlPatchesTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Settings;
+
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Patch\AppendList;
+use Haspadar\Piqule\Settings\Patch\OverrideScalar;
+use Haspadar\Piqule\Settings\Patch\RemoveList;
+use Haspadar\Piqule\Settings\YamlPatches;
+use Haspadar\Piqule\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class YamlPatchesTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyListForFileWithNoSections(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "other: 1\n");
+
+        self::assertSame(
+            [],
+            (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches(),
+            'YamlPatches must return no patches when the file has no override/append/remove sections',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListForEmptyFile(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', '');
+
+        self::assertSame(
+            [],
+            (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches(),
+            'YamlPatches must return no patches when the file is empty',
+        );
+    }
+
+    #[Test]
+    public function readsOverrideSectionAsScalarPatch(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "override:\n  phpstan.level: 8\n",
+        );
+
+        $patches = (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+
+        self::assertInstanceOf(
+            OverrideScalar::class,
+            $patches[0],
+            'YamlPatches must read override scalars and produce OverrideScalar',
+        );
+    }
+
+    #[Test]
+    public function readsAppendSectionAsListPatch(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "append:\n  infra.exclude:\n    - dist\n",
+        );
+
+        $patches = (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+
+        self::assertInstanceOf(
+            AppendList::class,
+            $patches[0],
+            'YamlPatches must read append lists and produce AppendList',
+        );
+    }
+
+    #[Test]
+    public function readsRemoveSectionAsListPatch(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "remove:\n  phpstan.checked_exceptions:\n    - '\\Throwable'\n",
+        );
+
+        $patches = (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+
+        self::assertInstanceOf(
+            RemoveList::class,
+            $patches[0],
+            'YamlPatches must read remove lists and produce RemoveList',
+        );
+    }
+
+    #[Test]
+    public function combinesPatchesFromAllThreeSectionsInDeclarationOrder(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "override:\n  phpstan.level: 8\nappend:\n  infra.exclude:\n    - dist\nremove:\n  phpstan.checked_exceptions:\n    - '\\Throwable'\n",
+        );
+
+        $patches = (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+
+        self::assertCount(
+            3,
+            $patches,
+            'YamlPatches must combine override, append and remove patches into a single list',
+        );
+    }
+
+    #[Test]
+    public function rejectsTopLevelThatIsNotAMapping(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "- a\n- b\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+    }
+
+    #[Test]
+    public function rejectsSectionThatIsNotAMapping(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "override: 8\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+    }
+
+    #[Test]
+    public function rejectsMalformedYaml(): void
+    {
+        $folder = (new TempFolder())->withFile('.piqule.yaml', "override:\n  bad: [unclosed\n");
+
+        $this->expectException(PiquleException::class);
+
+        (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+    }
+}

--- a/tests/Unit/Settings/YamlPatchesTest.php
+++ b/tests/Unit/Settings/YamlPatchesTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Haspadar\Piqule\Tests\Unit\Settings;
 
-use Haspadar\Piqule\PiquleException;
 use Haspadar\Piqule\Settings\Patch\AppendList;
 use Haspadar\Piqule\Settings\Patch\OverrideScalar;
 use Haspadar\Piqule\Settings\Patch\RemoveList;
@@ -16,31 +15,19 @@ use PHPUnit\Framework\TestCase;
 final class YamlPatchesTest extends TestCase
 {
     #[Test]
-    public function returnsEmptyListForFileWithNoSections(): void
+    public function returnsEmptyListWhenAllSectionsAreAbsent(): void
     {
         $folder = (new TempFolder())->withFile('.piqule.yaml', "other: 1\n");
 
         self::assertSame(
             [],
             (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches(),
-            'YamlPatches must return no patches when the file has no override/append/remove sections',
+            'YamlPatches must return no patches when override/append/remove sections are missing',
         );
     }
 
     #[Test]
-    public function returnsEmptyListForEmptyFile(): void
-    {
-        $folder = (new TempFolder())->withFile('.piqule.yaml', '');
-
-        self::assertSame(
-            [],
-            (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches(),
-            'YamlPatches must return no patches when the file is empty',
-        );
-    }
-
-    #[Test]
-    public function readsOverrideSectionAsScalarPatch(): void
+    public function buildsOverrideScalarFromOverrideSection(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
@@ -57,7 +44,7 @@ final class YamlPatchesTest extends TestCase
     }
 
     #[Test]
-    public function readsAppendSectionAsListPatch(): void
+    public function buildsAppendListFromAppendSection(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
@@ -74,7 +61,7 @@ final class YamlPatchesTest extends TestCase
     }
 
     #[Test]
-    public function readsRemoveSectionAsListPatch(): void
+    public function buildsRemoveListFromRemoveSection(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
@@ -91,7 +78,7 @@ final class YamlPatchesTest extends TestCase
     }
 
     #[Test]
-    public function combinesPatchesFromAllThreeSectionsInDeclarationOrder(): void
+    public function combinesPatchesFromAllThreeSectionsIntoSingleList(): void
     {
         $folder = (new TempFolder())->withFile(
             '.piqule.yaml',
@@ -108,32 +95,19 @@ final class YamlPatchesTest extends TestCase
     }
 
     #[Test]
-    public function rejectsTopLevelThatIsNotAMapping(): void
+    public function ordersPatchesAsOverrideAppendRemoveRegardlessOfYamlDeclaration(): void
     {
-        $folder = (new TempFolder())->withFile('.piqule.yaml', "- a\n- b\n");
+        $folder = (new TempFolder())->withFile(
+            '.piqule.yaml',
+            "remove:\n  phpstan.checked_exceptions:\n    - '\\Throwable'\nappend:\n  infra.exclude:\n    - dist\noverride:\n  phpstan.level: 8\n",
+        );
 
-        $this->expectException(PiquleException::class);
+        $patches = (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
 
-        (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
-    }
-
-    #[Test]
-    public function rejectsSectionThatIsNotAMapping(): void
-    {
-        $folder = (new TempFolder())->withFile('.piqule.yaml', "override: 8\n");
-
-        $this->expectException(PiquleException::class);
-
-        (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
-    }
-
-    #[Test]
-    public function rejectsMalformedYaml(): void
-    {
-        $folder = (new TempFolder())->withFile('.piqule.yaml', "override:\n  bad: [unclosed\n");
-
-        $this->expectException(PiquleException::class);
-
-        (new YamlPatches($folder->path() . '/.piqule.yaml'))->patches();
+        self::assertInstanceOf(
+            OverrideScalar::class,
+            $patches[0],
+            'YamlPatches must place override patches first regardless of yaml section order',
+        );
     }
 }


### PR DESCRIPTION
- Added YamlDocument that reads `.piqule.yaml` and exposes top-level mapping sections
- Added OverridePatches, AppendPatches, RemovePatches that translate each yaml section into Patch instances
- Added YamlPatches that combines override, append and remove patches into a single ordered list
- Updated afferent coupling limit so the new yaml-parsing exception consumers fit the metric

Part of #653