### PR TITLE
Migrate Phpmetrics Template to Chain With Derived Includes and Excludes

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -76,8 +76,6 @@ defaults:
   phpmd.npath: 200
 
   phpmetrics.cli: true
-  phpmetrics.includes: ["../../src"]
-  phpmetrics.excludes: ["vendor", "tests", ".git"]
   phpmetrics.extensions: ["php"]
   phpmetrics.complexity.max_cyclomatic_per_method: 10
   phpmetrics.complexity.max_weighted_methods_per_class: 20

--- a/.sheriff/phpmetrics/config.json
+++ b/.sheriff/phpmetrics/config.json
@@ -6,7 +6,8 @@
   "excludes": [
     "vendor",
     "tests",
-    ".git"
+    ".git",
+    "templates"
   ],
   "extensions": [
     "php"

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -153,7 +153,6 @@ final readonly class DefaultConfig implements Config
             'markdownlint.ignores' => (new TrailingGlobDirs($excludes))->toList(),
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
             'phpmd.paths' => $sources,
-            'phpmetrics.includes' => $projectIncludes,
             'phpunit.source.include' => $projectIncludes,
             'infection.source.directories' => $projectIncludes,
             'shellcheck.ignore_dirs' => $excludes,

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -76,8 +76,6 @@ defaults:
   phpmd.npath: 200
 
   phpmetrics.cli: true
-  phpmetrics.includes: ["../../src"]
-  phpmetrics.excludes: ["vendor", "tests", ".git"]
   phpmetrics.extensions: ["php"]
   phpmetrics.complexity.max_cyclomatic_per_method: 10
   phpmetrics.complexity.max_weighted_methods_per_class: 20

--- a/templates/always/.sheriff/phpmetrics/config.json
+++ b/templates/always/.sheriff/phpmetrics/config.json
@@ -1,25 +1,16 @@
 {
   "composer": false,
   "includes": [
-<< config(phpmetrics.includes)
-|format_each('    "%s"')
-|join(",\n")
->>
+{% ListText(php.src)|EachFormatted("../../%s")|EachFormatted('    "%s"')|Joined(",\n") %}
   ],
   "excludes": [
-<< config(phpmetrics.excludes)
-|format_each('    "%s"')
-|join(",\n")
->>
+{% ListText(infra.exclude)|EachFormatted('    "%s"')|Joined(",\n") %}
   ],
   "extensions": [
-<< config(phpmetrics.extensions)
-|format_each('    "%s"')
-|join(",\n")
->>
+{% ListText(phpmetrics.extensions)|EachFormatted('    "%s"')|Joined(",\n") %}
   ],
   "report": {
-    "html": "<< config(phpmetrics.report.html)|join("") >>",
-    "json": "<< config(phpmetrics.report.json)|join("") >>"
+    "html": "{% ListText(phpmetrics.report.html)|Joined("") %}",
+    "json": "{% ListText(phpmetrics.report.json)|Joined("") %}"
   }
 }

--- a/tests/Unit/Formula/Action/ConfigActionTest.php
+++ b/tests/Unit/Formula/Action/ConfigActionTest.php
@@ -21,9 +21,9 @@ final class ConfigActionTest extends TestCase
             (new ConfigAction(
                 new OverrideConfig(
                     new DefaultConfig(),
-                    ['phpmetrics.includes' => ['mbstring', 'intl']],
+                    ['phpmetrics.extensions' => ['mbstring', 'intl']],
                 ),
-                'phpmetrics.includes',
+                'phpmetrics.extensions',
             ))->transformed(new ListArgs([])),
             new HasArgsValues(['mbstring', 'intl']),
             'ConfigAction must return list values from the config for the given key',


### PR DESCRIPTION
- Migrated phpmetrics config.json template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `phpmetrics.includes` and `phpmetrics.excludes` from defaults so they derive from `php.src` and `infra.exclude`
- Removed `phpmetrics.includes` derivation from `DefaultConfig::dynamic()`
- Updated ConfigActionTest fixture to use `phpmetrics.extensions` instead of the removed `phpmetrics.includes`

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHPMetrics exclusion configuration rules.
  * Added PHP Mess Detector configuration settings.
  * Refined configuration template system structure.

* **Tests**
  * Updated test configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->