### PR TITLE
Add Listed marker and scalar Plain text sources for the Chain layer

### DIFF
--- a/src/Chain/Listed.php
+++ b/src/Chain/Listed.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain;
+
+/**
+ * Marker for chain ops that expose an ordered list of inner ops.
+ *
+ * Implementations carry a list of Op objects between pipeline stages, so map
+ * and reduce operations can transform or fold the parts before rendering.
+ * Calling rendered() directly on a Listed is a misuse: implementations are
+ * expected to throw PiquleException, since collapsing parts into a string
+ * is the job of an explicit Reduced step (typically Joined) further down
+ * the pipeline.
+ */
+interface Listed extends Op
+{
+    /**
+     * Returns the inner ops in their pipeline order.
+     *
+     * @return list<Op> Inner ops the next pipeline stage will iterate over
+     */
+    public function parts(): array;
+}

--- a/src/Chain/Plain/BoolText.php
+++ b/src/Chain/Plain/BoolText.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Op;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use Override;
+
+/**
+ * Renders a BoolValue as a plain "true" or "false" literal.
+ *
+ * Format-neutral source for boolean configuration values. The result is the
+ * same in neon, json, php and most other formats, so callers do not need a
+ * format-specific renderer to embed a boolean into a template.
+ *
+ * Example:
+ *
+ *     (new BoolText(new BoolValue(true)))->rendered(); // "true"
+ */
+final readonly class BoolText implements Op
+{
+    /**
+     * Initializes with the boolean value to render.
+     *
+     * @param BoolValue $value Boolean payload rendered as a plain literal
+     */
+    public function __construct(private BoolValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return $this->value->raw
+            ? 'true'
+            : 'false';
+    }
+}

--- a/src/Chain/Plain/FloatText.php
+++ b/src/Chain/Plain/FloatText.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Op;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use Override;
+
+/**
+ * Renders a FloatValue as its plain decimal representation.
+ *
+ * Special floats (INF, -INF, NAN) cannot be embedded into a configuration
+ * template safely, so rendering them is a configuration error.
+ *
+ * Example:
+ *
+ *     (new FloatText(new FloatValue(0.5)))->rendered(); // "0.5"
+ */
+final readonly class FloatText implements Op
+{
+    /**
+     * Initializes with the float value to render.
+     *
+     * @param FloatValue $value Float payload rendered as a plain decimal
+     */
+    public function __construct(private FloatValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        $raw = $this->value->raw;
+
+        if (!is_finite($raw)) {
+            throw new PiquleException(
+                sprintf('FloatText cannot render non-finite value "%s"', (string) $raw),
+            );
+        }
+
+        return (string) $raw;
+    }
+}

--- a/src/Chain/Plain/IntText.php
+++ b/src/Chain/Plain/IntText.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Op;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use Override;
+
+/**
+ * Renders an IntValue as its decimal string representation.
+ *
+ * Example:
+ *
+ *     (new IntText(new IntValue(8)))->rendered(); // "8"
+ */
+final readonly class IntText implements Op
+{
+    /**
+     * Initializes with the integer value to render.
+     *
+     * @param IntValue $value Integer payload rendered as a decimal literal
+     */
+    public function __construct(private IntValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return (string) $this->value->raw;
+    }
+}

--- a/src/Chain/Plain/StringText.php
+++ b/src/Chain/Plain/StringText.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Op;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use Override;
+
+/**
+ * Renders a StringValue as its raw string payload without quotes.
+ *
+ * Format-neutral source for string configuration values. Callers that need a
+ * quoted or escaped representation should compose this with a format-specific
+ * renderer instead of relying on StringText for escaping.
+ *
+ * Example:
+ *
+ *     (new StringText(new StringValue('1G')))->rendered(); // "1G"
+ */
+final readonly class StringText implements Op
+{
+    /**
+     * Initializes with the string value to render.
+     *
+     * @param StringValue $value String payload rendered verbatim, without quoting
+     */
+    public function __construct(private StringValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return $this->value->raw;
+    }
+}

--- a/tests/Unit/Chain/Plain/BoolTextTest.php
+++ b/tests/Unit/Chain/Plain/BoolTextTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Plain\BoolText;
+use Haspadar\Piqule\Settings\Value\BoolValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class BoolTextTest extends TestCase
+{
+    #[Test]
+    public function rendersTrueAsLiteralTrue(): void
+    {
+        self::assertSame(
+            'true',
+            (new BoolText(new BoolValue(true)))->rendered(),
+            'BoolText must render true as the plain literal "true"',
+        );
+    }
+
+    #[Test]
+    public function rendersFalseAsLiteralFalse(): void
+    {
+        self::assertSame(
+            'false',
+            (new BoolText(new BoolValue(false)))->rendered(),
+            'BoolText must render false as the plain literal "false"',
+        );
+    }
+}

