### PR TITLE
Migrate Typos Template to Chain With Inline Derive

### DIFF
--- a/templates/always/.sheriff/typos/_typos.toml
+++ b/templates/always/.sheriff/typos/_typos.toml
@@ -6,5 +6,5 @@ binary = false
 
 [files]
 extend-exclude = [
-<< config(typos.exclude)|format_each('    "%s",')|join("\n") >>
+{% ListText(infra.exclude)|EachFormatted("%s/")|EachFormatted('    "%s",')|Joined("\n") %}
 ]


### PR DESCRIPTION
- Migrated typos exclude placeholder from legacy DSL to Chain markers
- Inlined the trailing-slash derive directly in the pipeline so DefaultSettings stays static

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined configuration system for typo detection to improve how file exclusion patterns are generated and managed during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->