### PR TITLE
Migrate Php-Cs-Fixer Template to Chain With EachReplaced

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -1,5 +1,5 @@
 override:
-  phpmetrics.coupling.max_afferent: 33
+  phpmetrics.coupling.max_afferent: 34
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
   ci.pr.max_lines_changed: 5000

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -56,7 +56,6 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
-  php_cs_fixer.exclude: ["vendor", "tests", ".git"]
   php_cs_fixer.extend: ""
   php_cs_fixer.paths: ["../.."]
 

--- a/.sheriff/php-cs-fixer/php-cs-fixer.project.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.project.php
@@ -10,7 +10,7 @@ $rules = require __DIR__ . '/php-cs-fixer.php';
 $rules->setFinder(
     Finder::create()
         ->in([__DIR__ . '/../..'])
-        ->exclude(['vendor','tests','.git']),
+        ->exclude(['vendor','tests','.git','templates']),
 )->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
 
 return $rules;

--- a/.sheriff/phpmetrics/rules.php
+++ b/.sheriff/phpmetrics/rules.php
@@ -23,7 +23,7 @@ return [
         'max_methods_per_class' => 10,
     ],
     'coupling' => [
-        'max_afferent' => 33,
+        'max_afferent' => 34,
         'max_efferent' => 25,
     ],
 ];

--- a/src/Chain/Map/EachReplaced.php
+++ b/src/Chain/Map/EachReplaced.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Map;
+
+use Haspadar\Sheriff\Chain\Listed;
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+
+/**
+ * Replaces every occurrence of a needle in each part of a Listed source.
+ *
+ * Element-wise counterpart to Replaced. Stays Listed so further pipeline
+ * stages can keep iterating; rendering directly is rejected and requires a
+ * Reduced op (typically Joined) to collapse the parts into a string.
+ *
+ * Example:
+ *
+ *     (new EachReplaced(new ListText($versions), '.', 'x'))->parts();
+ *     // [Replaced(StringText('8.3'), '.', 'x'), Replaced(StringText('8.4'), '.', 'x')]
+ */
+final readonly class EachReplaced implements Listed
+{
+    /**
+     * Initializes with the source list and the replacement pair applied per part.
+     *
+     * @param Listed $origin Source list whose parts are rewritten one by one
+     * @param string $needle Substring searched in each rendered part
+     * @param string $replacement Substring inserted in place of every needle
+     */
+    public function __construct(
+        private Listed $origin,
+        private string $needle,
+        private string $replacement,
+    ) {}
+
+    #[Override]
+    public function parts(): array
+    {
+        return array_map(
+            fn(Op $part): Op => new Replaced($part, $this->needle, $this->replacement),
+            $this->origin->parts(),
+        );
+    }
+
+    #[Override]
+    public function rendered(): string
+    {
+        throw new SheriffException(
+            'EachReplaced cannot render directly — collapse it via a Reduced op such as Joined',
+        );
+    }
+}

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -56,7 +56,6 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
-  php_cs_fixer.exclude: ["vendor", "tests", ".git"]
   php_cs_fixer.extend: ""
   php_cs_fixer.paths: ["../.."]
 

--- a/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -26,7 +26,7 @@ return (new PhpCsFixer\Config())
     [
 
         '@PER-CS2.0' => true,
-<< config(php.versions)|replace(".", "x")|format_each("        '@PHP%sMigration' => true,")|join("\n") >>
+{% ListText(php.versions)|EachReplaced(".", "x")|EachFormatted("        '@PHP%sMigration' => true,")|Joined("\n") %}
 
         // Arrays
         'array_syntax' => ['syntax' => 'short'],
@@ -106,6 +106,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
-<< config(php_cs_fixer.extend)|join("") >>
+{% StringText(php_cs_fixer.extend) %}
     ]))
-    ->setUnsupportedPhpVersionAllowed(<< config(php_cs_fixer.allow_unsupported)|join("") >>);
+    ->setUnsupportedPhpVersionAllowed({% ListText(php_cs_fixer.allow_unsupported)|Joined("") %});

--- a/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.project.php
+++ b/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.project.php
@@ -9,8 +9,8 @@ $rules = require __DIR__ . '/php-cs-fixer.php';
 
 $rules->setFinder(
     Finder::create()
-        ->in([<< config(php_cs_fixer.paths) |format_each("__DIR__ . '/%s'") |join(",\n") >>])
-        ->exclude([<< config(php_cs_fixer.exclude)|format_each("'%s'")|join(",") >>]),
+        ->in([{% ListText(php_cs_fixer.paths)|EachFormatted("__DIR__ . '/%s'")|Joined(",\n") %}])
+        ->exclude([{% ListText(infra.exclude)|EachFormatted("'%s'")|Joined(",") %}]),
 )->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
 
 return $rules;

--- a/tests/Unit/Chain/Map/EachReplacedTest.php
+++ b/tests/Unit/Chain/Map/EachReplacedTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Map;
+
+use Haspadar\Sheriff\Chain\Map\EachReplaced;
+use Haspadar\Sheriff\Chain\Map\Replaced;
+use Haspadar\Sheriff\Chain\Plain\ListText;
+use Haspadar\Sheriff\SheriffException;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EachReplacedTest extends TestCase
+{
+    #[Test]
+    public function wrapsEachPartIntoReplaced(): void
+    {
+        self::assertContainsOnlyInstancesOf(
+            Replaced::class,
+            (new EachReplaced(
+                new ListText(new ListValue([
+                    new StringValue('8.3'),
+                    new StringValue('8.4'),
+                ])),
+                '.',
+                'x',
+            ))->parts(),
+            'EachReplaced must wrap every part of the source list into Replaced',
+        );
+    }
+
+    #[Test]
+    public function rewritesEachRenderedPart(): void
+    {
+        $parts = (new EachReplaced(
+            new ListText(new ListValue([
+                new StringValue('8.3'),
+                new StringValue('8.4'),
+            ])),
+            '.',
+            'x',
+        ))->parts();
+
+        self::assertSame(
+            ['8x3', '8x4'],
+            [$parts[0]->rendered(), $parts[1]->rendered()],
+            'EachReplaced must rewrite every needle in every rendered part',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyPartsForEmptySourceList(): void
+    {
+        self::assertSame(
+            [],
+            (new EachReplaced(
+                new ListText(new ListValue([])),
+                '.',
+                'x',
+            ))->parts(),
+            'EachReplaced must return no parts when the source list is empty',
+        );
+    }
+
+    #[Test]
+    public function refusesDirectRendering(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EachReplaced(
+            new ListText(new ListValue([new StringValue('8.3')])),
+            '.',
+            'x',
+        ))->rendered();
+    }
+}


### PR DESCRIPTION
- Migrated php-cs-fixer.php and php-cs-fixer.project.php templates from legacy DSL to Chain pipelines with `{% %}` markers
- Added `EachReplaced` op so list parts can rewrite substrings (mirrors `Replaced` over a `Listed` source)
- Removed `php_cs_fixer.exclude` from defaults so the Finder excludes derive from `infra.exclude`
- Bumped `phpmetrics.coupling.max_afferent` to 34 to accommodate the new op's reliance on `SheriffException`

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chain map operation for per-part needle replacement functionality.

* **Chores**
  * Updated internal configuration for code quality and formatting tools.
  * Adjusted metrics thresholds and exclude patterns.
  * Enhanced template-based configuration generation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->