--- a/tests/Unit/Chain/Plain/FloatTextTest.php
+++ b/tests/Unit/Chain/Plain/FloatTextTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Plain\FloatText;
+use Haspadar\Piqule\PiquleException;
+use Haspadar\Piqule\Settings\Value\FloatValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FloatTextTest extends TestCase
+{
+    #[Test]
+    public function rendersFiniteFloatAsDecimalString(): void
+    {
+        self::assertSame(
+            '0.5',
+            (new FloatText(new FloatValue(0.5)))->rendered(),
+            'FloatText must render a finite float as its decimal string',
+        );
+    }
+
+    #[Test]
+    public function rejectsInfinity(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new FloatText(new FloatValue(INF)))->rendered();
+    }
+
+    #[Test]
+    public function rejectsNotANumber(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new FloatText(new FloatValue(NAN)))->rendered();
+    }
+
+    #[Test]
+    public function rejectsNegativeInfinity(): void
+    {
+        $this->expectException(PiquleException::class);
+
+        (new FloatText(new FloatValue(-INF)))->rendered();
+    }
+
+    #[Test]
+    public function rendersNegativeFiniteFloatWithLeadingMinus(): void
+    {
+        self::assertSame(
+            '-0.5',
+            (new FloatText(new FloatValue(-0.5)))->rendered(),
+            'FloatText must keep the leading minus sign for negative finite floats',
+        );
+    }
+
+    #[Test]
+    public function rendersWholeFloatWithoutDecimalPoint(): void
+    {
+        self::assertSame(
+            '1',
+            (new FloatText(new FloatValue(1.0)))->rendered(),
+            'FloatText pins PHP default behavior of rendering 1.0 as "1" via string cast',
+        );
+    }
+}

--- a/tests/Unit/Chain/Plain/IntTextTest.php
+++ b/tests/Unit/Chain/Plain/IntTextTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Plain\IntText;
+use Haspadar\Piqule\Settings\Value\IntValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class IntTextTest extends TestCase
+{
+    #[Test]
+    public function rendersPositiveIntegerAsDecimalString(): void
+    {
+        self::assertSame(
+            '8',
+            (new IntText(new IntValue(8)))->rendered(),
+            'IntText must render a positive integer as its decimal string',
+        );
+    }
+
+    #[Test]
+    public function rendersNegativeIntegerWithLeadingMinus(): void
+    {
+        self::assertSame(
+            '-3',
+            (new IntText(new IntValue(-3)))->rendered(),
+            'IntText must keep the leading minus sign for negative integers',
+        );
+    }
+
+    #[Test]
+    public function rendersZeroAsLiteralZero(): void
+    {
+        self::assertSame(
+            '0',
+            (new IntText(new IntValue(0)))->rendered(),
+            'IntText must render zero as the bare digit "0"',
+        );
+    }
+
+    #[Test]
+    public function rendersIntMaxBoundaryWithoutOverflow(): void
+    {
+        self::assertSame(
+            (string) PHP_INT_MAX,
+            (new IntText(new IntValue(PHP_INT_MAX)))->rendered(),
+            'IntText must round-trip PHP_INT_MAX through string casting without loss',
+        );
+    }
+
+    #[Test]
+    public function rendersIntMinBoundaryWithoutOverflow(): void
+    {
+        self::assertSame(
+            (string) PHP_INT_MIN,
+            (new IntText(new IntValue(PHP_INT_MIN)))->rendered(),
+            'IntText must round-trip PHP_INT_MIN through string casting without loss',
+        );
+    }
+}

--- a/tests/Unit/Chain/Plain/StringTextTest.php
+++ b/tests/Unit/Chain/Plain/StringTextTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Piqule\Tests\Unit\Chain\Plain;
+
+use Haspadar\Piqule\Chain\Plain\StringText;
+use Haspadar\Piqule\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class StringTextTest extends TestCase
+{
+    #[Test]
+    public function rendersStringPayloadVerbatim(): void
+    {
+        self::assertSame(
+            '1G',
+            (new StringText(new StringValue('1G')))->rendered(),
+            'StringText must render the string payload as-is, without quoting',
+        );
+    }
+
+    #[Test]
+    public function preservesSpecialCharactersWithoutEscaping(): void
+    {
+        self::assertSame(
+            'a"b\\c',
+            (new StringText(new StringValue('a"b\\c')))->rendered(),
+            'StringText must not escape quotes or backslashes — escaping is the format renderer responsibility',
+        );
+    }
+
+    #[Test]
+    public function rendersEmptyStringAsEmptyOutput(): void
+    {
+        self::assertSame(
+            '',
+            (new StringText(new StringValue('')))->rendered(),
+            'StringText must render an empty StringValue as an empty string',
+        );
+    }
+
+    #[Test]
+    public function preservesNewlinesAndTabsWithoutEscaping(): void
+    {
+        self::assertSame(
+            "line1\nline2\tend",
+            (new StringText(new StringValue("line1\nline2\tend")))->rendered(),
+            'StringText must keep newlines and tabs verbatim — escaping is the format renderer responsibility',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Mark `Listed` so chain ops can carry an intermediate ordered list of inner ops between pipeline stages, complementing `Mapped` and `Reduced`. Direct rendering of a `Listed` is a contract misuse and is documented to throw `PiquleException`.
- Add four format-neutral `Chain\Plain\*` scalar sources that turn typed settings values into plain text: `BoolText`, `IntText`, `FloatText`, `StringText`. These are the building blocks the upcoming pipeline parser will plug into the head of every template formula.
- `FloatText` rejects `INF`/`-INF`/`NAN` since non-finite floats have no safe configuration text shape; `StringText` deliberately does not escape, leaving that to format-specific renderers downstream.

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plain-text rendering operations for configuration values including booleans, floats, integers, and strings.
  * Introduced `Listed` interface for organizing chain operations with ordered parts.

* **Tests**
  * Added comprehensive test coverage for new text rendering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->