### PR TITLE
Make AppendTree Recursive for Nested List Leaves

### DIFF
--- a/src/Settings/Patch/AppendTree.php
+++ b/src/Settings/Patch/AppendTree.php
@@ -5,27 +5,41 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Settings\Patch;
 
 use Haspadar\Sheriff\Settings\Patch;
+use Haspadar\Sheriff\Settings\Value\AppendedTree;
+use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
 use Haspadar\Sheriff\Settings\Value\Value;
 use Override;
 use TypeError;
 
 /**
- * Adds new keys to a tree configuration value without overwriting existing entries.
+ * Deep-appends a tree of extra entries onto a base tree.
+ *
+ * Walks both trees in parallel: missing keys are added as-is, matching trees
+ * recurse, matching lists are concatenated. Any other shape collision raises a
+ * SheriffException so misconfigured `.sheriff.yaml` files fail loudly.
+ *
+ * An empty ListValue base is accepted as an empty tree because the YAML
+ * default `key: {}` collapses to `[]` in PHP/Symfony, and RawValue wraps
+ * it as ListValue rather than TreeValue.
  *
  * Example:
  *
  *     new AppendTree('phpstan.parameters', new TreeValue([
- *         'reportUnmatchedIgnoredErrors' => new BoolValue(true),
+ *         'haspadar' => new TreeValue([
+ *             'afferentCoupling' => new TreeValue([
+ *                 'excludedClasses' => new ListValue([new StringValue('\\App\\My')]),
+ *             ]),
+ *         ]),
  *     ]));
  */
 final readonly class AppendTree implements Patch
 {
     /**
-     * Initializes with the target key and the entries to add to the base tree.
+     * Initializes with the target key and the entries to merge into the base tree.
      *
-     * @param string $key Configuration key whose tree value receives the extra entries
-     * @param TreeValue $extra Entries added to the base tree only when their key is absent
+     * @param string $key Configuration key whose tree value is extended
+     * @param TreeValue $extra Tree whose entries add new keys or extend matching list/tree leaves
      */
     public function __construct(private string $key, private TreeValue $extra) {}
 
@@ -38,18 +52,16 @@ final readonly class AppendTree implements Patch
     #[Override]
     public function applied(Value $base): Value
     {
+        if ($base instanceof ListValue && $base->children === []) {
+            return $this->extra;
+        }
+
         if (!$base instanceof TreeValue) {
             throw new TypeError(
                 sprintf('AppendTree expects TreeValue at "%s"', $this->key),
             );
         }
 
-        $entries = $base->entries;
-
-        foreach ($this->extra->entries as $key => $value) {
-            $entries[$key] ??= $value;
-        }
-
-        return new TreeValue($entries);
+        return (new AppendedTree($base, $this->extra))->value();
     }
 }

--- a/src/Settings/Value/AppendedTree.php
+++ b/src/Settings/Value/AppendedTree.php
@@ -22,12 +22,17 @@ use Haspadar\Sheriff\SheriffException;
 final readonly class AppendedTree
 {
     /**
-     * Initializes with the base tree and the tree carrying the appended entries.
+     * Initializes with the base tree, the tree carrying the appended entries, and the parent path used in error messages.
      *
      * @param TreeValue $base Tree whose entries are kept untouched when the extra leaves them out
      * @param TreeValue $extra Tree whose entries either add new keys or extend matching list/tree leaves
+     * @param string $path Dot-separated parent path threaded through nested merges for diagnostics; empty at the top level
      */
-    public function __construct(private TreeValue $base, private TreeValue $extra) {}
+    public function __construct(
+        private TreeValue $base,
+        private TreeValue $extra,
+        private string $path = '',
+    ) {}
 
     /**
      * Returns the merged tree with extra entries appended into matching leaves.
@@ -55,7 +60,7 @@ final readonly class AppendedTree
     private function resolved(string $key, Value $first, Value $second): Value
     {
         if ($first instanceof TreeValue && $second instanceof TreeValue) {
-            return (new self($first, $second))->value();
+            return (new self($first, $second, $this->qualified($key)))->value();
         }
 
         if ($first instanceof ListValue && $second instanceof ListValue) {
@@ -65,10 +70,18 @@ final readonly class AppendedTree
         throw new SheriffException(
             sprintf(
                 'AppendedTree cannot merge "%s": base is %s but extra is %s; expected matching trees or lists',
-                $key,
+                $this->qualified($key),
                 get_debug_type($first),
                 get_debug_type($second),
             ),
         );
+    }
+
+    /** Joins the current path with the given key for a fully-qualified diagnostic. */
+    private function qualified(string $key): string
+    {
+        return $this->path === ''
+            ? $key
+            : sprintf('%s.%s', $this->path, $key);
     }
 }

