### PR TITLE
Migrate Docker Helper to Chain for docker.image

### DIFF
--- a/templates/always/.sheriff/_docker.sh
+++ b/templates/always/.sheriff/_docker.sh
@@ -7,7 +7,7 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 PROJECT_ROOT="$(pwd)"
-DEFAULT_IMAGE="<< config(docker.image) >>"
+DEFAULT_IMAGE="{% StringText(docker.image) %}"
 IMAGE="${SHERIFF_INFRA_IMAGE:-$DEFAULT_IMAGE}"
 
 docker run --rm \


### PR DESCRIPTION
- Migrated `templates/always/.sheriff/_docker.sh` from legacy DSL to Chain pipelines with `{% %}` markers
- Switched `docker.image` interpolation to `StringText`

Part of #653