### PR TITLE
Migrate Sheriff Workflow to Chain With EnvsText Source Op

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -1,5 +1,5 @@
 override:
-  phpmetrics.coupling.max_afferent: 34
+  phpmetrics.coupling.max_afferent: 35
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
   ci.pr.max_lines_changed: 5000

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -13,6 +13,7 @@ defaults:
   php.src: ["src"]
   infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
+  envs: {}
 
   check.full: false
   check.parallel: true

--- a/.sheriff/phpmetrics/rules.php
+++ b/.sheriff/phpmetrics/rules.php
@@ -23,7 +23,7 @@ return [
         'max_methods_per_class' => 10,
     ],
     'coupling' => [
-        'max_afferent' => 34,
+        'max_afferent' => 35,
         'max_efferent' => 25,
     ],
 ];

--- a/src/Chain/Parse/SourceFormula.php
+++ b/src/Chain/Parse/SourceFormula.php
@@ -10,15 +10,16 @@ use Haspadar\Sheriff\SheriffException;
 use Override;
 
 /**
- * Builds a pipeline source op from a settings key.
+ * Builds a pipeline source op from a settings key plus optional literals.
  *
- * Used for pipeline heads like `BoolText(phpstan.cli)` or
- * `NeonTree(phpstan.parameters)`. The single argument is treated as a dotted
- * settings key; the resolved Value is fed into the target class's
- * constructor. Type mismatches surface naturally as PHP TypeErrors,
- * making misconfigured templates fail loudly at render time. Works for any
- * Chain class whose constructor takes one Value, regardless of namespace
- * (Chain\Plain or Chain\Render\<Format>).
+ * Used for pipeline heads like `BoolText(phpstan.cli)`,
+ * `NeonTree(phpstan.parameters)`, or `EnvsText(envs, " ")`. The first
+ * argument is treated as a dotted settings key; the resolved Value is fed into
+ * the target class's constructor as the first ctor argument, followed by any
+ * remaining template arguments as literal strings. Type mismatches surface
+ * naturally as PHP TypeErrors, making misconfigured templates fail loudly at
+ * render time. Works for any Chain class whose constructor takes a Value
+ * followed by zero or more strings, regardless of namespace.
  *
  * Example:
  *
@@ -32,19 +33,18 @@ final readonly class SourceFormula implements Formula
      * Initializes with the source class and its raw template arguments.
      *
      * @param class-string<Op> $target FQCN of the source class to instantiate
-     * @param list<string> $args Raw template arguments, exactly one settings key for sources
+     * @param list<string> $args Raw template arguments — the first is the settings key, the rest are passed as ctor literals
      */
     public function __construct(private string $target, private array $args) {}
 
     #[Override]
     public function op(array $previous, Settings $settings): Op
     {
-        if (count($this->args) !== 1) {
+        if ($this->args === []) {
             throw new SheriffException(
                 sprintf(
-                    'SourceFormula "%s" expects exactly one settings key, got %d arguments',
+                    'SourceFormula "%s" expects at least one settings key',
                     $this->target,
-                    count($this->args),
                 ),
             );
         }
@@ -64,6 +64,6 @@ final readonly class SourceFormula implements Formula
         $value = $settings->value($key);
         $className = $this->target;
 
-        return new $className($value);
+        return new $className($value, ...array_slice($this->args, 1));
     }
 }

--- a/src/Chain/Plain/EnvsText.php
+++ b/src/Chain/Plain/EnvsText.php
@@ -106,6 +106,12 @@ final readonly class EnvsText implements Op
             );
         }
 
+        if (preg_match('/["\\\\]/', $value->raw) === 1) {
+            throw new SheriffException(
+                sprintf('Environment variable "%s" command must not contain " or \\ characters', $name),
+            );
+        }
+
         return $value->raw;
     }
 }

