### PR TITLE
Migrate Shellcheck Command to Chain With Derived Ignore Dirs

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -122,7 +122,6 @@ defaults:
   shellcheck.cli: true
   shellcheck.exclude: []
   shellcheck.external_sources: true
-  shellcheck.ignore_dirs: ["vendor", "tests", ".git"]
   shellcheck.severity: "warning"
   shellcheck.shell: "bash"
   shellcheck.source_path: "."

--- a/DEV.md
+++ b/DEV.md
@@ -541,7 +541,6 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `shellcheck.cli` | `true` | Enable ShellCheck |
 | `shellcheck.exclude` | `[]` | Excluded rule codes |
 | `shellcheck.external_sources` | `true` | Follow sourced files |
-| `shellcheck.ignore_dirs` | `["vendor", "tests", ".git"]` | Ignored directories |
 | `shellcheck.severity` | `"warning"` | Minimum severity |
 | `shellcheck.shell` | `"bash"` | Shell dialect |
 | `shellcheck.source_path` | `"."` | Source path for includes |
@@ -552,9 +551,8 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 |-----|---------|-------------|
 | `sonar.cloud` | `true` | Use SonarCloud automatic analysis (skip local scanner and SONAR_TOKEN) |
 | `sonar.cli` | `false` | Enable local sonar-scanner |
-| `sonar.organization` | `[]` | SonarCloud organization |
-| `sonar.projectKey` | `[]` | SonarCloud project key |
-| `sonar.sources` | `["src"]` | Source directories |
+| `sonar.organization` | `""` | SonarCloud organization |
+| `sonar.projectKey` | `""` | SonarCloud project key |
 | `sonar.tests` | `["tests"]` | Test directories |
 | `sonar.exclusions` | `[]` | Excluded paths |
 | `sonar.php.coverage.reportPaths` | `[".sheriff/codecov/coverage.xml"]` | Coverage report path |

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -155,7 +155,6 @@ final readonly class DefaultConfig implements Config
             'phpmd.paths' => $sources,
             'phpunit.source.include' => $projectIncludes,
             'infection.source.directories' => $projectIncludes,
-            'shellcheck.ignore_dirs' => $excludes,
             'sonar.sources' => $sources,
             'typos.exclude' => (new TrailingSlashDirs($excludes))->toList(),
             'yamllint.ignore' => array_merge(

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -122,7 +122,6 @@ defaults:
   shellcheck.cli: true
   shellcheck.exclude: []
   shellcheck.external_sources: true
-  shellcheck.ignore_dirs: ["vendor", "tests", ".git"]
   shellcheck.severity: "warning"
   shellcheck.shell: "bash"
   shellcheck.source_path: "."

--- a/templates/always/.sheriff/shellcheck/command.sh
+++ b/templates/always/.sheriff/shellcheck/command.sh
@@ -22,10 +22,7 @@ while IFS= read -r -d '' file; do
 done < <(
   find . \
     -type f \
-<< config(shellcheck.ignore_dirs)
-   |format_each('    ! -path "./%s/*" \')
-   |join("\n")
->>
+{% ListText(infra.exclude)|EachFormatted('    ! -path "./%s/*" \\')|Joined("\n") %}
     -print0
 )
 

--- a/tests/Integration/Config/ConfigYamlTemplateTest.php
+++ b/tests/Integration/Config/ConfigYamlTemplateTest.php
@@ -82,8 +82,8 @@ final class ConfigYamlTemplateTest extends TestCase
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.sheriff.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('shellcheck.ignore_dirs', ['dist']),
-                'Override infra.exclude must cascade to shellcheck.ignore_dirs',
+                new HasConfigYamlKey('markdownlint.ignores', ['dist/**']),
+                'Override infra.exclude must cascade to markdownlint.ignores',
             );
         } finally {
             $folder->close();
@@ -101,8 +101,8 @@ final class ConfigYamlTemplateTest extends TestCase
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.sheriff.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('shellcheck.ignore_dirs', ['vendor', 'tests', '.git', 'dist']),
-                'Append infra.exclude must cascade to shellcheck.ignore_dirs',
+                new HasConfigYamlKey('markdownlint.ignores', ['vendor/**', 'tests/**', '.git/**', 'dist/**']),
+                'Append infra.exclude must cascade to markdownlint.ignores',
             );
         } finally {
             $folder->close();


### PR DESCRIPTION
- Migrated shellcheck command.sh template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `shellcheck.ignore_dirs` from defaults so the find-prune list derives from `infra.exclude`
- Removed the corresponding entry from `DefaultConfig::dynamic()`
- Updated cascade tests to assert against `markdownlint.ignores` since shellcheck no longer exposes a derived key

Part of #653