### PR TITLE
Snob CI Entrypoint

### DIFF
--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -62,7 +62,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run check
-        run: bin/piqule check ${{ matrix.check }}
+        run: bin/snob check ${{ matrix.check }}
 
 
   # ============================================================
@@ -98,7 +98,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run static check
-        run: bin/piqule check ${{ matrix.check }}
+        run: bin/snob check ${{ matrix.check }}
 
 
   # ============================================================

--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -3,7 +3,7 @@ override:
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
   ci.pr.max_lines_changed: 2000
-  ci.piqule_bin: bin/piqule
+  ci.piqule_bin: bin/snob
   sonar.organization: haspadar-org
   sonar.projectKey: haspadar_piqule
   infection.min_msi: 80

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -18,7 +18,7 @@ defaults:
   check.parallel: true
   check.slow: ["infection", "sonar"]
 
-  ci.piqule_bin: "vendor/bin/piqule"
+  ci.piqule_bin: "vendor/bin/snob"
   ci.pr.max_lines_changed: 250
 
   coverage.patch.target: 80

--- a/DEV.md
+++ b/DEV.md
@@ -362,7 +362,7 @@ All keys below are declared in `templates/always/.piqule/config.yaml` with their
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `ci.piqule_bin` | `"vendor/bin/piqule"` | Path to piqule binary in CI |
+| `ci.piqule_bin` | `"vendor/bin/snob"` | Path to Snob binary in CI |
 | `ci.pr.max_lines_changed` | `250` | Maximum lines changed per PR |
 
 ### Coverage

--- a/templates/always/.piqule/config.yaml
+++ b/templates/always/.piqule/config.yaml
@@ -18,7 +18,7 @@ defaults:
   check.parallel: true
   check.slow: ["infection", "sonar"]
 
-  ci.piqule_bin: "vendor/bin/piqule"
+  ci.piqule_bin: "vendor/bin/snob"
   ci.pr.max_lines_changed: 250
 
   coverage.patch.target: 80

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -62,12 +62,12 @@ final class DefaultConfigTest extends TestCase
     }
 
     #[Test]
-    public function returnsVendorBinaryPathWhenPiquleRunsInCi(): void
+    public function returnsVendorBinaryPathWhenSnobRunsInCi(): void
     {
         self::assertSame(
-            ['vendor/bin/piqule'],
+            ['vendor/bin/snob'],
             (new DefaultConfig())->list('ci.piqule_bin'),
-            'CI must run the Composer-installed piqule binary by default',
+            'CI must run the Composer-installed snob binary by default',
         );
     }
 


### PR DESCRIPTION
- Updated CI binary defaults to run `snob`
- Updated generated workflow output to use `bin/snob`
- Updated config coverage for the Snob CI binary default

Part of #671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure and analysis tooling configuration across workflows, configuration files, and tests to support the latest code quality checks environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->