### PR TITLE
Migrate Sonar Template to Chain With Derived Sources Path

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -129,9 +129,8 @@ defaults:
 
   sonar.cloud: true
   sonar.cli: false
-  sonar.organization: []
-  sonar.projectKey: []
-  sonar.sources: ["src"]
+  sonar.organization: ""
+  sonar.projectKey: ""
   sonar.tests: ["tests"]
   sonar.exclusions: []
   sonar.php.coverage.reportPaths: [".sheriff/codecov/coverage.xml"]

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -156,7 +156,6 @@ final readonly class DefaultConfig implements Config
             'phpunit.source.include' => $projectIncludes,
             'infection.source.directories' => $projectIncludes,
             'shellcheck.ignore_dirs' => $excludes,
-            'sonar.sources' => $sources,
             'typos.exclude' => (new TrailingSlashDirs($excludes))->toList(),
             'yamllint.ignore' => array_merge(
                 (new TrailingGlobDirs($excludes))->toList(),

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -129,9 +129,8 @@ defaults:
 
   sonar.cloud: true
   sonar.cli: false
-  sonar.organization: []
-  sonar.projectKey: []
-  sonar.sources: ["src"]
+  sonar.organization: ""
+  sonar.projectKey: ""
   sonar.tests: ["tests"]
   sonar.exclusions: []
   sonar.php.coverage.reportPaths: [".sheriff/codecov/coverage.xml"]

--- a/templates/always/.sheriff/sonar/sonar-project.properties
+++ b/templates/always/.sheriff/sonar/sonar-project.properties
@@ -1,6 +1,6 @@
-sonar.organization=<< config(sonar.organization)|join(",") >>
-sonar.projectKey=<< config(sonar.projectKey)|join(",") >>
-sonar.sources=<< config(sonar.sources)|join(",") >>
-sonar.tests=<< config(sonar.tests)|join(",") >>
-sonar.exclusions=<< config(sonar.exclusions)|join(",") >>
-sonar.php.coverage.reportPaths=<< config(sonar.php.coverage.reportPaths)|join(",") >>
+sonar.organization={% StringText(sonar.organization) %}
+sonar.projectKey={% StringText(sonar.projectKey) %}
+sonar.sources={% ListText(php.src)|Joined(",") %}
+sonar.tests={% ListText(sonar.tests)|Joined(",") %}
+sonar.exclusions={% ListText(sonar.exclusions)|Joined(",") %}
+sonar.php.coverage.reportPaths={% ListText(sonar.php.coverage.reportPaths)|Joined(",") %}


### PR DESCRIPTION
- Migrated sonar-project.properties template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `sonar.sources` from defaults so it derives from `php.src` via `ListText|Joined(",")`
- Removed the corresponding entry from `DefaultConfig::dynamic()`
- Tightened `sonar.organization` and `sonar.projectKey` defaults to empty strings to match their scalar usage

Part of #653