### PR TITLE
Migrate Yamllint Template to Chain With Inline Derive

### DIFF
--- a/templates/always/.sheriff/yamllint/.yamllint.yml
+++ b/templates/always/.sheriff/yamllint/.yamllint.yml
@@ -1,7 +1,9 @@
 extends: default
 
 ignore: |
-<< config(yamllint.ignore)|format_each("  %s")|join("\n") >>
+{% ListText(infra.exclude)|EachFormatted("%s/**")|EachFormatted("  %s")|Joined("\n") %}
+  .sheriff/**/html/**
+  .sheriff/**/coverage-report/**
 
 rules:
   document-start: disable
@@ -13,5 +15,5 @@ rules:
   # line-length max is configurable via yamllint.line_length.max; longer limits are common
   # in CI workflows where commands cannot be easily split across lines
   line-length:
-    max: << config(yamllint.line_length.max)|join("") >>
+    max: {% IntText(yamllint.line_length.max) %}
     level: warning


### PR DESCRIPTION
- Migrated yamllint placeholders from legacy DSL to Chain markers
- Inlined the trailing-glob derive and literal coverage paths directly in the template

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal configuration template generation for improved code maintainability and pattern handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->