### PR TITLE
Migrate Phpunit Template to Chain With Derived Source Paths

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -105,7 +105,6 @@ defaults:
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
-  phpunit.source.include: ["../../src"]
   phpunit.testsuites.unit: ["../../tests/Unit"]
   phpunit.testsuites.integration: ["../../tests/Integration"]
 

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -154,7 +154,6 @@ final readonly class DefaultConfig implements Config
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
             'phpmd.paths' => $sources,
             'phpmetrics.includes' => $projectIncludes,
-            'phpunit.source.include' => $projectIncludes,
             'infection.source.directories' => $projectIncludes,
             'shellcheck.ignore_dirs' => $excludes,
             'sonar.sources' => $sources,

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -105,7 +105,6 @@ defaults:
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
-  phpunit.source.include: ["../../src"]
   phpunit.testsuites.unit: ["../../tests/Unit"]
   phpunit.testsuites.integration: ["../../tests/Integration"]
 

--- a/templates/always/.sheriff/phpunit/phpunit.xml
+++ b/templates/always/.sheriff/phpunit/phpunit.xml
@@ -11,17 +11,17 @@
 >
     <testsuites>
         <testsuite name="unit">
-<< config(phpunit.testsuites.unit)|format_each("            <directory suffix="Test.php">%s</directory>")|join("\n") >>
+{% ListText(phpunit.testsuites.unit)|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
         </testsuite>
 
         <testsuite name="integration">
-<< config(phpunit.testsuites.integration)|format_each("            <directory suffix="Test.php">%s</directory>")|join("\n") >>
+{% ListText(phpunit.testsuites.integration)|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
         </testsuite>
     </testsuites>
 
     <source>
         <include>
-<< config(phpunit.source.include)|format_each("            <directory suffix=".php">%s</directory>")|join("\n") >>
+{% ListText(php.src)|EachFormatted("../../%s")|EachFormatted('            <directory suffix=".php">%s</directory>')|Joined("\n") %}
         </include>
     </source>
 </phpunit>


### PR DESCRIPTION
- Migrated phpunit.xml template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `phpunit.source.include` from defaults so it derives from `php.src` via `EachFormatted("../../%s")`
- Removed the corresponding entry from `DefaultConfig::dynamic()`

Part of #653