### PR TITLE
Migrate EnvVar and Secret Enablement to Settings

### DIFF
--- a/bin/sheriff-tokens-check
+++ b/bin/sheriff-tokens-check
@@ -25,6 +25,15 @@ $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
 
 $yamlPath = $projectRoot . '/.sheriff.yaml';
 
+$envVars = new EnvVars([
+    new SonarEnvVar(),
+]);
+
+$secrets = new Secrets([
+    new CodecovSecret(),
+    new InfectionSecret(),
+]);
+
 try {
     $patched = file_exists($yamlPath)
         ? array_reduce(
@@ -35,24 +44,20 @@ try {
         : new DefaultSettings();
 
     $settings = new ComposerSettings($patched, $projectRoot . '/composer.json');
+
+    $enabledEnvVars = array_filter(
+        $envVars->items(),
+        fn($var) => $var->enabled($settings),
+    );
+
+    $enabledSecrets = array_filter(
+        $secrets->items(),
+        fn($secret) => $secret->enabled($settings),
+    );
 } catch (SheriffException $e) {
     $output->error($e->getMessage());
     exit(1);
 }
-
-$envVars = new EnvVars([
-    new SonarEnvVar(),
-]);
-
-$secrets = new Secrets([
-    new CodecovSecret(),
-    new InfectionSecret(),
-]);
-
-$enabledEnvVars = array_filter(
-    $envVars->items(),
-    fn($var) => $var->enabled($settings),
-);
 
 foreach ($enabledEnvVars as $var) {
     $env = getenv($var->name());
@@ -65,11 +70,6 @@ foreach ($enabledEnvVars as $var) {
     $output->info(sprintf('[ENV] export %s=<your-token>  (bash/zsh)', $var->name()));
     $output->info(sprintf('[ENV] set -Ux %s <your-token>  (fish)', $var->name()));
 }
-
-$enabledSecrets = array_filter(
-    $secrets->items(),
-    fn($secret) => $secret->enabled($settings),
-);
 
 if ($enabledSecrets === []) {
     exit(0);

--- a/bin/sheriff-tokens-check
+++ b/bin/sheriff-tokens-check
@@ -3,10 +3,15 @@
 
 declare(strict_types=1);
 
-use Haspadar\Sheriff\Config\ProjectConfig;
 use Haspadar\Sheriff\EnvVar\EnvVars;
 use Haspadar\Sheriff\EnvVar\SonarEnvVar;
 use Haspadar\Sheriff\Output\Console;
+use Haspadar\Sheriff\Settings\ComposerSettings;
+use Haspadar\Sheriff\Settings\DefaultSettings;
+use Haspadar\Sheriff\Settings\Patch;
+use Haspadar\Sheriff\Settings\PatchedSettings;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\YamlPatches;
 use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Secret\CodecovSecret;
 use Haspadar\Sheriff\Secret\InfectionSecret;
@@ -18,8 +23,18 @@ $output = new Console();
 
 $projectRoot = getcwd() ?: throw new RuntimeException('Cannot determine cwd');
 
+$yamlPath = $projectRoot . '/.sheriff.yaml';
+
 try {
-    $config = new ProjectConfig($projectRoot);
+    $patched = file_exists($yamlPath)
+        ? array_reduce(
+            (new YamlPatches($yamlPath))->patches(),
+            static fn(Settings $base, Patch $patch): Settings => new PatchedSettings($base, $patch),
+            new DefaultSettings(),
+        )
+        : new DefaultSettings();
+
+    $settings = new ComposerSettings($patched, $projectRoot . '/composer.json');
 } catch (SheriffException $e) {
     $output->error($e->getMessage());
     exit(1);
@@ -36,7 +51,7 @@ $secrets = new Secrets([
 
 $enabledEnvVars = array_filter(
     $envVars->items(),
-    fn($var) => $var->enabled($config),
+    fn($var) => $var->enabled($settings),
 );
 
 foreach ($enabledEnvVars as $var) {
@@ -53,7 +68,7 @@ foreach ($enabledEnvVars as $var) {
 
 $enabledSecrets = array_filter(
     $secrets->items(),
-    fn($secret) => $secret->enabled($config),
+    fn($secret) => $secret->enabled($settings),
 );
 
 if ($enabledSecrets === []) {

--- a/src/EnvVar/EnvVar.php
+++ b/src/EnvVar/EnvVar.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\EnvVar;
 
-use Haspadar\Sheriff\Config\Config;
+use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\SheriffException;
 
 /**
- * Environment variable required on a developer machine
+ * Environment variable required on a developer machine.
  */
 interface EnvVar
 {
@@ -17,5 +17,5 @@ interface EnvVar
     public function url(): string;
 
     /** @throws SheriffException */
-    public function enabled(Config $config): bool;
+    public function enabled(Settings $settings): bool;
 }

--- a/src/EnvVar/SonarEnvVar.php
+++ b/src/EnvVar/SonarEnvVar.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\EnvVar;
 
-use Haspadar\Sheriff\Config\Config;
-use Haspadar\Sheriff\SheriffException;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Override;
 
 /**
@@ -26,38 +26,25 @@ final readonly class SonarEnvVar implements EnvVar
     }
 
     #[Override]
-    public function enabled(Config $config): bool
+    public function enabled(Settings $settings): bool
     {
-        if ($this->cloud($config)) {
+        if ($this->boolean($settings, 'sonar.cloud', true)) {
             return false;
         }
 
-        if (!$config->has('sonar.cli')) {
-            return true;
-        }
-
-        return filter_var(
-            $config->list('sonar.cli')[0] ?? true,
-            FILTER_VALIDATE_BOOLEAN,
-            FILTER_NULL_ON_FAILURE,
-        ) ?? true;
+        return $this->boolean($settings, 'sonar.cli', true);
     }
 
-    /**
-     * Checks whether SonarCloud mode is active.
-     *
-     * @throws SheriffException
-     */
-    private function cloud(Config $config): bool
+    private function boolean(Settings $settings, string $key, bool $default): bool
     {
-        if (!$config->has('sonar.cloud')) {
-            return true;
+        if (!$settings->has($key)) {
+            return $default;
         }
 
-        return filter_var(
-            $config->list('sonar.cloud')[0] ?? true,
-            FILTER_VALIDATE_BOOLEAN,
-            FILTER_NULL_ON_FAILURE,
-        ) ?? true;
+        $value = $settings->value($key);
+
+        return $value instanceof BoolValue
+            ? $value->raw
+            : $default;
     }
 }

--- a/src/EnvVar/SonarEnvVar.php
+++ b/src/EnvVar/SonarEnvVar.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\EnvVar;
 
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**
@@ -28,23 +28,10 @@ final readonly class SonarEnvVar implements EnvVar
     #[Override]
     public function enabled(Settings $settings): bool
     {
-        if ($this->boolean($settings, 'sonar.cloud', true)) {
+        if ((new BoolSetting($settings, 'sonar.cloud', true))->raw()) {
             return false;
         }
 
-        return $this->boolean($settings, 'sonar.cli', true);
-    }
-
-    private function boolean(Settings $settings, string $key, bool $default): bool
-    {
-        if (!$settings->has($key)) {
-            return $default;
-        }
-
-        $value = $settings->value($key);
-
-        return $value instanceof BoolValue
-            ? $value->raw
-            : $default;
+        return (new BoolSetting($settings, 'sonar.cli', true))->raw();
     }
 }

--- a/src/Secret/CodecovSecret.php
+++ b/src/Secret/CodecovSecret.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Secret;
 
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**
@@ -28,14 +28,6 @@ final readonly class CodecovSecret implements Secret
     #[Override]
     public function enabled(Settings $settings): bool
     {
-        if (!$settings->has('phpunit.cli')) {
-            return true;
-        }
-
-        $value = $settings->value('phpunit.cli');
-
-        return $value instanceof BoolValue
-            ? $value->raw
-            : true;
+        return (new BoolSetting($settings, 'phpunit.cli', true))->raw();
     }
 }

--- a/src/Secret/CodecovSecret.php
+++ b/src/Secret/CodecovSecret.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Secret;
 
-use Haspadar\Sheriff\Config\Config;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Override;
 
 /**
@@ -25,16 +26,16 @@ final readonly class CodecovSecret implements Secret
     }
 
     #[Override]
-    public function enabled(Config $config): bool
+    public function enabled(Settings $settings): bool
     {
-        if (!$config->has('phpunit.cli')) {
+        if (!$settings->has('phpunit.cli')) {
             return true;
         }
 
-        return filter_var(
-            $config->list('phpunit.cli')[0] ?? true,
-            FILTER_VALIDATE_BOOLEAN,
-            FILTER_NULL_ON_FAILURE,
-        ) ?? true;
+        $value = $settings->value('phpunit.cli');
+
+        return $value instanceof BoolValue
+            ? $value->raw
+            : true;
     }
 }

--- a/src/Secret/InfectionSecret.php
+++ b/src/Secret/InfectionSecret.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Secret;
 
-use Haspadar\Sheriff\Config\Config;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Override;
 
 /**
@@ -25,16 +26,16 @@ final readonly class InfectionSecret implements Secret
     }
 
     #[Override]
-    public function enabled(Config $config): bool
+    public function enabled(Settings $settings): bool
     {
-        if (!$config->has('infection.cli')) {
+        if (!$settings->has('infection.cli')) {
             return true;
         }
 
-        return filter_var(
-            $config->list('infection.cli')[0] ?? true,
-            FILTER_VALIDATE_BOOLEAN,
-            FILTER_NULL_ON_FAILURE,
-        ) ?? true;
+        $value = $settings->value('infection.cli');
+
+        return $value instanceof BoolValue
+            ? $value->raw
+            : true;
     }
 }

--- a/src/Secret/InfectionSecret.php
+++ b/src/Secret/InfectionSecret.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Secret;
 
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**
@@ -28,14 +28,6 @@ final readonly class InfectionSecret implements Secret
     #[Override]
     public function enabled(Settings $settings): bool
     {
-        if (!$settings->has('infection.cli')) {
-            return true;
-        }
-
-        $value = $settings->value('infection.cli');
-
-        return $value instanceof BoolValue
-            ? $value->raw
-            : true;
+        return (new BoolSetting($settings, 'infection.cli', true))->raw();
     }
 }

--- a/src/Secret/Secret.php
+++ b/src/Secret/Secret.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Secret;
 
-use Haspadar\Sheriff\Config\Config;
+use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\SheriffException;
 
 /**
- * GitHub Secret required by a CI service
+ * GitHub Secret required by a CI service.
  */
 interface Secret
 {
@@ -17,5 +17,5 @@ interface Secret
     public function url(string $org): string;
 
     /** @throws SheriffException */
-    public function enabled(Config $config): bool;
+    public function enabled(Settings $settings): bool;
 }

--- a/src/Settings/Value/BoolSetting.php
+++ b/src/Settings/Value/BoolSetting.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Settings\Value;
+
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * Reads a boolean setting from Settings with a fallback default.
+ *
+ * Returns the default when the key is absent or the stored Value is not a
+ * BoolValue. Centralises the strict bool lookup that EnvVar/Secret toggles
+ * share so the contract stays consistent.
+ *
+ * Example:
+ *
+ *     (new BoolSetting($settings, 'sonar.cloud', true))->raw();
+ */
+final readonly class BoolSetting
+{
+    /**
+     * Initializes with the source settings, the key, and the default fallback.
+     *
+     * @param Settings $settings Settings to query
+     * @param string $key Configuration key whose boolean value is read
+     * @param bool $default Value returned when the key is absent or not boolean
+     */
+    public function __construct(
+        private Settings $settings,
+        private string $key,
+        private bool $default,
+    ) {}
+
+    /**
+     * Returns the boolean payload, falling back to the default.
+     *
+     * @throws SheriffException
+     */
+    public function raw(): bool
+    {
+        if (!$this->settings->has($this->key)) {
+            return $this->default;
+        }
+
+        $value = $this->settings->value($this->key);
+
+        return $value instanceof BoolValue
+            ? $value->raw
+            : $this->default;
+    }
+}

--- a/tests/Unit/EnvVar/SonarEnvVarTest.php
+++ b/tests/Unit/EnvVar/SonarEnvVarTest.php
@@ -5,141 +5,52 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Unit\EnvVar;
 
 use Haspadar\Sheriff\EnvVar\SonarEnvVar;
-use Haspadar\Sheriff\Tests\Fake\Config\FakeConfig;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class SonarEnvVarTest extends TestCase
 {
     #[Test]
-    public function disabledWhenCloudTrue(): void
+    public function disabledWhenCloudIsTrue(): void
     {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.cloud' => [true]])),
+        self::assertFalse(
+            (new SonarEnvVar())->enabled(new FakeSettings(['sonar.cloud' => new BoolValue(true)])),
             'SonarEnvVar must be disabled when sonar.cloud is true',
         );
     }
 
     #[Test]
-    public function disabledWhenCloudAbsent(): void
+    public function disabledWhenCloudIsAbsent(): void
     {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig([])),
-            'SonarEnvVar must be disabled when sonar.cloud key is absent (default is cloud mode)',
+        self::assertFalse(
+            (new SonarEnvVar())->enabled(new FakeSettings([])),
+            'SonarEnvVar must default to cloud mode and be disabled when sonar.cloud is absent',
         );
     }
 
     #[Test]
-    public function enabledWhenCloudFalse(): void
+    public function enabledWhenCloudFalseAndCliEnabled(): void
     {
-        self::assertSame(
-            true,
-            (new SonarEnvVar())->enabled(new FakeConfig(['sonar.cloud' => [false]])),
-            'SonarEnvVar must be enabled when sonar.cloud is false (local scanner mode)',
-        );
-    }
-
-    #[Test]
-    public function disabledWhenCloudFalseAndSonarDisabled(): void
-    {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => [false],
-                'sonar.cli' => [false],
-            ])),
-            'SonarEnvVar must be disabled when sonar.cli is false even in scanner mode',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenCloudFalseAndSonarEnabled(): void
-    {
-        self::assertSame(
-            true,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => [false],
-                'sonar.cli' => [true],
+        self::assertTrue(
+            (new SonarEnvVar())->enabled(new FakeSettings([
+                'sonar.cloud' => new BoolValue(false),
+                'sonar.cli' => new BoolValue(true),
             ])),
             'SonarEnvVar must be enabled when sonar.cloud is false and sonar.cli is true',
         );
     }
 
     #[Test]
-    public function disabledWhenCloudTrueAndSonarDisabled(): void
+    public function disabledWhenCloudFalseAndCliDisabled(): void
     {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => [true],
-                'sonar.cli' => [false],
+        self::assertFalse(
+            (new SonarEnvVar())->enabled(new FakeSettings([
+                'sonar.cloud' => new BoolValue(false),
+                'sonar.cli' => new BoolValue(false),
             ])),
-            'SonarEnvVar must be disabled when sonar.cloud is true regardless of sonar.cli',
-        );
-    }
-
-    #[Test]
-    public function disabledWhenCloudFalseStringAndSonarDisabledString(): void
-    {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => ['false'],
-                'sonar.cli' => ['false'],
-            ])),
-            'SonarEnvVar must handle string "false" for both keys',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenCloudFalseAndCliKeyPresentButEmpty(): void
-    {
-        self::assertSame(
-            true,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => [false],
-                'sonar.cli' => [],
-            ])),
-            'SonarEnvVar must be enabled when sonar.cli is present but list is empty',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenCloudFalseAndCliValueNotParsableAsBoolean(): void
-    {
-        self::assertSame(
-            true,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => [false],
-                'sonar.cli' => ['maybe'],
-            ])),
-            'SonarEnvVar must be enabled when sonar.cli value cannot be parsed as boolean',
-        );
-    }
-
-    #[Test]
-    public function disabledWhenCloudKeyPresentButEmpty(): void
-    {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => [],
-            ])),
-            'SonarEnvVar must treat empty sonar.cloud list as cloud enabled and be disabled',
-        );
-    }
-
-    #[Test]
-    public function disabledWhenCloudValueNotParsableAsBoolean(): void
-    {
-        self::assertSame(
-            false,
-            (new SonarEnvVar())->enabled(new FakeConfig([
-                'sonar.cloud' => ['maybe'],
-            ])),
-            'SonarEnvVar must treat non-parsable sonar.cloud as true (cloud mode) and be disabled',
+            'SonarEnvVar must be disabled when local scanner is turned off via sonar.cli',
         );
     }
 

