### PR TITLE
Migrate Infection Template to Chain With Derived Source Dirs

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -6,8 +6,8 @@ override:
   ci.sheriff_bin: bin/sheriff
   sonar.organization: haspadar-org
   sonar.projectKey: haspadar_sheriff
-  infection.min_msi: 80
-  infection.min_covered_msi: 90
+  infection.min_msi: 80.0
+  infection.min_covered_msi: 90.0
   coverage.project.target: 85
   coverage.project.threshold: 1
   coverage.patch.target: 85

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -123,7 +123,6 @@ defaults:
   infection.min_msi: 50
   infection.min_covered_msi: 80
   infection.php_options: "-d memory_limit=1G"
-  infection.source.directories: ["../../src"]
   infection.timeout: 30
 
   shellcheck.cli: true

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -120,8 +120,8 @@ defaults:
   psalm.suppress.possibly_unused: []
 
   infection.cli: true
-  infection.min_msi: 50
-  infection.min_covered_msi: 80
+  infection.min_msi: 50.0
+  infection.min_covered_msi: 80.0
   infection.php_options: "-d memory_limit=1G"
   infection.timeout: 30
 

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -123,7 +123,6 @@ defaults:
   infection.min_msi: 50
   infection.min_covered_msi: 80
   infection.php_options: "-d memory_limit=1G"
-  infection.source.directories: ["../../src"]
   infection.timeout: 30
 
   shellcheck.cli: true

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -120,8 +120,8 @@ defaults:
   psalm.suppress.possibly_unused: []
 
   infection.cli: true
-  infection.min_msi: 50
-  infection.min_covered_msi: 80
+  infection.min_msi: 50.0
+  infection.min_covered_msi: 80.0
   infection.php_options: "-d memory_limit=1G"
   infection.timeout: 30
 

--- a/templates/always/.sheriff/infection/infection.json5
+++ b/templates/always/.sheriff/infection/infection.json5
@@ -15,8 +15,8 @@
 
   "initialTestsPhpOptions": "{% StringText(infection.php_options) %}",
   "timeout": {% IntText(infection.timeout) %},
-  "minMsi": {% IntText(infection.min_msi) %},
-  "minCoveredMsi": {% IntText(infection.min_covered_msi) %},
+  "minMsi": {% FloatText(infection.min_msi) %},
+  "minCoveredMsi": {% FloatText(infection.min_covered_msi) %},
   "logs": {
     "text": "infection.log",
     "summary": "infection-summary.log",

--- a/templates/always/.sheriff/infection/infection.json5
+++ b/templates/always/.sheriff/infection/infection.json5
@@ -3,10 +3,7 @@
 
   "source": {
     "directories": [
-<< config(infection.source.directories)
-    |format_each('        "%s"')
-    |join(",")
->>
+{% ListText(php.src)|EachFormatted("../../%s")|EachFormatted('        "%s"')|Joined(",") %}
     ]
   },
 
@@ -16,10 +13,10 @@
     "configDir": "../phpunit"
   },
 
-  "initialTestsPhpOptions": "<< config(infection.php_options)|join(' ') >>",
-  "timeout": << config(infection.timeout) >>,
-  "minMsi": << config(infection.min_msi) >>,
-  "minCoveredMsi": << config(infection.min_covered_msi) >>,
+  "initialTestsPhpOptions": "{% StringText(infection.php_options) %}",
+  "timeout": {% IntText(infection.timeout) %},
+  "minMsi": {% IntText(infection.min_msi) %},
+  "minCoveredMsi": {% IntText(infection.min_covered_msi) %},
   "logs": {
     "text": "infection.log",
     "summary": "infection-summary.log",


### PR DESCRIPTION
- Migrated infection.json5 template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `infection.source.directories` from defaults so the path derives from `php.src` via `EachFormatted("../../%s")`
- Updated bundled `.sheriff/config.yaml` to match new defaults

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mutation testing configuration defaults with new thresholds for minimum MSI and covered MSI metrics.
  * Refined configuration template generation to improve how source directories and PHP test options are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->