### PR TITLE
Migrate Phpstan Command to Chain With Derived Skip-Empty Guard

### DIFF
--- a/templates/always/.sheriff/phpstan/command.sh
+++ b/templates/always/.sheriff/phpstan/command.sh
@@ -10,7 +10,7 @@ fi
 
 BIN="$(.sheriff/_composer.sh phpstan)"
 
-exec .sheriff/_skip_if_empty.sh src '*.php' PHPStan -- \
+exec .sheriff/_skip_if_empty.sh {% ListText(php.src)|First() %} '*.php' PHPStan -- \
   "$BIN" analyse \
   -c "$CONFIG" \
-  --memory-limit=<< config(phpstan.memory) >>
+  --memory-limit={% StringText(phpstan.memory) %}


### PR DESCRIPTION
- Migrated phpstan command.sh template from legacy DSL to Chain pipelines with `{% %}` markers
- Switched `phpstan.memory` interpolation to `StringText`
- Aligned `_skip_if_empty.sh` guard with `php.src` via `ListText|First()` so the precheck follows the configured source paths

Part of #653