--- a/src/Settings/Value/AppendedTree.php
+++ b/src/Settings/Value/AppendedTree.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Settings\Value;
+
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * Tree produced by deep-appending an extra tree onto a base tree.
+ *
+ * For every key in the extra tree:
+ *   * if the base lacks the key, the extra value is added as-is;
+ *   * if both sides hold a TreeValue, the merge recurses;
+ *   * if both sides hold a ListValue, the extra entries are appended after the base entries;
+ *   * any other type collision is a configuration error.
+ *
+ * Example:
+ *
+ *     (new AppendedTree($base, $extra))->value();
+ */
+final readonly class AppendedTree
+{
+    /**
+     * Initializes with the base tree and the tree carrying the appended entries.
+     *
+     * @param TreeValue $base Tree whose entries are kept untouched when the extra leaves them out
+     * @param TreeValue $extra Tree whose entries either add new keys or extend matching list/tree leaves
+     */
+    public function __construct(private TreeValue $base, private TreeValue $extra) {}
+
+    /**
+     * Returns the merged tree with extra entries appended into matching leaves.
+     *
+     * @throws SheriffException
+     */
+    public function value(): TreeValue
+    {
+        $entries = $this->base->entries;
+
+        foreach ($this->extra->entries as $key => $value) {
+            $entries[$key] = array_key_exists($key, $entries)
+                ? $this->resolved($key, $entries[$key], $value)
+                : $value;
+        }
+
+        return new TreeValue($entries);
+    }
+
+    /**
+     * Combines two values that share the same key during the merge.
+     *
+     * @throws SheriffException
+     */
+    private function resolved(string $key, Value $first, Value $second): Value
+    {
+        if ($first instanceof TreeValue && $second instanceof TreeValue) {
+            return (new self($first, $second))->value();
+        }
+
+        if ($first instanceof ListValue && $second instanceof ListValue) {
+            return new ListValue([...$first->children, ...$second->children]);
+        }
+
+        throw new SheriffException(
+            sprintf(
+                'AppendedTree cannot merge "%s": base is %s but extra is %s; expected matching trees or lists',
+                $key,
+                get_debug_type($first),
+                get_debug_type($second),
+            ),
+        );
+    }
+}

