### PR TITLE
Migrate Phpcs Template to Chain With Derived Files and Excludes

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -61,9 +61,7 @@ defaults:
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
-  phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
   phpcs.extend: ""
-  phpcs.files: ["../../src"]
   phpcs.root_namespace: ""
 
   phpmd.cli: true

--- a/.sheriff/phpcs/phpcs.xml
+++ b/.sheriff/phpcs/phpcs.xml
@@ -7,6 +7,7 @@
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>tests/*</exclude-pattern>
     <exclude-pattern>.git/*</exclude-pattern>
+    <exclude-pattern>templates/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -151,7 +151,6 @@ final readonly class DefaultConfig implements Config
             'hadolint.ignore' => $excludes,
             'jsonlint.patterns' => ['**/*.json', '**/*.json5', '**/*.jsonc'],
             'markdownlint.ignores' => (new TrailingGlobDirs($excludes))->toList(),
-            'phpcs.files' => $projectIncludes,
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
             'phpmd.paths' => $sources,
             'phpmetrics.includes' => $projectIncludes,

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -61,9 +61,7 @@ defaults:
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
-  phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
   phpcs.extend: ""
-  phpcs.files: ["../../src"]
   phpcs.root_namespace: ""
 
   phpmd.cli: true

--- a/templates/always/.sheriff/phpcs/phpcs.xml
+++ b/templates/always/.sheriff/phpcs/phpcs.xml
@@ -2,13 +2,9 @@
 <ruleset name="Sheriff PHPCS Rules">
     <description>Structural and semantic PHP rules</description>
 
-<< config(phpcs.files)
-    |format_each("    <file>%s</file>")
-    |join("\n") >>
+{% ListText(php.src)|EachFormatted("../../%s")|EachFormatted("    <file>%s</file>")|Joined("\n") %}
 
-<< config(phpcs.excludes)
-    |format_each("    <exclude-pattern>%s</exclude-pattern>")
-    |join("\n") >>
+{% ListText(infra.exclude)|EachFormatted("%s/*")|EachFormatted("    <exclude-pattern>%s</exclude-pattern>")|Joined("\n") %}
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
@@ -22,5 +18,5 @@
     <rule ref=".sheriff/phpcs/slevomat-flow.xml"/>
     <rule ref=".sheriff/phpcs/slevomat-style.xml"/>
 
-<< config(phpcs.extend)|join("") >>
+{% StringText(phpcs.extend) %}
 </ruleset>


### PR DESCRIPTION
- Migrated phpcs.xml template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `phpcs.files` and `phpcs.excludes` from defaults so they derive from `php.src` and `infra.exclude`
- Updated `DefaultConfig::dynamic()` to drop the now-redundant `phpcs.files` derivation
- Updated bundled `.sheriff/config.yaml` to match new defaults

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified PHP CodeSniffer configuration structure by removing phpcs.excludes and phpcs.files parameters.
  * Added template exclude-pattern for improved file filtering.
  * Introduced new dynamic defaults for hadolint, jsonlint, and markdownlint configuration.
  * Updated template system to use dynamic pattern generation instead of static configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->