### PR TITLE
Chain Template Pipeline Parsing

### DIFF
--- a/src/Chain/Parse/FormulaArgs.php
+++ b/src/Chain/Parse/FormulaArgs.php
@@ -73,18 +73,22 @@ final readonly class FormulaArgs
             if ($escaped) {
                 $result .= $this->escaped($char);
                 $escaped = false;
+
                 continue;
             }
 
             if ($char === '\\') {
                 $escaped = true;
+
                 continue;
             }
 
             $result .= $char;
         }
 
-        return $escaped ? sprintf('%s\\', $result) : $result;
+        return $escaped
+            ? sprintf('%s\\', $result)
+            : $result;
     }
 
     private function escaped(string $char): string

--- a/src/Chain/Parse/FormulaArgs.php
+++ b/src/Chain/Parse/FormulaArgs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Chain\Parse;
 
-use Haspadar\Sheriff\SheriffException;
+use InvalidArgumentException;
 
 /**
  * Argument list from one pipeline formula call.
@@ -29,7 +29,7 @@ final readonly class FormulaArgs
     /**
      * Returns unquoted argument values.
      *
-     * @throws SheriffException
+     * @throws InvalidArgumentException
      * @return list<string>
      */
     public function values(): array

--- a/src/Chain/Parse/FormulaArgs.php
+++ b/src/Chain/Parse/FormulaArgs.php
@@ -66,8 +66,9 @@ final readonly class FormulaArgs
     {
         $result = '';
         $escaped = false;
+        $length = strlen($argument);
 
-        for ($offset = 0; $offset < strlen($argument); ++$offset) {
+        for ($offset = 0; $offset < $length; ++$offset) {
             $char = $argument[$offset];
 
             if ($escaped) {

--- a/src/Chain/Parse/FormulaArgs.php
+++ b/src/Chain/Parse/FormulaArgs.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * Argument list from one pipeline formula call.
+ *
+ * Example:
+ *
+ *     (new FormulaArgs('phpstan.paths, "- %s"'))->values();
+ */
+final readonly class FormulaArgs
+{
+    private const int MIN_QUOTED_LENGTH = 2;
+
+    private const int STRIP_LAST_CHAR = -1;
+
+    /**
+     * Initializes with the raw text inside formula parentheses.
+     *
+     * @param string $text Raw argument text
+     */
+    public function __construct(private string $text) {}
+
+    /**
+     * Returns unquoted argument values.
+     *
+     * @throws SheriffException
+     * @return list<string>
+     */
+    public function values(): array
+    {
+        if (trim($this->text) === '') {
+            return [];
+        }
+
+        return array_map(
+            $this->unquoted(...),
+            (new SeparatedTexts($this->text, ','))->values(),
+        );
+    }
+
+    private function unquoted(string $argument): string
+    {
+        $length = strlen($argument);
+
+        if ($length < self::MIN_QUOTED_LENGTH) {
+            return $argument;
+        }
+
+        $first = $argument[0];
+        $last = $argument[$length - 1];
+
+        if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+            return $this->unescaped(substr($argument, 1, self::STRIP_LAST_CHAR));
+        }
+
+        return $argument;
+    }
+
+    private function unescaped(string $argument): string
+    {
+        $result = '';
+        $escaped = false;
+
+        for ($offset = 0; $offset < strlen($argument); ++$offset) {
+            $char = $argument[$offset];
+
+            if ($escaped) {
+                $result .= $this->escaped($char);
+                $escaped = false;
+                continue;
+            }
+
+            if ($char === '\\') {
+                $escaped = true;
+                continue;
+            }
+
+            $result .= $char;
+        }
+
+        return $escaped ? sprintf('%s\\', $result) : $result;
+    }
+
+    private function escaped(string $char): string
+    {
+        return match ($char) {
+            'n' => "\n",
+            'r' => "\r",
+            't' => "\t",
+            '\\' => '\\',
+            '"' => '"',
+            "'" => "'",
+            default => sprintf('\\%s', $char),
+        };
+    }
+}

--- a/src/Chain/Parse/FormulaTarget.php
+++ b/src/Chain/Parse/FormulaTarget.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Chain\Parse;
 
 use Haspadar\Sheriff\Chain\Op;
-use Haspadar\Sheriff\SheriffException;
+use InvalidArgumentException;
 
 /**
  * Formula class resolved from a template formula name.
@@ -27,7 +27,7 @@ final readonly class FormulaTarget
     /**
      * Returns the Formula implementation for the resolved Chain class.
      *
-     * @throws SheriffException
+     * @throws InvalidArgumentException
      */
     public function formula(): Formula
     {
@@ -50,7 +50,7 @@ final readonly class FormulaTarget
             return new ReduceFormula($target, $this->args);
         }
 
-        throw new SheriffException(sprintf('Unknown pipeline formula "%s"', $this->name));
+        throw new InvalidArgumentException(sprintf('Unknown pipeline formula "%s"', $this->name));
     }
 
     /**

--- a/src/Chain/Parse/FormulaTarget.php
+++ b/src/Chain/Parse/FormulaTarget.php
@@ -39,15 +39,11 @@ final readonly class FormulaTarget
                 continue;
             }
 
-            if ($candidate['kind'] === 'source') {
-                return new SourceFormula($target, $this->args);
-            }
-
-            if ($candidate['kind'] === 'map') {
-                return new MapFormula($target, $this->args);
-            }
-
-            return new ReduceFormula($target, $this->args);
+            return match ($candidate['kind']) {
+                'source' => new SourceFormula($target, $this->args),
+                'map' => new MapFormula($target, $this->args),
+                'reduce' => new ReduceFormula($target, $this->args),
+            };
         }
 
         throw new InvalidArgumentException(sprintf('Unknown pipeline formula "%s"', $this->name));

--- a/src/Chain/Parse/FormulaTarget.php
+++ b/src/Chain/Parse/FormulaTarget.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * Formula class resolved from a template formula name.
+ *
+ * Example:
+ *
+ *     (new FormulaTarget('ListText', ['phpstan.paths']))->formula();
+ */
+final readonly class FormulaTarget
+{
+    /**
+     * Initializes with a PascalCase formula name and its raw arguments.
+     *
+     * @param string $name Formula name from the template
+     * @param list<string> $args Formula arguments
+     */
+    public function __construct(private string $name, private array $args) {}
+
+    /**
+     * Returns the Formula implementation for the resolved Chain class.
+     *
+     * @throws SheriffException
+     */
+    public function formula(): Formula
+    {
+        foreach ($this->candidates() as $candidate) {
+            /** @var class-string<Op> $target */
+            $target = sprintf('%s%s', $candidate['namespace'], $this->name);
+
+            if (!class_exists($target) || !is_subclass_of($target, Op::class)) {
+                continue;
+            }
+
+            if ($candidate['kind'] === 'source') {
+                return new SourceFormula($target, $this->args);
+            }
+
+            if ($candidate['kind'] === 'map') {
+                return new MapFormula($target, $this->args);
+            }
+
+            return new ReduceFormula($target, $this->args);
+        }
+
+        throw new SheriffException(sprintf('Unknown pipeline formula "%s"', $this->name));
+    }
+
+    /**
+     * Returns namespaces in the resolution order.
+     *
+     * @return list<array{namespace: string, kind: 'source'|'map'|'reduce'}>
+     */
+    private function candidates(): array
+    {
+        return [
+            ['namespace' => 'Haspadar\\Sheriff\\Chain\\Render\\Neon\\', 'kind' => 'source'],
+            ['namespace' => 'Haspadar\\Sheriff\\Chain\\Render\\Json\\', 'kind' => 'source'],
+            ['namespace' => 'Haspadar\\Sheriff\\Chain\\Render\\Xml\\', 'kind' => 'source'],
+            ['namespace' => 'Haspadar\\Sheriff\\Chain\\Render\\Php\\', 'kind' => 'source'],
+            ['namespace' => 'Haspadar\\Sheriff\\Chain\\Map\\', 'kind' => 'map'],
+            ['namespace' => 'Haspadar\\Sheriff\\Chain\\Reduce\\', 'kind' => 'reduce'],
+            ['namespace' => 'Haspadar\\Sheriff\\Chain\\Plain\\', 'kind' => 'source'],
+        ];
+    }
+}

--- a/src/Chain/Parse/PipelineFormula.php
+++ b/src/Chain/Parse/PipelineFormula.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Chain\Parse;
 
-use Haspadar\Sheriff\SheriffException;
+use InvalidArgumentException;
 
 /**
  * One textual `Name(args)` stage from a template pipeline.
@@ -29,12 +29,12 @@ final readonly class PipelineFormula
     /**
      * Returns the executable Formula represented by this text.
      *
-     * @throws SheriffException
+     * @throws InvalidArgumentException
      */
     public function formula(): Formula
     {
         if (preg_match('/^\s*([A-Z][A-Za-z0-9]*)\s*\((.*)\)\s*$/s', $this->text, $match) !== 1) {
-            throw new SheriffException(sprintf('Invalid pipeline formula "%s"', $this->text));
+            throw new InvalidArgumentException(sprintf('Invalid pipeline formula "%s"', $this->text));
         }
 
         return (new FormulaTarget(

--- a/src/Chain/Parse/PipelineFormula.php
+++ b/src/Chain/Parse/PipelineFormula.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * One textual `Name(args)` stage from a template pipeline.
+ *
+ * Example:
+ *
+ *     (new PipelineFormula('ListText(phpstan.paths)'))->formula();
+ */
+final readonly class PipelineFormula
+{
+    private const int MATCH_NAME = 1;
+
+    private const int MATCH_ARGS = 2;
+
+    /**
+     * Initializes with one formula call.
+     *
+     * @param string $text Formula call text
+     */
+    public function __construct(private string $text) {}
+
+    /**
+     * Returns the executable Formula represented by this text.
+     *
+     * @throws SheriffException
+     */
+    public function formula(): Formula
+    {
+        if (preg_match('/^\s*([A-Z][A-Za-z0-9]*)\s*\((.*)\)\s*$/s', $this->text, $match) !== 1) {
+            throw new SheriffException(sprintf('Invalid pipeline formula "%s"', $this->text));
+        }
+
+        return (new FormulaTarget(
+            $match[self::MATCH_NAME],
+            (new FormulaArgs($match[self::MATCH_ARGS]))->values(),
+        ))->formula();
+    }
+}

--- a/src/Chain/Parse/PipelineFormulas.php
+++ b/src/Chain/Parse/PipelineFormulas.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Chain\Parse;
 
-use Haspadar\Sheriff\SheriffException;
+use InvalidArgumentException;
 
 /**
  * Formula stages parsed from a template pipeline string.
@@ -25,7 +25,7 @@ final readonly class PipelineFormulas
     /**
      * Returns formulas in source-to-tail order.
      *
-     * @throws SheriffException
+     * @throws InvalidArgumentException
      * @return list<Formula>
      */
     public function formulas(): array

--- a/src/Chain/Parse/PipelineFormulas.php
+++ b/src/Chain/Parse/PipelineFormulas.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * Formula stages parsed from a template pipeline string.
+ *
+ * Example:
+ *
+ *     (new PipelineFormulas('ListText(phpstan.paths)|Joined(", ")'))->formulas();
+ */
+final readonly class PipelineFormulas
+{
+    /**
+     * Initializes with the raw pipeline expression.
+     *
+     * @param string $pipeline Text between `<<` and `>>`
+     */
+    public function __construct(private string $pipeline) {}
+
+    /**
+     * Returns formulas in source-to-tail order.
+     *
+     * @throws SheriffException
+     * @return list<Formula>
+     */
+    public function formulas(): array
+    {
+        return array_map(
+            fn(string $text): Formula => (new PipelineFormula($text))->formula(),
+            (new SeparatedTexts($this->pipeline, '|'))->values(),
+        );
+    }
+}

--- a/src/Chain/Parse/PipelineFormulas.php
+++ b/src/Chain/Parse/PipelineFormulas.php
@@ -31,7 +31,7 @@ final readonly class PipelineFormulas
     public function formulas(): array
     {
         return array_map(
-            fn(string $text): Formula => (new PipelineFormula($text))->formula(),
+            static fn(string $text): Formula => (new PipelineFormula($text))->formula(),
             (new SeparatedTexts($this->pipeline, '|'))->values(),
         );
     }

--- a/src/Chain/Parse/SeparatedTexts.php
+++ b/src/Chain/Parse/SeparatedTexts.php
@@ -16,10 +16,10 @@ use InvalidArgumentException;
 final readonly class SeparatedTexts
 {
     /**
-     * Initializes with the raw text and a single-character separator.
+     * Initializes with the raw text and a separator string.
      *
      * @param string $text Text to split
-     * @param string $separator Separator character
+     * @param string $separator Separator string
      */
     public function __construct(private string $text, private string $separator) {}
 

--- a/src/Chain/Parse/SeparatedTexts.php
+++ b/src/Chain/Parse/SeparatedTexts.php
@@ -7,7 +7,7 @@ namespace Haspadar\Sheriff\Chain\Parse;
 use Haspadar\Sheriff\SheriffException;
 
 /**
- * Text split by a separator that is ignored inside double-quoted fragments.
+ * Text split by a separator that is ignored inside quoted fragments.
  *
  * Example:
  *
@@ -46,7 +46,7 @@ final readonly class SeparatedTexts
     private function pattern(): string
     {
         return sprintf(
-            '/%s(?=(?:[^"]*"[^"]*")*[^"]*$)/',
+            '/%s(?=(?:[^\'"\\\\]|\\\\.|"(?:[^"\\\\]|\\\\.)*"|\'(?:[^\'\\\\]|\\\\.)*\')*$)/',
             preg_quote($this->separator, '/'),
         );
     }

--- a/src/Chain/Parse/SeparatedTexts.php
+++ b/src/Chain/Parse/SeparatedTexts.php
@@ -38,11 +38,16 @@ final readonly class SeparatedTexts
         }
 
         return array_map(
-            fn(string $value): string => trim($value),
+            static fn(string $value): string => trim($value),
             $values,
         );
     }
 
+    /**
+     * Returns the regex used to find separators outside quoted text.
+     *
+     * @return non-empty-string
+     */
     private function pattern(): string
     {
         return sprintf(

--- a/src/Chain/Parse/SeparatedTexts.php
+++ b/src/Chain/Parse/SeparatedTexts.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * Text split by a separator that is ignored inside double-quoted fragments.
+ *
+ * Example:
+ *
+ *     (new SeparatedTexts('A("x|y")|B()', '|'))->values();
+ */
+final readonly class SeparatedTexts
+{
+    /**
+     * Initializes with the raw text and a single-character separator.
+     *
+     * @param string $text Text to split
+     * @param string $separator Separator character
+     */
+    public function __construct(private string $text, private string $separator) {}
+
+    /**
+     * Returns trimmed fragments while preserving quoted contents.
+     *
+     * @throws SheriffException
+     * @return list<string>
+     */
+    public function values(): array
+    {
+        $values = preg_split($this->pattern(), $this->text);
+
+        if (!is_array($values)) {
+            throw new SheriffException(sprintf('Cannot split "%s"', $this->text));
+        }
+
+        return array_map(
+            fn(string $value): string => trim($value),
+            $values,
+        );
+    }
+
+    private function pattern(): string
+    {
+        return sprintf(
+            '/%s(?=(?:[^"]*"[^"]*")*[^"]*$)/',
+            preg_quote($this->separator, '/'),
+        );
+    }
+}

--- a/src/Chain/Parse/SeparatedTexts.php
+++ b/src/Chain/Parse/SeparatedTexts.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Chain\Parse;
 
-use Haspadar\Sheriff\SheriffException;
+use InvalidArgumentException;
 
 /**
  * Text split by a separator that is ignored inside quoted fragments.
@@ -26,7 +26,7 @@ final readonly class SeparatedTexts
     /**
      * Returns trimmed fragments while preserving quoted contents.
      *
-     * @throws SheriffException
+     * @throws InvalidArgumentException
      * @return list<string>
      */
     public function values(): array
@@ -34,7 +34,7 @@ final readonly class SeparatedTexts
         $values = preg_split($this->pattern(), $this->text);
 
         if (!is_array($values)) {
-            throw new SheriffException(sprintf('Cannot split "%s"', $this->text));
+            throw new InvalidArgumentException(sprintf('Cannot split "%s"', $this->text));
         }
 
         return array_map(

--- a/src/File/TemplateFile.php
+++ b/src/File/TemplateFile.php
@@ -8,6 +8,7 @@ use Haspadar\Sheriff\Chain\Parse\PipelineFormulas;
 use Haspadar\Sheriff\Chain\Parse\PipelineOp;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\SheriffException;
+use InvalidArgumentException;
 use Override;
 use TypeError;
 
@@ -58,7 +59,7 @@ final readonly class TemplateFile implements File
                 (new PipelineFormulas($expression))->formulas(),
                 $this->settings,
             ))->rendered();
-        } catch (SheriffException | TypeError $e) {
+        } catch (InvalidArgumentException | SheriffException | TypeError $e) {
             throw new SheriffException(
                 sprintf(
                     'File "%s", pipeline "%s": %s',

--- a/src/File/TemplateFile.php
+++ b/src/File/TemplateFile.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\File;
+
+use Haspadar\Sheriff\Chain\Parse\PipelineFormulas;
+use Haspadar\Sheriff\Chain\Parse\PipelineOp;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+use TypeError;
+
+/**
+ * Replaces Chain template placeholders in the wrapped file.
+ */
+final readonly class TemplateFile implements File
+{
+    /**
+     * Initializes with the file and settings used by template pipelines.
+     *
+     * @param File $origin File whose contents may contain Chain placeholders
+     * @param Settings $settings Settings context read by source formulas
+     */
+    public function __construct(private File $origin, private Settings $settings) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return $this->origin->name();
+    }
+
+    #[Override]
+    public function contents(): string
+    {
+        return (string) preg_replace_callback(
+            '/<<\s*(.*?)\s*>>/s',
+            fn(array $match): string => $this->replaced($match[1]),
+            $this->origin->contents(),
+        );
+    }
+
+    #[Override]
+    public function mode(): int
+    {
+        return $this->origin->mode();
+    }
+
+    /**
+     * Renders one placeholder expression through Chain.
+     *
+     * @throws SheriffException
+     */
+    private function replaced(string $expression): string
+    {
+        try {
+            return (new PipelineOp(
+                (new PipelineFormulas($expression))->formulas(),
+                $this->settings,
+            ))->rendered();
+        } catch (SheriffException | TypeError $e) {
+            throw new SheriffException(
+                sprintf(
+                    'File "%s", pipeline "%s": %s',
+                    $this->name(),
+                    trim($expression),
+                    $e->getMessage(),
+                ),
+                0,
+                $e,
+            );
+        }
+    }
+}

--- a/tests/Unit/Chain/Parse/FormulaArgsTest.php
+++ b/tests/Unit/Chain/Parse/FormulaArgsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Parse\FormulaArgs;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FormulaArgsTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyListWhenOnlyWhitespaceIsGiven(): void
+    {
+        self::assertSame(
+            [],
+            (new FormulaArgs('   '))->values(),
+            'FormulaArgs must treat whitespace-only argument lists as empty',
+        );
+    }
+
+    #[Test]
+    public function unquotesEmptyStringArgument(): void
+    {
+        self::assertSame(
+            [''],
+            (new FormulaArgs('""'))->values(),
+            'FormulaArgs must unquote empty string literals',
+        );
+    }
+
+    #[Test]
+    public function keepsMismatchedQuotesVerbatim(): void
+    {
+        self::assertSame(
+            ['"value'],
+            (new FormulaArgs('"value'))->values(),
+            'FormulaArgs must only unquote arguments whose opening and closing quotes match',
+        );
+    }
+
+    #[Test]
+    public function unescapesKnownAndUnknownSequences(): void
+    {
+        self::assertSame(
+            ["\n\r\t\\\"'\\x"],
+            (new FormulaArgs('"\\n\\r\\t\\\\\\"\\\'\\x"'))->values(),
+            'FormulaArgs must unescape known sequences and preserve unknown escapes',
+        );
+    }
+}

--- a/tests/Unit/Chain/Parse/PipelineFormulasTest.php
+++ b/tests/Unit/Chain/Parse/PipelineFormulasTest.php
@@ -63,6 +63,24 @@ final class PipelineFormulasTest extends TestCase
     }
 
     #[Test]
+    public function keepsSeparatorsInsideSingleQuotedArguments(): void
+    {
+        self::assertSame(
+            'src,tests',
+            (new PipelineOp(
+                (new PipelineFormulas("ListText(phpstan.paths)|Joined(',')"))->formulas(),
+                self::settings([
+                    'phpstan.paths' => new ListValue([
+                        new StringValue('src'),
+                        new StringValue('tests'),
+                    ]),
+                ]),
+            ))->rendered(),
+            'PipelineFormulas must not split separators inside single-quoted arguments',
+        );
+    }
+
+    #[Test]
     public function failsWhenFormulaNameIsUnknown(): void
     {
         $this->expectException(SheriffException::class);

--- a/tests/Unit/Chain/Parse/PipelineFormulasTest.php
+++ b/tests/Unit/Chain/Parse/PipelineFormulasTest.php
@@ -81,6 +81,19 @@ final class PipelineFormulasTest extends TestCase
     }
 
     #[Test]
+    public function parsesMultilineFormulaArguments(): void
+    {
+        self::assertSame(
+            "x\nSheriff",
+            (new PipelineOp(
+                (new PipelineFormulas("StringText(app.name)|Formatted(\"x\n%s\")"))->formulas(),
+                self::settings(['app.name' => new StringValue('Sheriff')]),
+            ))->rendered(),
+            'PipelineFormulas must allow multiline quoted arguments',
+        );
+    }
+
+    #[Test]
     public function failsWhenFormulaNameIsUnknown(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -94,6 +107,22 @@ final class PipelineFormulasTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new PipelineFormulas('StringText'))->formulas();
+    }
+
+    #[Test]
+    public function failsWhenFormulaHasLeadingJunk(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new PipelineFormulas('junk StringText(app.name)'))->formulas();
+    }
+
+    #[Test]
+    public function failsWhenFormulaHasTrailingJunk(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new PipelineFormulas('StringText(app.name) junk'))->formulas();
     }
 
     /**

--- a/tests/Unit/Chain/Parse/PipelineFormulasTest.php
+++ b/tests/Unit/Chain/Parse/PipelineFormulasTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Parse\PipelineFormulas;
+use Haspadar\Sheriff\Chain\Parse\PipelineOp;
+use Haspadar\Sheriff\SheriffException;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PipelineFormulasTest extends TestCase
+{
+    #[Test]
+    public function parsesSingleSourceFormula(): void
+    {
+        self::assertSame(
+            '9',
+            (new PipelineOp(
+                (new PipelineFormulas('IntText(phpstan.level)'))->formulas(),
+                self::settings(['phpstan.level' => new IntValue(9)]),
+            ))->rendered(),
+            'PipelineFormulas must parse one source formula into an executable pipeline',
+        );
+    }
+
+    #[Test]
+    public function parsesSourceMapAndReducePipeline(): void
+    {
+        self::assertSame(
+            "- src\n- tests",
+            (new PipelineOp(
+                (new PipelineFormulas('ListText(phpstan.paths)|EachFormatted("- %s")|Joined("\n")'))->formulas(),
+                self::settings([
+                    'phpstan.paths' => new ListValue([
+                        new StringValue('src'),
+                        new StringValue('tests'),
+                    ]),
+                ]),
+            ))->rendered(),
+            'PipelineFormulas must preserve pipeline stage order from source through map to reduce',
+        );
+    }
+
+    #[Test]
+    public function keepsSeparatorsInsideQuotedArguments(): void
+    {
+        self::assertSame(
+            'x,Sheriff|y',
+            (new PipelineOp(
+                (new PipelineFormulas('StringText(app.name)|Formatted("x,%s|y")'))->formulas(),
+                self::settings(['app.name' => new StringValue('Sheriff')]),
+            ))->rendered(),
+            'PipelineFormulas must not split comma or pipe characters inside quoted arguments',
+        );
+    }
+
+    #[Test]
+    public function failsWhenFormulaNameIsUnknown(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new PipelineFormulas('MissingFormula(app.name)'))->formulas();
+    }
+
+    #[Test]
+    public function failsWhenFormulaSyntaxIsInvalid(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new PipelineFormulas('StringText'))->formulas();
+    }
+
+    /**
+     * @param array<string, Value> $values
+     */
+    private static function settings(array $values): Settings
+    {
+        return new readonly class ($values) implements Settings {
+            /**
+             * @param array<string, Value> $values
+             */
+            public function __construct(private array $values) {}
+
+            #[Override]
+            public function has(string $name): bool
+            {
+                return array_key_exists($name, $this->values);
+            }
+
+            #[Override]
+            public function value(string $name): Value
+            {
+                return $this->values[$name];
+            }
+        };
+    }
+}

--- a/tests/Unit/Chain/Parse/PipelineFormulasTest.php
+++ b/tests/Unit/Chain/Parse/PipelineFormulasTest.php
@@ -6,7 +6,7 @@ namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
 
 use Haspadar\Sheriff\Chain\Parse\PipelineFormulas;
 use Haspadar\Sheriff\Chain\Parse\PipelineOp;
-use Haspadar\Sheriff\SheriffException;
+use InvalidArgumentException;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\Settings\Value\IntValue;
 use Haspadar\Sheriff\Settings\Value\ListValue;
@@ -83,7 +83,7 @@ final class PipelineFormulasTest extends TestCase
     #[Test]
     public function failsWhenFormulaNameIsUnknown(): void
     {
-        $this->expectException(SheriffException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         (new PipelineFormulas('MissingFormula(app.name)'))->formulas();
     }
@@ -91,7 +91,7 @@ final class PipelineFormulasTest extends TestCase
     #[Test]
     public function failsWhenFormulaSyntaxIsInvalid(): void
     {
-        $this->expectException(SheriffException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         (new PipelineFormulas('StringText'))->formulas();
     }

--- a/tests/Unit/Chain/Parse/SeparatedTextsTest.php
+++ b/tests/Unit/Chain/Parse/SeparatedTextsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Parse\SeparatedTexts;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SeparatedTextsTest extends TestCase
+{
+    #[Test]
+    public function trimsFragmentsAroundSeparator(): void
+    {
+        self::assertSame(
+            ['A()', 'B()'],
+            (new SeparatedTexts(' A() | B() ', '|'))->values(),
+            'SeparatedTexts must trim fragments split around a separator',
+        );
+    }
+
+    #[Test]
+    public function keepsEscapedQuotesInsideQuotedFragments(): void
+    {
+        self::assertSame(
+            ['A("x\"|y")', 'B()'],
+            (new SeparatedTexts('A("x\"|y")|B()', '|'))->values(),
+            'SeparatedTexts must ignore separators inside escaped quoted fragments',
+        );
+    }
+}

--- a/tests/Unit/File/TemplateFileTest.php
+++ b/tests/Unit/File/TemplateFileTest.php
@@ -78,4 +78,40 @@ final class TemplateFileTest extends TestCase
             ),
         );
     }
+
+    #[Test]
+    public function wrapsMissingSettingErrorsWithFileContext(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('missing.neon', '<< StringText(app.name) >>'),
+                new FakeSettings([]),
+            ),
+            new HasFormulaError(
+                'missing.neon',
+                'StringText(app.name)',
+                'cannot find settings key',
+            ),
+        );
+    }
+
+    #[Test]
+    public function wrapsTypeErrorsWithFileContext(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('typed.neon', '<< StringText(phpstan.paths) >>'),
+                new FakeSettings([
+                    'phpstan.paths' => new ListValue([
+                        new StringValue('src'),
+                    ]),
+                ]),
+            ),
+            new HasFormulaError(
+                'typed.neon',
+                'StringText(phpstan.paths)',
+                'StringValue',
+            ),
+        );
+    }
 }

