### PR TITLE
Migrate Hadolint Command to Chain With Derived Ignore Dirs

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -38,7 +38,6 @@ defaults:
 
   hadolint.cli: true
   hadolint.failure_threshold: "error"
-  hadolint.ignore: ["vendor", "tests", ".git"]
   hadolint.ignored_yaml: "[]"
   hadolint.override.error_yaml: "[]"
   hadolint.override.warning_yaml: "[]"

--- a/DEV.md
+++ b/DEV.md
@@ -406,7 +406,6 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 |-----|---------|-------------|
 | `hadolint.cli` | `true` | Enable Dockerfile linting |
 | `hadolint.failure_threshold` | `"error"` | Minimum severity to fail |
-| `hadolint.ignore` | `["vendor", "tests", ".git"]` | Ignored directories |
 | `hadolint.ignored_yaml` | `"[]"` | Ignored rules (YAML literal) |
 | `hadolint.override.error_yaml` | `"[]"` | Rules promoted to error (YAML literal) |
 | `hadolint.override.warning_yaml` | `"[]"` | Rules promoted to warning (YAML literal) |

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -148,7 +148,6 @@ final readonly class DefaultConfig implements Config
         return [
             'php.src' => $sources,
             'infra.exclude' => $excludes,
-            'hadolint.ignore' => $excludes,
             'jsonlint.patterns' => ['**/*.json', '**/*.json5', '**/*.jsonc'],
             'markdownlint.ignores' => (new TrailingGlobDirs($excludes))->toList(),
             'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -38,7 +38,6 @@ defaults:
 
   hadolint.cli: true
   hadolint.failure_threshold: "error"
-  hadolint.ignore: ["vendor", "tests", ".git"]
   hadolint.ignored_yaml: "[]"
   hadolint.override.error_yaml: "[]"
   hadolint.override.warning_yaml: "[]"

--- a/templates/always/.sheriff/hadolint/command.sh
+++ b/templates/always/.sheriff/hadolint/command.sh
@@ -19,16 +19,10 @@ done < <(
   find . \
     -type f \
     \( \
-<< config(hadolint.patterns)
-   |format_each('      -name "%s" -o \')
-   |join("\n")
->>
+{% ListText(hadolint.patterns)|EachFormatted('      -name "%s" -o \\')|Joined("\n") %}
       -false \
     \) \
-<< config(hadolint.ignore)
-   |format_each('    ! -path "./%s/*" \')
-   |join("\n")
->>
+{% ListText(infra.exclude)|EachFormatted('    ! -path "./%s/*" \\')|Joined("\n") %}
     -print0
 )
 


### PR DESCRIPTION
- Migrated hadolint command.sh template from legacy DSL to Chain pipelines with `{% %}` markers
- Removed `hadolint.ignore` from defaults so the find-prune list derives from `infra.exclude`
- Removed the corresponding entry from `DefaultConfig::dynamic()`
- Dropped the obsolete `hadolint.ignore` row from DEV docs

Part of #653