### PR TITLE
Migrate Phpmd Command to Chain With Derived Source Paths

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -64,7 +64,6 @@ defaults:
   phpcs.root_namespace: ""
 
   phpmd.cli: true
-  phpmd.paths: ["src"]
   phpmd.class_complexity: 50
   phpmd.class_length: 200
   phpmd.cyclomatic: 10

--- a/.sheriff/phpmd/command.sh
+++ b/.sheriff/phpmd/command.sh
@@ -12,6 +12,6 @@ BIN="$(.sheriff/_composer.sh phpmd)"
 
 exec .sheriff/_skip_if_empty.sh src '*.php' PHPMD -- \
   "$BIN" \
-src \
+  src \
   text \
   "$CONFIG"

--- a/DEV.md
+++ b/DEV.md
@@ -455,7 +455,6 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | Key | Default | Description |
 |-----|---------|-------------|
 | `phpmd.cli` | `true` | Enable PHP Mess Detector |
-| `phpmd.paths` | `["src"]` | Source paths |
 | `phpmd.class_complexity` | `50` | Max class complexity |
 | `phpmd.class_length` | `200` | Max class length |
 | `phpmd.cyclomatic` | `10` | Max cyclomatic complexity |

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -152,7 +152,6 @@ final readonly class DefaultConfig implements Config
             'jsonlint.patterns' => ['**/*.json', '**/*.json5', '**/*.jsonc'],
             'markdownlint.ignores' => (new TrailingGlobDirs($excludes))->toList(),
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
-            'phpmd.paths' => $sources,
             'infection.source.directories' => $projectIncludes,
             'typos.exclude' => (new TrailingSlashDirs($excludes))->toList(),
             'yamllint.ignore' => array_merge(

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -64,7 +64,6 @@ defaults:
   phpcs.root_namespace: ""
 
   phpmd.cli: true
-  phpmd.paths: ["src"]
   phpmd.class_complexity: 50
   phpmd.class_length: 200
   phpmd.cyclomatic: 10

--- a/templates/always/.sheriff/phpmd/command.sh
+++ b/templates/always/.sheriff/phpmd/command.sh
@@ -12,8 +12,6 @@ BIN="$(.sheriff/_composer.sh phpmd)"
 
 exec .sheriff/_skip_if_empty.sh src '*.php' PHPMD -- \
   "$BIN" \
-<< config(phpmd.paths)
-   |join(" ")
->> \
+  {% ListText(php.src)|Joined(" ") %} \
   text \
   "$CONFIG"

--- a/templates/always/.sheriff/phpmd/command.sh
+++ b/templates/always/.sheriff/phpmd/command.sh
@@ -10,7 +10,7 @@ fi
 
 BIN="$(.sheriff/_composer.sh phpmd)"
 
-exec .sheriff/_skip_if_empty.sh src '*.php' PHPMD -- \
+exec .sheriff/_skip_if_empty.sh {% ListText(php.src)|First() %} '*.php' PHPMD -- \
   "$BIN" \
   {% ListText(php.src)|Joined(" ") %} \
   text \

--- a/tests/Integration/Config/ConfigYamlTemplateTest.php
+++ b/tests/Integration/Config/ConfigYamlTemplateTest.php
@@ -120,8 +120,8 @@ final class ConfigYamlTemplateTest extends TestCase
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.sheriff.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('phpmd.paths', ['lib']),
-                'Override php.src must cascade to phpmd.paths',
+                new HasConfigYamlKey('infection.source.directories', ['../../lib']),
+                'Override php.src must cascade to infection.source.directories',
             );
         } finally {
             $folder->close();
@@ -139,8 +139,8 @@ final class ConfigYamlTemplateTest extends TestCase
         try {
             self::assertThat(
                 new YamlConfig($folder->path() . '/.sheriff.yaml', new DefaultConfig()),
-                new HasConfigYamlKey('phpmd.paths', ['src', 'lib']),
-                'Append php.src must cascade to phpmd.paths',
+                new HasConfigYamlKey('infection.source.directories', ['../../src', '../../lib']),
+                'Append php.src must cascade to infection.source.directories',
             );
         } finally {
             $folder->close();
@@ -152,8 +152,8 @@ final class ConfigYamlTemplateTest extends TestCase
     {
         self::assertThat(
             new DefaultConfig(['lib', 'app']),
-            new HasConfigYamlKey('phpmd.paths', ['lib', 'app']),
-            'Custom include must cascade to phpmd.paths',
+            new HasConfigYamlKey('infection.source.directories', ['../../lib', '../../app']),
+            'Custom include must cascade to infection.source.directories',
         );
     }
 


### PR DESCRIPTION
- Migrated phpmd command.sh template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `phpmd.paths` from defaults so the source paths derive from `php.src`
- Removed the corresponding entry from `DefaultConfig::dynamic()`
- Switched cascade integration tests to assert against `infection.source.directories` (since phpmd no longer exposes a derived key)
- Dropped the obsolete `phpmd.paths` row from DEV docs

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified PHPMD configuration by removing path-specific defaults.
  * Added default support for jsonlint and markdownlint configuration.
  * Updated configuration cascading behavior for source directory specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->