### PR TITLE
Integration Test for TemplateFile With DefaultSettings

### DIFF
--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -7,6 +7,7 @@ namespace Haspadar\Sheriff\Tests\Integration\File;
 use Haspadar\Sheriff\File\TemplateFile;
 use Haspadar\Sheriff\File\TextFile;
 use Haspadar\Sheriff\Settings\DefaultSettings;
+use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Tests\Constraint\Files\HasFileContents;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -42,12 +43,18 @@ final class TemplateFileTest extends TestCase
     #[Test]
     public function rendersListValueJoinedFromDefaultSettings(): void
     {
+        $settings = new DefaultSettings();
+        $versions = array_map(
+            static fn(StringValue $v): string => $v->raw,
+            $settings->value('php.versions')->children,
+        );
+
         self::assertThat(
             new TemplateFile(
                 new TextFile('matrix.yml', 'php: [<< ListText(php.versions)|Joined(", ") >>]'),
-                new DefaultSettings(),
+                $settings,
             ),
-            new HasFileContents('php: [8.3]'),
+            new HasFileContents(sprintf('php: [%s]', implode(', ', $versions))),
             'TemplateFile must render ListText joined from DefaultSettings',
         );
     }
@@ -55,12 +62,18 @@ final class TemplateFileTest extends TestCase
     #[Test]
     public function rendersListValueWithEachFormattedFromDefaultSettings(): void
     {
+        $settings = new DefaultSettings();
+        $versions = array_map(
+            static fn(StringValue $v): string => $v->raw . '-alpine',
+            $settings->value('php.versions')->children,
+        );
+
         self::assertThat(
             new TemplateFile(
                 new TextFile('docker.yml', 'image: << ListText(php.versions)|EachFormatted("%s-alpine")|Joined(" ") >>'),
-                new DefaultSettings(),
+                $settings,
             ),
-            new HasFileContents('image: 8.3-alpine'),
+            new HasFileContents(sprintf('image: %s', implode(' ', $versions))),
             'TemplateFile must render EachFormatted pipeline from DefaultSettings',
         );
     }

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Integration\File;
+
+use Haspadar\Sheriff\File\TemplateFile;
+use Haspadar\Sheriff\File\TextFile;
+use Haspadar\Sheriff\Settings\DefaultSettings;
+use Haspadar\Sheriff\Tests\Constraint\Files\HasFileContents;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TemplateFileTest extends TestCase
+{
+    #[Test]
+    public function rendersStringValueFromDefaultSettings(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('hadolint.yml', 'failure-threshold: << StringText(hadolint.failure_threshold) >>'),
+                new DefaultSettings(),
+            ),
+            new HasFileContents('failure-threshold: error'),
+            'TemplateFile must render StringText key from DefaultSettings',
+        );
+    }
+
+    #[Test]
+    public function rendersIntValueFromDefaultSettings(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('phpstan.neon', 'level: << IntText(phpstan.level) >>'),
+                new DefaultSettings(),
+            ),
+            new HasFileContents('level: 9'),
+            'TemplateFile must render IntText key from DefaultSettings',
+        );
+    }
+
+    #[Test]
+    public function rendersListValueJoinedFromDefaultSettings(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('matrix.yml', 'php: [<< ListText(php.versions)|Joined(", ") >>]'),
+                new DefaultSettings(),
+            ),
+            new HasFileContents('php: [8.3]'),
+            'TemplateFile must render ListText joined from DefaultSettings',
+        );
+    }
+
+    #[Test]
+    public function rendersListValueWithEachFormattedFromDefaultSettings(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('docker.yml', 'image: << ListText(php.versions)|EachFormatted("%s-alpine")|Joined(" ") >>'),
+                new DefaultSettings(),
+            ),
+            new HasFileContents('image: 8.3-alpine'),
+            'TemplateFile must render EachFormatted pipeline from DefaultSettings',
+        );
+    }
+
+    #[Test]
+    public function rendersBoolValueFromDefaultSettings(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('codecov.yml', 'cloud: << BoolText(codecov.cloud) >>'),
+                new DefaultSettings(),
+            ),
+            new HasFileContents('cloud: true'),
+            'TemplateFile must render BoolText key from DefaultSettings',
+        );
+    }
+}


### PR DESCRIPTION
- Added integration tests that render Chain pipelines over real DefaultSettings keys

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for template file rendering functionality with various data types and formatting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->