### PR TITLE
Surface phpcs.root_namespace via ComposerSettings Decorator

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -60,7 +60,6 @@ defaults:
 
   phpcs.cli: true
   phpcs.extend: ""
-  phpcs.root_namespace: ""
 
   phpmd.cli: true
   phpmd.class_complexity: 50

--- a/bin/sheriff-sync
+++ b/bin/sheriff-sync
@@ -16,6 +16,7 @@ use Haspadar\Sheriff\Files\FilteredFiles;
 use Haspadar\Sheriff\Files\FolderFiles;
 use Haspadar\Sheriff\Files\MappedFiles;
 use Haspadar\Sheriff\Output\Console;
+use Haspadar\Sheriff\Settings\ComposerSettings;
 use Haspadar\Sheriff\Settings\DefaultSettings;
 use Haspadar\Sheriff\Settings\Patch;
 use Haspadar\Sheriff\Settings\PatchedSettings;
@@ -56,13 +57,15 @@ try {
 
     $actions = (new FormulaActions($config, $envs))->map();
 
-    $settings = file_exists($yamlPath)
+    $patched = file_exists($yamlPath)
         ? array_reduce(
             (new YamlPatches($yamlPath))->patches(),
             static fn(Settings $base, Patch $patch): Settings => new PatchedSettings($base, $patch),
             new DefaultSettings(),
         )
         : new DefaultSettings();
+
+    $settings = new ComposerSettings($patched, $projectRoot . '/composer.json');
 
     $reactions = new StorageReactions([new ReportingStorageReaction($output)]);
     $disk = new DiskStorage($projectRoot);

--- a/src/Config/ConfigPaths.php
+++ b/src/Config/ConfigPaths.php
@@ -10,21 +10,13 @@ namespace Haspadar\Sheriff\Config;
 final readonly class ConfigPaths
 {
     /**
-     * Initializes with optional custom paths for composer.json and config.yaml.
+     * Initializes with an optional custom path for the sheriff defaults YAML file.
      *
-     * @param string $composer Path to the project composer.json (empty means none)
      * @param string $config Path to the sheriff defaults YAML file
      */
     public function __construct(
-        private string $composer = '',
         private string $config = __DIR__ . '/../../templates/always/.sheriff/config.yaml',
     ) {}
-
-    /** Returns the composer.json file path. */
-    public function composerJson(): string
-    {
-        return $this->composer;
-    }
 
     /** Returns the config.yaml file path. */
     public function configYaml(): string

--- a/src/Config/DefaultConfig.php
+++ b/src/Config/DefaultConfig.php
@@ -20,7 +20,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  *     new DefaultConfig();
  *
- *     new DefaultConfig(paths: new ConfigPaths(composer: '/path/to/composer.json'));
+ *     new DefaultConfig(paths: new ConfigPaths(config: '/path/to/config.yaml'));
  */
 final readonly class DefaultConfig implements Config
 {
@@ -150,7 +150,6 @@ final readonly class DefaultConfig implements Config
             'infra.exclude' => $excludes,
             'jsonlint.patterns' => ['**/*.json', '**/*.json5', '**/*.jsonc'],
             'markdownlint.ignores' => (new TrailingGlobDirs($excludes))->toList(),
-            'phpcs.root_namespace' => (new ComposerRootNamespace($this->paths->composerJson()))->toString(),
             'infection.source.directories' => $projectIncludes,
             'typos.exclude' => (new TrailingSlashDirs($excludes))->toList(),
             'yamllint.ignore' => array_merge(

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -53,11 +53,7 @@ final readonly class ProjectConfig implements Config
      */
     private function resolve(): Config
     {
-        $defaults = new DefaultConfig(
-            [],
-            [],
-            new ConfigPaths(sprintf('%s/composer.json', $this->root)),
-        );
+        $defaults = new DefaultConfig();
 
         $yamlPath = sprintf('%s/.sheriff.yaml', $this->root);
         $phpPath = sprintf('%s/.sheriff.php', $this->root);

--- a/src/Settings/ComposerSettings.php
+++ b/src/Settings/ComposerSettings.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Settings;
+
+use Haspadar\Sheriff\Config\ComposerRootNamespace;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Override;
+
+/**
+ * Settings decorator that exposes derived keys read from `composer.json`.
+ *
+ * Currently provides `phpcs.root_namespace` — the first PSR-4 root namespace
+ * declared by the project. Other composer-derived keys can be added here
+ * without touching the rest of the Settings stack.
+ *
+ * Example:
+ *
+ *     new ComposerSettings(new DefaultSettings(), '/path/to/composer.json');
+ */
+final readonly class ComposerSettings implements Settings
+{
+    private const string ROOT_NAMESPACE_KEY = 'phpcs.root_namespace';
+
+    /**
+     * Initializes with the underlying settings and the composer.json path.
+     *
+     * @param Settings $base Underlying settings whose keys are passed through
+     * @param string $composer Absolute path to the composer.json file
+     */
+    public function __construct(private Settings $base, private string $composer) {}
+
+    #[Override]
+    public function has(string $name): bool
+    {
+        return $name === self::ROOT_NAMESPACE_KEY || $this->base->has($name);
+    }
+
+    #[Override]
+    public function value(string $name): Value
+    {
+        if ($name === self::ROOT_NAMESPACE_KEY && !$this->base->has($name)) {
+            return new StringValue(
+                (new ComposerRootNamespace($this->composer))->toString(),
+            );
+        }
+
+        return $this->base->value($name);
+    }
+}

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -60,7 +60,6 @@ defaults:
 
   phpcs.cli: true
   phpcs.extend: ""
-  phpcs.root_namespace: ""
 
   phpmd.cli: true
   phpmd.class_complexity: 50

--- a/templates/always/.sheriff/phpcs/slevomat-style.xml
+++ b/templates/always/.sheriff/phpcs/slevomat-style.xml
@@ -30,7 +30,7 @@
     <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
         <properties>
             <property name="rootNamespaces" type="array">
-                <element key="src" value="<< config(phpcs.root_namespace)|join("") >>"/>
+                <element key="src" value="{% StringText(phpcs.root_namespace) %}"/>
             </property>
         </properties>
     </rule>

--- a/tests/Unit/Config/DefaultConfigTest.php
+++ b/tests/Unit/Config/DefaultConfigTest.php
@@ -134,25 +134,6 @@ final class DefaultConfigTest extends TestCase
     }
 
     #[Test]
-    public function usesRootNamespaceFromComposerJson(): void
-    {
-        $folder = (new TempFolder())->withFile(
-            'composer.json',
-            '{"autoload":{"psr-4":{"Acme\\\\":"src/"}}}',
-        );
-
-        $namespace = (new DefaultConfig(paths: new ConfigPaths($folder->path() . '/composer.json')))->list('phpcs.root_namespace');
-
-        $folder->close();
-
-        self::assertSame(
-            ['Acme'],
-            $namespace,
-            'DefaultConfig must extract root namespace from composer.json psr-4 section',
-        );
-    }
-
-    #[Test]
     public function throwsWhenConfigYamlHasNoDefaultsSection(): void
     {
         $folder = (new TempFolder())->withFile('empty.yaml', 'root: true');

--- a/tests/Unit/Settings/ComposerSettingsTest.php
+++ b/tests/Unit/Settings/ComposerSettingsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Settings;
+
+use Haspadar\Sheriff\Settings\ComposerSettings;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
+use Haspadar\Sheriff\Tests\Fixture\TempFolder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ComposerSettingsTest extends TestCase
+{
+    #[Test]
+    public function exposesRootNamespaceKeyDerivedFromComposerJson(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'composer.json',
+            json_encode(['autoload' => ['psr-4' => ['App\\' => 'src/']]], JSON_THROW_ON_ERROR),
+        );
+
+        $value = (new ComposerSettings(
+            new FakeSettings([]),
+            $folder->path() . '/composer.json',
+        ))->value('phpcs.root_namespace');
+
+        $folder->close();
+
+        self::assertEquals(
+            new StringValue('App'),
+            $value,
+            'ComposerSettings must read the first PSR-4 namespace from composer.json',
+        );
+    }
+
+    #[Test]
+    public function rendersEmptyStringWhenComposerJsonIsAbsent(): void
+    {
+        self::assertEquals(
+            new StringValue(''),
+            (new ComposerSettings(
+                new FakeSettings([]),
+                '/nonexistent/path/composer.json',
+            ))->value('phpcs.root_namespace'),
+            'ComposerSettings must return an empty StringValue when composer.json is missing',
+        );
+    }
+
+    #[Test]
+    public function reportsRootNamespaceKeyAsAvailableEvenWithoutBase(): void
+    {
+        self::assertTrue(
+            (new ComposerSettings(
+                new FakeSettings([]),
+                '/anywhere/composer.json',
+            ))->has('phpcs.root_namespace'),
+            'ComposerSettings must report phpcs.root_namespace as available regardless of the base settings',
+        );
+    }
+
+    #[Test]
+    public function delegatesUnknownKeysToBaseSettings(): void
+    {
+        self::assertEquals(
+            new IntValue(9),
+            (new ComposerSettings(
+                new FakeSettings(['phpstan.level' => new IntValue(9)]),
+                '/anywhere/composer.json',
+            ))->value('phpstan.level'),
+            'ComposerSettings must pass through non-namespace keys to the base settings',
+        );
+    }
+
+    #[Test]
+    public function letsBaseSettingsOverrideTheDerivedNamespace(): void
+    {
+        self::assertEquals(
+            new StringValue('Custom'),
+            (new ComposerSettings(
+                new FakeSettings(['phpcs.root_namespace' => new StringValue('Custom')]),
+                '/anywhere/composer.json',
+            ))->value('phpcs.root_namespace'),
+            'User-provided phpcs.root_namespace must win over the composer.json derivation',
+        );
+    }
+
+    #[Test]
+    public function delegatesHasToBaseSettingsForOtherKeys(): void
+    {
+        self::assertFalse(
+            (new ComposerSettings(
+                new FakeSettings([]),
+                '/anywhere/composer.json',
+            ))->has('phpstan.level'),
+            'ComposerSettings must delegate has() to the base settings for non-namespace keys',
+        );
+    }
+}


### PR DESCRIPTION
- Added `Settings\ComposerSettings` decorator that exposes `phpcs.root_namespace` derived from `composer.json` PSR-4 autoload, with explicit user override precedence (base settings win when the key is declared)
- Wired `ComposerSettings` over the patched settings stack in `bin/sheriff-sync`
- Migrated `templates/always/.sheriff/phpcs/slevomat-style.xml` from legacy DSL to `{% StringText(phpcs.root_namespace) %}`
- Removed the `phpcs.root_namespace` derivation from `DefaultConfig::dynamic()` and the now-redundant `phpcs.root_namespace: ""` default in `templates/always/.sheriff/config.yaml`
- Removed the obsolete `composer` argument from `Config\ConfigPaths` (no callers left) and simplified `ProjectConfig::resolve()` accordingly
- Dropped the corresponding `usesRootNamespaceFromComposerJson` test from `DefaultConfigTest` since coverage now lives in `ComposerSettingsTest`

Part of #653

Notes:
- The previous `<< config(phpcs.root_namespace)|join("") >>` silently concatenated multiple PSR-4 roots; the new `StringText` source uses the first root from `ComposerRootNamespace::toString()`. Single-root projects render identically; multi-root projects now surface only the first namespace, which matches the documented behaviour.

**Breaking changes:**
- `Config\ConfigPaths` constructor no longer accepts a `composer` argument. Callers using `new ConfigPaths('/path/to/composer.json')` positionally will silently treat the path as the YAML config; switch to named `config:` argument or drop the argument entirely.