--- a/src/Chain/Plain/EnvsText.php
+++ b/src/Chain/Plain/EnvsText.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Plain;
+
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+
+/**
+ * Renders a TreeValue of CI environment variables as a GitHub Actions step.
+ *
+ * Each entry is `VAR_NAME => "shell command"`. The variable name must match
+ * `^[A-Za-z_][A-Za-z0-9_]*$`. Empty trees render as the empty string so the
+ * surrounding workflow yaml stays well-formed.
+ *
+ * Example:
+ *
+ *     (new EnvsText(
+ *         new TreeValue(['COMPOSER_ROOT_VERSION' => new StringValue('git describe')]),
+ *         ' ',
+ *     ))->rendered();
+ */
+final readonly class EnvsText implements Op
+{
+    /**
+     * Initializes with the envs payload and the YAML indent prefix.
+     *
+     * @param Value $envs TreeValue of env names to shell commands; an empty ListValue is also accepted because YAML `{}` parses as `[]`
+     * @param string $indent Raw indentation prefix used for nested YAML output
+     */
+    public function __construct(private Value $envs, private string $indent) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        $entries = $this->entries();
+
+        if ($entries === []) {
+            return '';
+        }
+
+        $lines = [
+            sprintf('%s    git fetch --tags --unshallow 2>/dev/null || git fetch --tags', $this->indent),
+        ];
+
+        foreach ($entries as $name => $value) {
+            $lines[] = sprintf(
+                '%s    echo "%s=$(%s)" >> "$GITHUB_ENV"',
+                $this->indent,
+                $name,
+                $this->command($name, $value),
+            );
+        }
+
+        return sprintf(
+            "%s- name: Set environment variables\n%s  run: |\n%s",
+            $this->indent,
+            $this->indent,
+            implode("\n", $lines),
+        );
+    }
+
+    /**
+     * Resolves the envs payload to its key-value entries.
+     *
+     * @throws SheriffException
+     * @return array<string, Value>
+     */
+    private function entries(): array
+    {
+        if ($this->envs instanceof TreeValue) {
+            return $this->envs->entries;
+        }
+
+        if ($this->envs instanceof ListValue && $this->envs->children === []) {
+            return [];
+        }
+
+        throw new SheriffException(
+            sprintf('EnvsText requires a TreeValue payload, got %s', get_debug_type($this->envs)),
+        );
+    }
+
+    /**
+     * Validates the env name and unwraps the StringValue command.
+     *
+     * @throws SheriffException
+     */
+    private function command(string $name, Value $value): string
+    {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name) !== 1) {
+            throw new SheriffException(
+                sprintf('Invalid environment variable name "%s"', $name),
+            );
+        }
+
+        if (!$value instanceof StringValue) {
+            throw new SheriffException(
+                sprintf('Environment variable "%s" must hold a StringValue command', $name),
+            );
+        }
+
+        return $value->raw;
+    }
+}

--- a/src/Settings/Patch/OverrideTree.php
+++ b/src/Settings/Patch/OverrideTree.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Settings\Patch;
 
 use Haspadar\Sheriff\Settings\Patch;
+use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\MergedTree;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
 use Haspadar\Sheriff\Settings\Value\Value;
@@ -13,6 +14,10 @@ use TypeError;
 
 /**
  * Deep-merges an override tree into the base tree at the given key.
+ *
+ * An empty ListValue base is accepted as an empty tree because the YAML
+ * default `key: {}` collapses to `[]` in PHP/Symfony, and RawValue wraps
+ * it as ListValue rather than TreeValue.
  *
  * Example:
  *
@@ -43,6 +48,10 @@ final readonly class OverrideTree implements Patch
     #[Override]
     public function applied(Value $base): Value
     {
+        if ($base instanceof ListValue && $base->children === []) {
+            return (new MergedTree(new TreeValue([]), $this->value))->value();
+        }
+
         if (!$base instanceof TreeValue) {
             throw new TypeError(
                 sprintf('OverrideTree expects TreeValue at "%s"', $this->key),

--- a/src/Settings/YamlPatches.php
+++ b/src/Settings/YamlPatches.php
@@ -41,8 +41,24 @@ final readonly class YamlPatches
     {
         return [
             ...(new OverridePatches($this->document->section('override')))->patches(),
+            ...(new OverridePatches($this->envsOverride()))->patches(),
             ...(new AppendPatches($this->document->section('append')))->patches(),
             ...(new RemovePatches($this->document->section('remove')))->patches(),
         ];
+    }
+
+    /**
+     * Lifts the top-level `envs:` section into an override on the `envs` key.
+     *
+     * @throws SheriffException
+     * @return array<string, mixed>
+     */
+    private function envsOverride(): array
+    {
+        $envs = $this->document->section('envs');
+
+        return $envs === []
+            ? []
+            : ['envs' => $envs];
     }
 }

--- a/templates/always/.github/workflows/sheriff.yml
+++ b/templates/always/.github/workflows/sheriff.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: maidsafe/pr_size_checker@948bfb3e96d93fbeeef4e207375163e8dae5665e
         with:
-          max_lines_changed: << config(ci.pr.max_lines_changed)|join("") >>
+          max_lines_changed: {% IntText(ci.pr.max_lines_changed) %}
 
 
   # ============================================================
@@ -55,14 +55,14 @@ jobs:
 
       - uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
         with:
-          php-version: << config(php.versions)|first() >>
+          php-version: {% ListText(php.versions)|First() %}
 
