### PR TITLE
Migrate Jsonlint Template to Chain With Derived Excludes

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -49,7 +49,7 @@ defaults:
   jsonlint.continue: true
   jsonlint.duplicate_keys: false
   jsonlint.mode: ["json5"]
-  jsonlint.patterns: ["**/*.json", "**/*.json5", "**/*.jsonc", "!vendor/**", "!tests/**", "!.git/**"]
+  jsonlint.patterns: ["**/*.json", "**/*.json5", "**/*.jsonc"]
 
   markdownlint.cli: true
   markdownlint.ignores: ["vendor/**", "tests/**", ".git/**"]

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Config;
 
-use Haspadar\Sheriff\Config\Dirs\NegatedGlobDirs;
 use Haspadar\Sheriff\Config\Dirs\ProjectDirs;
 use Haspadar\Sheriff\Config\Dirs\TrailingGlobDirs;
 use Haspadar\Sheriff\Config\Dirs\TrailingSlashDirs;
@@ -150,10 +149,7 @@ final readonly class DefaultConfig implements Config
             'php.src' => $sources,
             'infra.exclude' => $excludes,
             'hadolint.ignore' => $excludes,
-            'jsonlint.patterns' => array_merge(
-                ['**/*.json', '**/*.json5', '**/*.jsonc'],
-                (new NegatedGlobDirs($excludes))->toList(),
-            ),
+            'jsonlint.patterns' => ['**/*.json', '**/*.json5', '**/*.jsonc'],
             'markdownlint.ignores' => (new TrailingGlobDirs($excludes))->toList(),
             'phpcs.files' => $projectIncludes,
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -49,7 +49,7 @@ defaults:
   jsonlint.continue: true
   jsonlint.duplicate_keys: false
   jsonlint.mode: ["json5"]
-  jsonlint.patterns: ["**/*.json", "**/*.json5", "**/*.jsonc", "!vendor/**", "!tests/**", "!.git/**"]
+  jsonlint.patterns: ["**/*.json", "**/*.json5", "**/*.jsonc"]
 
   markdownlint.cli: true
   markdownlint.ignores: ["vendor/**", "tests/**", ".git/**"]

--- a/templates/always/.sheriff/jsonlint/config.json
+++ b/templates/always/.sheriff/jsonlint/config.json
@@ -1,11 +1,10 @@
 {
-  "mode": << config(jsonlint.mode)|format_each('"%s"')|join("") >>,
-  "compact": << config(jsonlint.compact) >>,
-  "continue": << config(jsonlint.continue) >>,
-  "duplicate-keys": << config(jsonlint.duplicate_keys) >>,
+  "mode": {% ListText(jsonlint.mode)|EachFormatted('"%s"')|Joined("") %},
+  "compact": {% BoolText(jsonlint.compact) %},
+  "continue": {% BoolText(jsonlint.continue) %},
+  "duplicate-keys": {% BoolText(jsonlint.duplicate_keys) %},
   "patterns": [
-<< config(jsonlint.patterns)
-   |format_each('    "%s"')
-   |join(",\n") >>
+{% ListText(jsonlint.patterns)|EachFormatted('    "%s"')|Joined(",\n") %},
+{% ListText(infra.exclude)|EachFormatted("!%s/**")|EachFormatted('    "%s"')|Joined(",\n") %}
   ]
 }


### PR DESCRIPTION
- Migrated jsonlint config template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed duplicated negated globs from `jsonlint.patterns` so excludes derive from `infra.exclude`
- Updated bundled `.sheriff/config.yaml` to match new defaults

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened JSON linting scope by removing directory exclusions so more JSON-like files are checked.
  * Updated JSON linting configuration templating syntax.
  * Added a new infra-driven exclusion mechanism to allow configurable excludes alongside the simplified include patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->