### PR TITLE
Migrate Markdownlint Template to Chain With Inline Derive

### DIFF
--- a/templates/always/.sheriff/markdownlint/.markdownlint-cli2.jsonc
+++ b/templates/always/.sheriff/markdownlint/.markdownlint-cli2.jsonc
@@ -11,6 +11,6 @@
 
   // Ignore dependency/vendor directories to avoid linting third-party content.
   "ignores": [
-<< config(markdownlint.ignores)|format_each('    "%s"')|join(",\n") >>
+{% ListText(infra.exclude)|EachFormatted("%s/**")|EachFormatted('    "%s"')|Joined(",\n") %}
   ]
 }


### PR DESCRIPTION
- Migrated markdownlint ignores placeholder from legacy DSL to Chain markers
- Inlined the trailing-glob derive directly in the pipeline so DefaultSettings stays static

Part of #653