-<< envs("      ") >>
+{% EnvsText(envs, "      ") %}
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run check
-        run: << config(ci.sheriff_bin)|join("") >> check ${{ matrix.check }}
+        run: {% StringText(ci.sheriff_bin) %} check ${{ matrix.check }}
 
 
   # ============================================================
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [<< config(php.versions)|format_each('"%s"')|join(", ") >>]
+        php: [{% ListText(php.versions)|EachFormatted('"%s"')|Joined(", ") %}]
         check:
           - phpcs
           - phpstan
@@ -93,19 +93,19 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: mbstring, dom, json
 
-<< envs("      ") >>
+{% EnvsText(envs, "      ") %}
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run static check
-        run: << config(ci.sheriff_bin)|join("") >> check ${{ matrix.check }}
+        run: {% StringText(ci.sheriff_bin) %} check ${{ matrix.check }}
 
 
   # ============================================================
   # PHP TESTS + COVERAGE + MUTATION
   # ============================================================
   php-tests:
-    name: Tests / Coverage / Mutation (PHP << config(php.versions)|first() >>)
+    name: Tests / Coverage / Mutation (PHP {% ListText(php.versions)|First() %})
     runs-on: ubuntu-latest
     needs: php-static
     permissions:
@@ -116,11 +116,11 @@ jobs:
 
       - uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
         with:
-          php-version: << config(php.versions)|first() >>
+          php-version: {% ListText(php.versions)|First() %}
           coverage: xdebug
           extensions: mbstring, dom, json
 
-<< envs("      ") >>
+{% EnvsText(envs, "      ") %}
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
@@ -135,7 +135,7 @@ jobs:
       # Upload coverage to Codecov (if coverage exists)
       # ------------------------------------------------------------
       - name: Upload coverage to Codecov
-        if: << config(codecov.cloud)|first()|join("") >> == true && hashFiles('.sheriff/codecov/coverage.xml') != ''
+        if: {% BoolText(codecov.cloud) %} == true && hashFiles('.sheriff/codecov/coverage.xml') != ''
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -13,6 +13,7 @@ defaults:
   php.src: ["src"]
   infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
+  envs: {}
 
   check.full: false
   check.parallel: true

--- a/tests/Unit/Chain/Parse/SourceFormulaTest.php
+++ b/tests/Unit/Chain/Parse/SourceFormulaTest.php
@@ -88,21 +88,12 @@ final class SourceFormulaTest extends TestCase
     }
 
     #[Test]
-    public function failsWhenArgumentCountIsNotExactlyOne(): void
+    public function failsWhenArgumentListIsEmpty(): void
     {
         $this->expectException(SheriffException::class);
 
         (new SourceFormula(IntText::class, []))
             ->op([], self::settings([]));
-    }
-
-    #[Test]
-    public function failsWithMultipleArguments(): void
-    {
-        $this->expectException(SheriffException::class);
-
-        (new SourceFormula(IntText::class, ['phpstan.level', 'extra']))
-            ->op([], self::settings(['phpstan.level' => new IntValue(9)]));
     }
 
     #[Test]