--- a/tests/Unit/Secret/CodecovSecretTest.php
+++ b/tests/Unit/Secret/CodecovSecretTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Unit\Secret;
 
 use Haspadar\Sheriff\Secret\CodecovSecret;
-use Haspadar\Sheriff\Tests\Fake\Config\FakeConfig;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -14,9 +15,8 @@ final class CodecovSecretTest extends TestCase
     #[Test]
     public function enabledWhenPhpUnitEnabled(): void
     {
-        self::assertSame(
-            true,
-            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.cli' => [true]])),
+        self::assertTrue(
+            (new CodecovSecret())->enabled(new FakeSettings(['phpunit.cli' => new BoolValue(true)])),
             'CodecovSecret must be enabled when phpunit.cli is true',
         );
     }
@@ -24,40 +24,18 @@ final class CodecovSecretTest extends TestCase
     #[Test]
     public function enabledWhenKeyAbsent(): void
     {
-        self::assertSame(
-            true,
-            (new CodecovSecret())->enabled(new FakeConfig([])),
-            'CodecovSecret must be enabled when phpunit.cli key is absent',
+        self::assertTrue(
+            (new CodecovSecret())->enabled(new FakeSettings([])),
+            'CodecovSecret must default to enabled when phpunit.cli key is absent',
         );
     }
 
     #[Test]
     public function disabledWhenPhpUnitDisabled(): void
     {
-        self::assertSame(
-            false,
-            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.cli' => [false]])),
+        self::assertFalse(
+            (new CodecovSecret())->enabled(new FakeSettings(['phpunit.cli' => new BoolValue(false)])),
             'CodecovSecret must be disabled when phpunit.cli is false',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenKeyPresentButEmpty(): void
-    {
-        self::assertSame(
-            true,
-            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.cli' => []])),
-            'CodecovSecret must be enabled when phpunit.cli key is present but list is empty',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenValueIsNotParsableAsBoolean(): void
-    {
-        self::assertSame(
-            true,
-            (new CodecovSecret())->enabled(new FakeConfig(['phpunit.cli' => ['maybe']])),
-            'CodecovSecret must be enabled when phpunit.cli value cannot be parsed as boolean',
         );
     }
 

--- a/tests/Unit/Secret/InfectionSecretTest.php
+++ b/tests/Unit/Secret/InfectionSecretTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Unit\Secret;
 
 use Haspadar\Sheriff\Secret\InfectionSecret;
-use Haspadar\Sheriff\Tests\Fake\Config\FakeConfig;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -14,9 +15,8 @@ final class InfectionSecretTest extends TestCase
     #[Test]
     public function enabledWhenInfectionEnabled(): void
     {
-        self::assertSame(
-            true,
-            (new InfectionSecret())->enabled(new FakeConfig(['infection.cli' => [true]])),
+        self::assertTrue(
+            (new InfectionSecret())->enabled(new FakeSettings(['infection.cli' => new BoolValue(true)])),
             'InfectionSecret must be enabled when infection.cli is true',
         );
     }
@@ -24,40 +24,18 @@ final class InfectionSecretTest extends TestCase
     #[Test]
     public function enabledWhenKeyAbsent(): void
     {
-        self::assertSame(
-            true,
-            (new InfectionSecret())->enabled(new FakeConfig([])),
-            'InfectionSecret must be enabled when infection.cli key is absent',
+        self::assertTrue(
+            (new InfectionSecret())->enabled(new FakeSettings([])),
+            'InfectionSecret must default to enabled when infection.cli key is absent',
         );
     }
 
     #[Test]
     public function disabledWhenInfectionDisabled(): void
     {
-        self::assertSame(
-            false,
-            (new InfectionSecret())->enabled(new FakeConfig(['infection.cli' => [false]])),
+        self::assertFalse(
+            (new InfectionSecret())->enabled(new FakeSettings(['infection.cli' => new BoolValue(false)])),
             'InfectionSecret must be disabled when infection.cli is false',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenKeyPresentButEmpty(): void
-    {
-        self::assertSame(
-            true,
-            (new InfectionSecret())->enabled(new FakeConfig(['infection.cli' => []])),
-            'InfectionSecret must be enabled when infection.cli key is present but list is empty',
-        );
-    }
-
-    #[Test]
-    public function enabledWhenValueIsNotParsableAsBoolean(): void
-    {
-        self::assertSame(
-            true,
-            (new InfectionSecret())->enabled(new FakeConfig(['infection.cli' => ['maybe']])),
-            'InfectionSecret must be enabled when infection.cli value cannot be parsed as boolean',
         );
     }
 

--- a/tests/Unit/Settings/Value/BoolSettingTest.php
+++ b/tests/Unit/Settings/Value/BoolSettingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Settings\Value;
+
+use Haspadar\Sheriff\Settings\Value\BoolSetting;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class BoolSettingTest extends TestCase
+{
+    #[Test]
+    public function readsBoolValueWhenKeyPresent(): void
+    {
+        self::assertFalse(
+            (new BoolSetting(
+                new FakeSettings(['flag' => new BoolValue(false)]),
+                'flag',
+                true,
+            ))->raw(),
+            'BoolSetting must unwrap a BoolValue payload regardless of the default',
+        );
+    }
+
+    #[Test]
+    public function fallsBackToDefaultWhenKeyAbsent(): void
+    {
+        self::assertTrue(
+            (new BoolSetting(
+                new FakeSettings([]),
+                'flag',
+                true,
+            ))->raw(),
+            'BoolSetting must return the default when the key is missing',
+        );
+    }
+
+    #[Test]
+    public function fallsBackToDefaultWhenValueIsNotBoolValue(): void
+    {
+        self::assertTrue(
+            (new BoolSetting(
+                new FakeSettings(['flag' => new StringValue('false')]),
+                'flag',
+                true,
+            ))->raw(),
+            'BoolSetting must return the default when the stored value is not a BoolValue',
+        );
+    }
+}


### PR DESCRIPTION
- Switched `EnvVar` and `Secret` interfaces from `Config` to `Settings`
- Rewrote `SonarEnvVar`, `CodecovSecret`, `InfectionSecret` to read typed `BoolValue` payloads instead of `Config::list()` boolean coercion
- Updated `bin/sheriff-tokens-check` to build the patched `Settings` stack (`DefaultSettings` + `YamlPatches` + `ComposerSettings`) like `bin/sheriff-sync` does
- Rewrote unit tests around `FakeSettings` + `BoolValue` and dropped permissive-coercion cases (string `"false"`, `"maybe"`, empty list) since the new contract is strict

Part of #653

**Breaking changes:**
- `EnvVar::enabled()` and `Secret::enabled()` now take a `Settings` instead of a `Config`. Custom implementations must be updated accordingly.
- The boolean toggles no longer accept string aliases like `"yes"`, `"on"`, `"1"`, or `"maybe"`. Each `*.cli` / `sonar.cloud` key must be a YAML boolean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration can now be initialized via a YAML-patch file (.sheriff.yaml), with defaults applied when absent.

* **Refactor**
  * Internal configuration handling migrated to a unified settings-driven model for more consistent feature toggles and checks.

* **Tests**
  * Test suite updated to reflect the new settings API and boolean-setting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->