--- a/tests/Unit/File/TemplateFileTest.php
+++ b/tests/Unit/File/TemplateFileTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\File;
+
+use Haspadar\Sheriff\File\TemplateFile;
+use Haspadar\Sheriff\File\TextFile;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Tests\Constraint\Files\HasFileContents;
+use Haspadar\Sheriff\Tests\Constraint\HasFormulaError;
+use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TemplateFileTest extends TestCase
+{
+    #[Test]
+    public function replacesPlaceholderUsingChainPipeline(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile(
+                    'phpstan.neon',
+                    'paths: << ListText(phpstan.paths)|EachFormatted("- %s")|Joined("\n") >>',
+                ),
+                new FakeSettings([
+                    'phpstan.paths' => new ListValue([
+                        new StringValue('src'),
+                        new StringValue('tests'),
+                    ]),
+                ]),
+            ),
+            new HasFileContents("paths: - src\n- tests"),
+            'TemplateFile must render Chain placeholders through PipelineOp',
+        );
+    }
+
+    #[Test]
+    public function leavesFileUntouchedWhenNoPlaceholdersPresent(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('plain.txt', "plain\ntext"),
+                new FakeSettings([]),
+            ),
+            new HasFileContents("plain\ntext"),
+            'TemplateFile must leave files without Chain placeholders unchanged',
+        );
+    }
+
+    #[Test]
+    public function keepsOriginalMode(): void
+    {
+        self::assertSame(
+            0o755,
+            (new TemplateFile(
+                new TextFile('script.sh', '#!/bin/sh', 0o755),
+                new FakeSettings([]),
+            ))->mode(),
+            'TemplateFile must preserve wrapped file mode',
+        );
+    }
+
+    #[Test]
+    public function wrapsPipelineErrorsWithFileContext(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('broken.neon', '<< MissingFormula(phpstan.paths) >>'),
+                new FakeSettings([]),
+            ),
+            new HasFormulaError(
+                'broken.neon',
+                'MissingFormula(phpstan.paths)',
+                'Unknown pipeline formula',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
- Added parser support for Chain template pipeline expressions
- Added TemplateFile rendering through PipelineOp with file-context errors
- Added parser and template unit coverage for quoted pipeline arguments

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template placeholder substitution now supports pipeline formulas with quoted arguments, escape sequences, and multi-stage pipelines.
  * Template rendering errors are reported with contextual file and expression information.

* **Tests**
  * Added unit tests covering pipeline parsing, argument splitting/unescaping, formula resolution, placeholder rendering, and error-wrapping cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->