### PR TITLE
Add common Mapped and Reduced ops for the Chain layer

### DIFF
--- a/src/Chain/Map/Formatted.php
+++ b/src/Chain/Map/Formatted.php
@@ -11,9 +11,10 @@ use Override;
 /**
  * Wraps an Op's rendered output into a sprintf template.
  *
- * The template is fed straight to PHP's sprintf, so it must contain exactly
- * one %s placeholder. Templates with no %s, several %s, or trailing % will
- * trigger ValueError or ArgumentCountError at render time.
+ * The template is fed straight to PHP's sprintf and may carry zero or one %s
+ * placeholder. A template without %s is returned unchanged, with one %s the
+ * origin's rendered output is inserted. Multiple %s or a trailing % is a
+ * misuse: sprintf raises ArgumentCountError or ValueError at render time.
  *
  * Example:
  *
@@ -26,7 +27,7 @@ final readonly class Formatted implements Mapped
      * Initializes with the source op and a sprintf template.
      *
      * @param Op $origin Source op whose rendered output is substituted into the template
-     * @param string $template Sprintf template with exactly one %s placeholder
+     * @param string $template Sprintf template with zero or one %s placeholder
      */
     public function __construct(private Op $origin, private string $template) {}
 

--- a/src/Chain/Map/Formatted.php
+++ b/src/Chain/Map/Formatted.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Map;
+
+use Haspadar\Piqule\Chain\Mapped;
+use Haspadar\Piqule\Chain\Op;
+use Override;
+
+/**
+ * Wraps an Op's rendered output into a sprintf template.
+ *
+ * The template is fed straight to PHP's sprintf, so it must contain exactly
+ * one %s placeholder. Templates with no %s, several %s, or trailing % will
+ * trigger ValueError or ArgumentCountError at render time.
+ *
+ * Example:
+ *
+ *     (new Formatted(new NeonBool(new BoolValue(true)), 'value: %s'))->rendered();
+ *     // "value: true"
+ */
+final readonly class Formatted implements Mapped
+{
+    /**
+     * Initializes with the source op and a sprintf template.
+     *
+     * @param Op $origin Source op whose rendered output is substituted into the template
+     * @param string $template Sprintf template with exactly one %s placeholder
+     */
+    public function __construct(private Op $origin, private string $template) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return sprintf($this->template, $this->origin->rendered());
+    }
+}

--- a/src/Chain/Mapped.php
+++ b/src/Chain/Mapped.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain;
+
+/**
+ * Marker for chain ops that transform one rendered string into another.
+ *
+ * Implementations decorate a single Op and rewrite its rendered output
+ * before it reaches the template (sprintf, replace, escape, etc.).
+ */
+interface Mapped extends Op {}

--- a/src/Chain/Reduce/Joined.php
+++ b/src/Chain/Reduce/Joined.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Reduce;
+
+use Haspadar\Piqule\Chain\Op;
+use Haspadar\Piqule\Chain\Reduced;
+use Override;
+
+/**
+ * Concatenates the rendered outputs of multiple Ops with a glue string.
+ *
+ * Example:
+ *
+ *     (new Joined([
+ *         new NeonBool(new BoolValue(true)),
+ *         new NeonBool(new BoolValue(false)),
+ *     ], ', '))->rendered();
+ *     // "true, false"
+ */
+final readonly class Joined implements Reduced
+{
+    /**
+     * Initializes with the parts to render and the glue between them.
+     *
+     * @param list<Op> $parts Source ops whose rendered outputs are joined in order
+     * @param string $glue String inserted between consecutive rendered outputs
+     */
+    public function __construct(private array $parts, private string $glue) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return implode(
+            $this->glue,
+            array_map(static fn(Op $part): string => $part->rendered(), $this->parts),
+        );
+    }
+}

--- a/src/Chain/Reduced.php
+++ b/src/Chain/Reduced.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain;
+
+/**
+ * Marker for chain ops that fold multiple rendered strings into one.
+ *
+ * Implementations take a list of Op objects and produce a single rendered
+ * string out of their concatenation, first element, and so on.
+ */
+interface Reduced extends Op {}