--- a/tests/Unit/Chain/Plain/EnvsTextTest.php
+++ b/tests/Unit/Chain/Plain/EnvsTextTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Plain;
+
+use Haspadar\Sheriff\Chain\Plain\EnvsText;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EnvsTextTest extends TestCase
+{
+    #[Test]
+    public function rendersEmptyStringForEmptyTree(): void
+    {
+        self::assertSame(
+            '',
+            (new EnvsText(new TreeValue([]), '      '))->rendered(),
+            'EnvsText must render an empty string when the envs tree is empty',
+        );
+    }
+
+    #[Test]
+    public function rendersEmptyStringForEmptyListSinceYamlEmptyMappingParsesAsList(): void
+    {
+        self::assertSame(
+            '',
+            (new EnvsText(new ListValue([]), '      '))->rendered(),
+            'EnvsText must accept an empty ListValue payload because YAML `{}` parses as `[]`',
+        );
+    }
+
+    #[Test]
+    public function rendersWorkflowStepWithFetchPrologueAndEchoLines(): void
+    {
+        self::assertSame(
+            "      - name: Set environment variables\n"
+            . "        run: |\n"
+            . "          git fetch --tags --unshallow 2>/dev/null || git fetch --tags\n"
+            . '          echo "COMPOSER_ROOT_VERSION=$(git describe)" >> "$GITHUB_ENV"',
+            (new EnvsText(
+                new TreeValue([
+                    'COMPOSER_ROOT_VERSION' => new StringValue('git describe'),
+                ]),
+                '      ',
+            ))->rendered(),
+            'EnvsText must render the GHA step with the fetch prologue and one echo line per env var',
+        );
+    }
+
+    #[Test]
+    public function rejectsInvalidEnvironmentVariableName(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EnvsText(
+            new TreeValue(['1BAD' => new StringValue('cmd')]),
+            '      ',
+        ))->rendered();
+    }
+
+    #[Test]
+    public function rejectsNonStringValueCommand(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EnvsText(
+            new TreeValue(['VAR' => new TreeValue([])]),
+            '      ',
+        ))->rendered();
+    }
+
+    #[Test]
+    public function rejectsNonEmptyListPayload(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EnvsText(
+            new ListValue([new StringValue('x')]),
+            '      ',
+        ))->rendered();
+    }
+
+    #[Test]
+    public function rendersEveryTreeEntryAsItsOwnEchoLine(): void
+    {
+        self::assertSame(
+            "      - name: Set environment variables\n"
+            . "        run: |\n"
+            . "          git fetch --tags --unshallow 2>/dev/null || git fetch --tags\n"
+            . '          echo "FOO=$(echo a)" >> "$GITHUB_ENV"' . "\n"
+            . '          echo "BAR=$(echo b)" >> "$GITHUB_ENV"',
+            (new EnvsText(
+                new TreeValue([
+                    'FOO' => new StringValue('echo a'),
+                    'BAR' => new StringValue('echo b'),
+                ]),
+                '      ',
+            ))->rendered(),
+            'EnvsText must render one echo line per env-var while keeping the shared fetch prologue',
+        );
+    }
+
+    #[Test]
+    public function rendersWithoutLeadingIndentWhenIndentIsEmpty(): void
+    {
+        self::assertSame(
+            "- name: Set environment variables\n"
+            . "  run: |\n"
+            . "    git fetch --tags --unshallow 2>/dev/null || git fetch --tags\n"
+            . '    echo "FOO=$(cmd)" >> "$GITHUB_ENV"',
+            (new EnvsText(
+                new TreeValue(['FOO' => new StringValue('cmd')]),
+                '',
+            ))->rendered(),
+            'EnvsText must apply an empty indent verbatim, leaving the inner four-space step indent intact',
+        );
+    }
+}

--- a/tests/Unit/Chain/Plain/EnvsTextTest.php
+++ b/tests/Unit/Chain/Plain/EnvsTextTest.php
@@ -64,6 +64,28 @@ final class EnvsTextTest extends TestCase
     }
 
     #[Test]
+    public function rejectsCommandWithDoubleQuoteToPreventShellInjection(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EnvsText(
+            new TreeValue(['VAR' => new StringValue('echo "x"')]),
+            '      ',
+        ))->rendered();
+    }
+
+    #[Test]
+    public function rejectsCommandWithBackslashToPreventShellInjection(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EnvsText(
+            new TreeValue(['VAR' => new StringValue('echo a\\b')]),
+            '      ',
+        ))->rendered();
+    }
+
+    #[Test]
     public function rejectsNonStringValueCommand(): void
     {
         $this->expectException(SheriffException::class);


### PR DESCRIPTION
- Added `EnvsText` source op that renders the GitHub Actions step exporting CI env vars from a `TreeValue` (or empty `ListValue`) plus a literal indent
- Relaxed `SourceFormula` to accept ≥1 arguments — first stays the settings key, the rest are forwarded as ctor literals (lets `EnvsText(envs, "      ")` work without a dedicated formula type)
- Lifted top-level `envs:` section in `.sheriff.yaml` into an OverridePatches input on the `envs` settings key in `YamlPatches`
- Added `envs: {}` default to `templates/always/.sheriff/config.yaml`
- Made `OverrideTree` accept an empty `ListValue` base as empty tree, since YAML `{}` parses as `[]` and `RawValue` wraps it as `ListValue`
- Migrated `templates/always/.github/workflows/sheriff.yml` from legacy DSL to Chain pipelines with `{% %}` markers, including all `<< envs("      ") >>` calls
- Bumped `phpmetrics.coupling.max_afferent` to 35 to accommodate `EnvsText` referencing `SheriffException`

Part of #653

Notes:
- `_docker.sh`, `phpcs/slevomat-style.xml` and `sonar/command.sh` still hold a few `<< config(...) >>` markers — those are tracked in separate follow-up branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variable support can be configured and injected into GitHub Actions workflows.
  * Formula expressions now accept a settings key plus optional literal arguments when constructing targets.

* **Bug Fixes**
  * Better handling for empty override bases to merge as empty trees.

* **Chores**
  * Workflow templates updated to use the new env templating helpers.
  * Adjusted code-quality coupling threshold.

* **Tests**
  * Added unit tests covering env rendering and formula argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->