### PR TITLE
Migrate Phpunit Command Php-Options to Chain

### DIFF
--- a/templates/always/.sheriff/phpunit/command.sh
+++ b/templates/always/.sheriff/phpunit/command.sh
@@ -30,7 +30,7 @@ if [ -n "$SEED" ]; then
   ARGS+=(--random-order-seed="$SEED")
 fi
 
-PHP_OPTIONS_STR="<< config(phpunit.php_options)|join(' ') >>"
+PHP_OPTIONS_STR="{% StringText(phpunit.php_options) %}"
 PHP_OPTIONS=()
 if [ -n "$PHP_OPTIONS_STR" ]; then
   read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"


### PR DESCRIPTION
- Migrated phpunit command.sh template from legacy DSL to Chain pipelines with `{% %}` markers
- Switched `phpunit.php_options` interpolation to `StringText`

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP configuration templating in the build system for improved template compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->