### PR TITLE
Migrate Shellcheck Template to Chain

### DIFF
--- a/templates/always/.sheriff/shellcheck/.shellcheckrc
+++ b/templates/always/.sheriff/shellcheck/.shellcheckrc
@@ -3,16 +3,16 @@
 # ============================================================
 
 # Target shell (bash, sh, dash, ksh)
-shell=<< config(shellcheck.shell) >>
+shell={% StringText(shellcheck.shell) %}
 
 # Minimum severity: error, warning, info, style
-severity=<< config(shellcheck.severity) >>
+severity={% StringText(shellcheck.severity) %}
 
 # Allow sourcing external files
-external-sources=<< config(shellcheck.external_sources) >>
+external-sources={% BoolText(shellcheck.external_sources) %}
 
 # Additional include path for sourced files (optional)
-# source-path=<< config(shellcheck.source_path) >>
+# source-path={% StringText(shellcheck.source_path) %}
 
 # Excluded rules (one per line)
-<< config(shellcheck.exclude)|join("\n") >>
+{% ListText(shellcheck.exclude)|Joined("\n") %}


### PR DESCRIPTION
- Migrated .shellcheckrc placeholders from legacy DSL to Chain markers

Part of #653