### PR TITLE
Migrate Phpstan Template to Chain With Derived Paths

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -100,7 +100,6 @@ defaults:
   phpstan.cli: true
   phpstan.level: 9
   phpstan.memory: "1G"
-  phpstan.paths: ["../../src"]
   phpstan.checked_exceptions: ['\Throwable']
   phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
   phpstan.afferent_coupling.ignore_interfaces: true

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -155,7 +155,6 @@ final readonly class DefaultConfig implements Config
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
             'phpmd.paths' => $sources,
             'phpmetrics.includes' => $projectIncludes,
-            'phpstan.paths' => $projectIncludes,
             'phpunit.source.include' => $projectIncludes,
             'psalm.project.directories' => $projectIncludes,
             'infection.source.directories' => $projectIncludes,

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -100,7 +100,6 @@ defaults:
   phpstan.cli: true
   phpstan.level: 9
   phpstan.memory: "1G"
-  phpstan.paths: ["../../src"]
   phpstan.checked_exceptions: ['\Throwable']
   phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
   phpstan.afferent_coupling.ignore_interfaces: true

--- a/templates/always/.sheriff/phpstan/phpstan.neon
+++ b/templates/always/.sheriff/phpstan/phpstan.neon
@@ -1,11 +1,11 @@
 includes:
-<< config(phpstan.neon_includes)|format_each("    - %s")|join("\n") >>
+{% ListText(phpstan.neon_includes)|EachFormatted("    - %s")|Joined("\n") %}
 
 parameters:
-    level: << config(phpstan.level)|join("") >>
+    level: {% IntText(phpstan.level) %}
 
     paths:
-<< config(phpstan.paths)|format_each("        - %s")|join("\n") >>
+{% ListText(php.src)|EachFormatted("../../%s")|EachFormatted("        - %s")|Joined("\n") %}
 
     errorFormat: table
     reportUnmatchedIgnoredErrors: true
@@ -16,9 +16,9 @@ parameters:
 
     exceptions:
         checkedExceptionClasses:
-<< config(phpstan.checked_exceptions)|format_each("            - %s")|join("\n") >>
+{% ListText(phpstan.checked_exceptions)|EachFormatted("            - %s")|Joined("\n") %}
 
     haspadar:
         afferentCoupling:
-            ignoreInterfaces: << config(phpstan.afferent_coupling.ignore_interfaces)|join("") >>
-<< config(phpstan.afferent_coupling.excluded_classes)|format_each("                - %s")|join("\n")|if_not_empty()|format("            excludedClasses:\n%s") >>
+            ignoreInterfaces: {% BoolText(phpstan.afferent_coupling.ignore_interfaces) %}
+{% ListText(phpstan.afferent_coupling.excluded_classes)|EachFormatted("                - %s")|Joined("\n")|WhenNotEmpty("            excludedClasses:\n%s") %}


### PR DESCRIPTION
- Migrated phpstan.neon template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `phpstan.paths` from defaults so the path derives from `php.src` via `EachFormatted("../../%s")`
- Removed `phpstan.paths` derivation from `DefaultConfig::dynamic()`
- Replaced legacy `if_not_empty()|format(...)` with `WhenNotEmpty` op for the optional `excludedClasses` block

Part of #653