### PR TITLE
Run Chain Alongside Legacy DSL Through {% %} Markers

### DIFF
--- a/bin/sheriff-sync
+++ b/bin/sheriff-sync
@@ -9,12 +9,18 @@ use Haspadar\Sheriff\Envs\YamlEnvs;
 use Haspadar\Sheriff\File\ConfiguredFile;
 use Haspadar\Sheriff\File\File;
 use Haspadar\Sheriff\File\PrefixedFile;
+use Haspadar\Sheriff\File\TemplateFile;
 use Haspadar\Sheriff\Formula\Actions\FormulaActions;
 use Haspadar\Sheriff\Files\EachFile;
 use Haspadar\Sheriff\Files\FilteredFiles;
 use Haspadar\Sheriff\Files\FolderFiles;
 use Haspadar\Sheriff\Files\MappedFiles;
 use Haspadar\Sheriff\Output\Console;
+use Haspadar\Sheriff\Settings\DefaultSettings;
+use Haspadar\Sheriff\Settings\Patch;
+use Haspadar\Sheriff\Settings\PatchedSettings;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\YamlPatches;
 use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Storage\AppendingStorage;
 use Haspadar\Sheriff\Storage\DiffingStorage;
@@ -50,6 +56,14 @@ try {
 
     $actions = (new FormulaActions($config, $envs))->map();
 
+    $settings = file_exists($yamlPath)
+        ? array_reduce(
+            (new YamlPatches($yamlPath))->patches(),
+            static fn(Settings $base, Patch $patch): Settings => new PatchedSettings($base, $patch),
+            new DefaultSettings(),
+        )
+        : new DefaultSettings();
+
     $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
     $disk = new DiskStorage($projectRoot);
 
@@ -58,7 +72,7 @@ try {
             new DiskStorage($libraryRoot . '/templates/always'),
             '',
         ),
-        fn(File $file): File => new ConfiguredFile($file, $actions),
+        fn(File $file): File => new TemplateFile(new ConfiguredFile($file, $actions), $settings),
     );
 
     $gitFiles = new MappedFiles(
@@ -74,7 +88,7 @@ try {
             new DiskStorage($libraryRoot . '/templates/once'),
             '',
         ),
-        fn(File $file): File => new ConfiguredFile($file, $actions),
+        fn(File $file): File => new TemplateFile(new ConfiguredFile($file, $actions), $settings),
     );
 
     $gitDiffFiles = new FilteredFiles(

--- a/src/File/TemplateFile.php
+++ b/src/File/TemplateFile.php
@@ -35,7 +35,7 @@ final readonly class TemplateFile implements File
     public function contents(): string
     {
         return (string) preg_replace_callback(
-            '/<<\s*(.*?)\s*>>/s',
+            '/\{%\s*(.*?)\s*%\}/s',
             fn(array $match): string => $this->replaced($match[1]),
             $this->origin->contents(),
         );

--- a/templates/always/.sheriff/hadolint/.hadolint.yml
+++ b/templates/always/.sheriff/hadolint/.hadolint.yml
@@ -1,9 +1,9 @@
 # Hadolint configuration (Sheriff managed)
 
-failure-threshold: << config(hadolint.failure_threshold) >>
+failure-threshold: {% StringText(hadolint.failure_threshold) %}
 
-ignored: << config(hadolint.ignored_yaml) >>
+ignored: {% StringText(hadolint.ignored_yaml) %}
 
 override:
-  error: << config(hadolint.override.error_yaml) >>
-  warning: << config(hadolint.override.warning_yaml) >>
+  error: {% StringText(hadolint.override.error_yaml) %}
+  warning: {% StringText(hadolint.override.warning_yaml) %}

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -19,7 +19,7 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('hadolint.yml', 'failure-threshold: << StringText(hadolint.failure_threshold) >>'),
+                new TextFile('hadolint.yml', 'failure-threshold: {% StringText(hadolint.failure_threshold) %}'),
                 new DefaultSettings(),
             ),
             new HasFileContents('failure-threshold: error'),
@@ -32,7 +32,7 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('phpstan.neon', 'level: << IntText(phpstan.level) >>'),
+                new TextFile('phpstan.neon', 'level: {% IntText(phpstan.level) %}'),
                 new DefaultSettings(),
             ),
             new HasFileContents('level: 9'),
@@ -51,7 +51,7 @@ final class TemplateFileTest extends TestCase
 
         self::assertThat(
             new TemplateFile(
-                new TextFile('matrix.yml', 'php: [<< ListText(php.versions)|Joined(", ") >>]'),
+                new TextFile('matrix.yml', 'php: [{% ListText(php.versions)|Joined(", ") %}]'),
                 $settings,
             ),
             new HasFileContents(sprintf('php: [%s]', implode(', ', $versions))),
@@ -70,7 +70,7 @@ final class TemplateFileTest extends TestCase
 
         self::assertThat(
             new TemplateFile(
-                new TextFile('docker.yml', 'image: << ListText(php.versions)|EachFormatted("%s-alpine")|Joined(" ") >>'),
+                new TextFile('docker.yml', 'image: {% ListText(php.versions)|EachFormatted("%s-alpine")|Joined(" ") %}'),
                 $settings,
             ),
             new HasFileContents(sprintf('image: %s', implode(' ', $versions))),
@@ -83,7 +83,7 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('codecov.yml', 'cloud: << BoolText(codecov.cloud) >>'),
+                new TextFile('codecov.yml', 'cloud: {% BoolText(codecov.cloud) %}'),
                 new DefaultSettings(),
             ),
             new HasFileContents('cloud: true'),

--- a/tests/Unit/File/TemplateFileTest.php
+++ b/tests/Unit/File/TemplateFileTest.php
@@ -23,7 +23,7 @@ final class TemplateFileTest extends TestCase
             new TemplateFile(
                 new TextFile(
                     'phpstan.neon',
-                    'paths: << ListText(phpstan.paths)|EachFormatted("- %s")|Joined("\n") >>',
+                    'paths: {% ListText(phpstan.paths)|EachFormatted("- %s")|Joined("\n") %}',
                 ),
                 new FakeSettings([
                     'phpstan.paths' => new ListValue([
@@ -68,7 +68,7 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('broken.neon', '<< MissingFormula(phpstan.paths) >>'),
+                new TextFile('broken.neon', '{% MissingFormula(phpstan.paths) %}'),
                 new FakeSettings([]),
             ),
             new HasFormulaError(
@@ -84,7 +84,7 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('missing.neon', '<< StringText(app.name) >>'),
+                new TextFile('missing.neon', '{% StringText(app.name) %}'),
                 new FakeSettings([]),
             ),
             new HasFormulaError(
@@ -100,7 +100,7 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('typed.neon', '<< StringText(phpstan.paths) >>'),
+                new TextFile('typed.neon', '{% StringText(phpstan.paths) %}'),
                 new FakeSettings([
                     'phpstan.paths' => new ListValue([
                         new StringValue('src'),


### PR DESCRIPTION
- Switched Chain placeholder marker from << >> to {% %} so legacy DSL keeps its own syntax
- Updated sheriff-sync to render templates through TemplateFile on top of ConfiguredFile
- Migrated hadolint template to Chain to prove the dual-render path generates identical output

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated template placeholder syntax from `<< >>` to `{% %}` delimiters for template rendering.
  * Enhanced integration of configuration settings with managed template files for improved configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->