--- a/tests/Unit/Settings/Patch/AppendTreeTest.php
+++ b/tests/Unit/Settings/Patch/AppendTreeTest.php
@@ -147,6 +147,7 @@ final class AppendTreeTest extends TestCase
     public function rejectsScalarCollisionBetweenBaseAndExtra(): void
     {
         $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('AppendedTree cannot merge "flag"');
 
         (new AppendTree(
             'phpstan.parameters',

--- a/tests/Unit/Settings/Patch/AppendTreeTest.php
+++ b/tests/Unit/Settings/Patch/AppendTreeTest.php
@@ -7,7 +7,10 @@ namespace Haspadar\Sheriff\Tests\Unit\Settings\Patch;
 use Haspadar\Sheriff\Settings\Patch\AppendTree;
 use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TypeError;
@@ -27,29 +30,82 @@ final class AppendTreeTest extends TestCase
     #[Test]
     public function addsKeyAbsentInBase(): void
     {
-        $base = new TreeValue(['existing' => new IntValue(1)]);
-        $extra = new TreeValue(['added' => new BoolValue(true)]);
-
         self::assertEquals(
             new TreeValue([
                 'existing' => new IntValue(1),
                 'added' => new BoolValue(true),
             ]),
-            (new AppendTree('phpstan.parameters', $extra))->applied($base),
+            (new AppendTree(
+                'phpstan.parameters',
+                new TreeValue(['added' => new BoolValue(true)]),
+            ))->applied(new TreeValue(['existing' => new IntValue(1)])),
             'AppendTree must add a key from the extra tree when it is absent in the base',
         );
     }
 
     #[Test]
-    public function keepsExistingKeyWhenAlsoPresentInExtra(): void
+    public function appendsListEntriesAtNestedLeaf(): void
     {
-        $base = new TreeValue(['flag' => new BoolValue(false)]);
-        $extra = new TreeValue(['flag' => new BoolValue(true)]);
-
         self::assertEquals(
-            new TreeValue(['flag' => new BoolValue(false)]),
-            (new AppendTree('phpstan.parameters', $extra))->applied($base),
-            'AppendTree must keep the base entry when the same key is present in the extra tree',
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'excludedClasses' => new ListValue([
+                        new StringValue('A'),
+                        new StringValue('B'),
+                    ]),
+                ]),
+            ]),
+            (new AppendTree(
+                'phpstan.parameters',
+                new TreeValue([
+                    'haspadar' => new TreeValue([
+                        'excludedClasses' => new ListValue([new StringValue('B')]),
+                    ]),
+                ]),
+            ))->applied(new TreeValue([
+                'haspadar' => new TreeValue([
+                    'excludedClasses' => new ListValue([new StringValue('A')]),
+                ]),
+            ])),
+            'AppendTree must walk through nested trees and concatenate matching list leaves',
+        );
+    }
+
+    #[Test]
+    public function appendsThroughThreeLevelsAsInIssueBody(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'excludedClasses' => new ListValue([
+                            new StringValue('\\Existing\\E'),
+                            new StringValue('\\App\\MyException'),
+                        ]),
+                    ]),
+                ]),
+            ]),
+            (new AppendTree(
+                'phpstan.parameters',
+                new TreeValue([
+                    'haspadar' => new TreeValue([
+                        'afferentCoupling' => new TreeValue([
+                            'excludedClasses' => new ListValue([
+                                new StringValue('\\App\\MyException'),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ))->applied(new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'excludedClasses' => new ListValue([
+                            new StringValue('\\Existing\\E'),
+                        ]),
+                    ]),
+                ]),
+            ])),
+            'AppendTree must reach the list leaf three levels deep when the user appends nested phpstan parameters',
         );
     }
 
@@ -66,11 +122,35 @@ final class AppendTreeTest extends TestCase
     }
 
     #[Test]
+    public function acceptsEmptyListBaseAsEmptyTree(): void
+    {
+        self::assertEquals(
+            new TreeValue(['added' => new BoolValue(true)]),
+            (new AppendTree(
+                'envs',
+                new TreeValue(['added' => new BoolValue(true)]),
+            ))->applied(new ListValue([])),
+            'AppendTree must accept an empty ListValue base because YAML `{}` parses as `[]`',
+        );
+    }
+
+    #[Test]
     public function rejectsBaseValueThatIsNotATree(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('phpstan.parameters');
 
         (new AppendTree('phpstan.parameters', new TreeValue([])))->applied(new IntValue(8));
+    }
+
+    #[Test]
+    public function rejectsScalarCollisionBetweenBaseAndExtra(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new AppendTree(
+            'phpstan.parameters',
+            new TreeValue(['flag' => new BoolValue(true)]),
+        ))->applied(new TreeValue(['flag' => new BoolValue(false)]));
     }
 }