--- a/tests/Unit/Chain/Map/FormattedTest.php
+++ b/tests/Unit/Chain/Map/FormattedTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Map;
+
+use ArgumentCountError;
+use Haspadar\Piqule\Chain\Map\Formatted;
+use Haspadar\Piqule\Chain\Render\Neon\NeonBool;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FormattedTest extends TestCase
+{
+    #[Test]
+    public function substitutesRenderedOutputIntoTemplate(): void
+    {
+        self::assertSame(
+            'value: true',
+            (new Formatted(new NeonBool(new BoolValue(true)), 'value: %s'))->rendered(),
+            'Formatted must substitute the source op output into the sprintf template',
+        );
+    }
+
+    #[Test]
+    public function preservesPercentSignsInsideRenderedOutput(): void
+    {
+        self::assertSame(
+            'coverage: 90% complete',
+            (new Formatted(new NeonBool(new BoolValue(true)), 'coverage: 90%% complete'))->rendered(),
+            'Formatted must keep literal percent signs intact via sprintf escape semantics',
+        );
+    }
+
+    #[Test]
+    public function returnsTemplateUnchangedWhenItHasNoPlaceholder(): void
+    {
+        self::assertSame(
+            'literal',
+            (new Formatted(new NeonBool(new BoolValue(true)), 'literal'))->rendered(),
+            'Formatted must return the template as-is when there is no %s placeholder to fill',
+        );
+    }
+
+    #[Test]
+    public function failsWhenTemplateExpectsMorePlaceholdersThanProvided(): void
+    {
+        $this->expectException(ArgumentCountError::class);
+
+        (new Formatted(new NeonBool(new BoolValue(true)), '%s and %s'))->rendered();
+    }
+
+    #[Test]
+    public function failsWhenTemplateContainsTrailingPercent(): void
+    {
+        $this->expectException(ArgumentCountError::class);
+
+        (new Formatted(new NeonBool(new BoolValue(true)), 'value: %s%'))->rendered();
+    }
+}

--- a/tests/Unit/Chain/Map/FormattedTest.php
+++ b/tests/Unit/Chain/Map/FormattedTest.php
@@ -27,9 +27,9 @@ final class FormattedTest extends TestCase
     public function preservesPercentSignsInsideRenderedOutput(): void
     {
         self::assertSame(
-            'coverage: 90% complete',
-            (new Formatted(new NeonBool(new BoolValue(true)), 'coverage: 90%% complete'))->rendered(),
-            'Formatted must keep literal percent signs intact via sprintf escape semantics',
+            'coverage: 90% true',
+            (new Formatted(new NeonBool(new BoolValue(true)), 'coverage: 90%% %s'))->rendered(),
+            'Formatted must escape literal percents and still substitute the source op output',
         );
     }
 

--- a/tests/Unit/Chain/Reduce/JoinedTest.php
+++ b/tests/Unit/Chain/Reduce/JoinedTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Reduce;
+
+use Haspadar\Piqule\Chain\Reduce\Joined;
+use Haspadar\Piqule\Chain\Render\Neon\NeonBool;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JoinedTest extends TestCase
+{
+    #[Test]
+    public function concatenatesRenderedPartsWithGlue(): void
+    {
+        self::assertSame(
+            'true, false',
+            (new Joined([
+                new NeonBool(new BoolValue(true)),
+                new NeonBool(new BoolValue(false)),
+            ], ', '))->rendered(),
+            'Joined must concatenate rendered outputs separated by the glue string',
+        );
+    }
+
+    #[Test]
+    public function omitsGlueForSingleElementList(): void
+    {
+        self::assertSame(
+            'true',
+            (new Joined([new NeonBool(new BoolValue(true))], ', '))->rendered(),
+            'Joined must not insert the glue when there is only one part to render',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyStringForEmptyPartsList(): void
+    {
+        self::assertSame(
+            '',
+            (new Joined([], ', '))->rendered(),
+            'Joined must return an empty string when there are no parts to join',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Mark `Mapped` (single-op decorators) and `Reduced` (multi-op combinators) so chain ops have explicit roles next to the existing `Rendered` family.
- Add `Chain\Map\Formatted` that wraps an op's rendered output in a sprintf template.
- Add `Chain\Reduce\Joined` that concatenates multiple op outputs with a glue string.

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template-based string formatting to transform rendered output using sprintf-style templates
  * Added string concatenation support to combine multiple rendered outputs with customizable separators

* **Tests**
  * Added comprehensive unit tests for formatting and concatenation functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->