--- a/tests/Unit/Settings/Value/AppendedTreeTest.php
+++ b/tests/Unit/Settings/Value/AppendedTreeTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Settings\Value;
+
+use Haspadar\Sheriff\Settings\Value\AppendedTree;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AppendedTreeTest extends TestCase
+{
+    #[Test]
+    public function copiesBaseEntriesWhenExtraIsEmpty(): void
+    {
+        $base = new TreeValue(['a' => new IntValue(1)]);
+
+        self::assertEquals(
+            $base,
+            (new AppendedTree($base, new TreeValue([])))->value(),
+            'AppendedTree must return the base tree when extra is empty',
+        );
+    }
+
+    #[Test]
+    public function copiesExtraEntriesWhenBaseIsEmpty(): void
+    {
+        $extra = new TreeValue(['a' => new IntValue(1)]);
+
+        self::assertEquals(
+            $extra,
+            (new AppendedTree(new TreeValue([]), $extra))->value(),
+            'AppendedTree must return the extra tree when base is empty',
+        );
+    }
+
+    #[Test]
+    public function recursesIntoNestedTrees(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'kept' => new BoolValue(true),
+                    'added' => new IntValue(42),
+                ]),
+            ]),
+            (new AppendedTree(
+                new TreeValue([
+                    'haspadar' => new TreeValue(['kept' => new BoolValue(true)]),
+                ]),
+                new TreeValue([
+                    'haspadar' => new TreeValue(['added' => new IntValue(42)]),
+                ]),
+            ))->value(),
+            'AppendedTree must merge matching nested trees instead of replacing them',
+        );
+    }
+
+    #[Test]
+    public function concatenatesMatchingListLeaves(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'excludedClasses' => new ListValue([
+                    new StringValue('A'),
+                    new StringValue('B'),
+                ]),
+            ]),
+            (new AppendedTree(
+                new TreeValue([
+                    'excludedClasses' => new ListValue([new StringValue('A')]),
+                ]),
+                new TreeValue([
+                    'excludedClasses' => new ListValue([new StringValue('B')]),
+                ]),
+            ))->value(),
+            'AppendedTree must concatenate matching list leaves in append order',
+        );
+    }
+
+    #[Test]
+    public function rejectsScalarCollision(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new AppendedTree(
+            new TreeValue(['flag' => new BoolValue(false)]),
+            new TreeValue(['flag' => new BoolValue(true)]),
+        ))->value();
+    }
+
+    #[Test]
+    public function rejectsTreeAndListCollision(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new AppendedTree(
+            new TreeValue(['x' => new TreeValue([])]),
+            new TreeValue(['x' => new ListValue([])]),
+        ))->value();
+    }
+}

--- a/tests/Unit/Settings/Value/AppendedTreeTest.php
+++ b/tests/Unit/Settings/Value/AppendedTreeTest.php
@@ -105,4 +105,28 @@ final class AppendedTreeTest extends TestCase
             new TreeValue(['x' => new ListValue([])]),
         ))->value();
     }
+
+    #[Test]
+    public function reportsFullDottedPathOnNestedCollision(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('AppendedTree cannot merge "haspadar.afferentCoupling.flag"');
+
+        (new AppendedTree(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'flag' => new BoolValue(false),
+                    ]),
+                ]),
+            ]),
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'flag' => new BoolValue(true),
+                    ]),
+                ]),
+            ]),
+        ))->value();
+    }
 }


### PR DESCRIPTION
- Added `Settings\Value\AppendedTree` value object that recursively merges an extra tree onto a base tree: missing keys are added, matching trees recurse, matching lists are concatenated, any other shape collision is rejected with `SheriffException`
- Switched `Settings\Patch\AppendTree` to use `AppendedTree` so `append:` in `.sheriff.yaml` reaches list leaves several levels deep (e.g. `phpstan.parameters.haspadar.afferentCoupling.excludedClasses`) instead of dropping deeply-nested additions on the floor
- Replaced the obsolete "keep base on collision" test with coverage of the new recursive behaviour and added a 3-level test mirroring the original issue body
- Added `AppendedTreeTest` covering empty cases, recursion, list concat, and collision errors

Part of #653

**Breaking changes:**
- Previously, `append:` with a key already present in the base would silently keep the base value. Now matching scalars/bools throw `SheriffException`, matching trees recurse, matching lists concatenate. Any `.sheriff.yaml` that redundantly listed an existing scalar under `append:` will now error — the new behaviour is the one the original issue specifies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured configuration tree merging logic for improved handling of nested structures and list concatenation.

* **Tests**
  * Added comprehensive test coverage for tree merging behavior, including edge cases for empty structures and collision detection with enhanced error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->