### PR TITLE
Render phpstan.parameters as a TreeValue Through NeonTree

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -18,8 +18,12 @@ override:
     - "../../bin/sheriff-fix"
     - "../../bin/sheriff-sync"
     - "../../bin/sheriff-tokens-check"
-  phpstan.afferent_coupling.excluded_classes: ['\Haspadar\Sheriff\SheriffException']
 
 append:
   infra.exclude:
     - templates
+  phpstan.parameters:
+    haspadar:
+      afferentCoupling:
+        excludedClasses:
+          - '\Haspadar\Sheriff\SheriffException'

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -91,12 +91,22 @@ defaults:
   phpmetrics.structure.max_methods_per_class: 10
 
   phpstan.cli: true
-  phpstan.level: 9
   phpstan.memory: "1G"
-  phpstan.checked_exceptions: ['\Throwable']
   phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
-  phpstan.afferent_coupling.ignore_interfaces: true
-  phpstan.afferent_coupling.excluded_classes: []
+  phpstan.parameters:
+    level: 9
+    errorFormat: table
+    reportUnmatchedIgnoredErrors: true
+    checkUninitializedProperties: true
+    checkClassCaseSensitivity: true
+    checkDynamicProperties: true
+    exceptions:
+      checkedExceptionClasses:
+        - '\Throwable'
+    haspadar:
+      afferentCoupling:
+        ignoreInterfaces: true
+        excludedClasses: []
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -3,22 +3,18 @@ includes:
     - ../../vendor/haspadar/phpstan-rules/rules.neon
 
 parameters:
-    level: 9
-
     paths:
         - ../../src
 
+    level: 9
     errorFormat: table
     reportUnmatchedIgnoredErrors: true
-
     checkUninitializedProperties: true
     checkClassCaseSensitivity: true
     checkDynamicProperties: true
-
     exceptions:
         checkedExceptionClasses:
             - \Throwable
-
     haspadar:
         afferentCoupling:
             ignoreInterfaces: true

--- a/src/Chain/Render/Neon/NeonBareString.php
+++ b/src/Chain/Render/Neon/NeonBareString.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Neon;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Override;
+
+/**
+ * Renders a StringValue as a neon bare literal when its content is safe to write unquoted.
+ *
+ * The neon spec lets identifiers, single-segment paths and a few common literals
+ * survive without quotes. Anything with whitespace, control characters or neon
+ * structural characters falls back to the quoted form via NeonString.
+ *
+ * Example:
+ *
+ *     (new NeonBareString(new StringValue('table')))->rendered(); // table
+ *     (new NeonBareString(new StringValue('a b')))->rendered(); // "a b"
+ *     (new NeonBareString(new StringValue('\\Throwable')))->rendered(); // \Throwable
+ */
+final readonly class NeonBareString implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param StringValue $value String payload to render as a bare literal when possible
+     */
+    public function __construct(private StringValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return $this->bareSafe()
+            ? $this->value->raw
+            : (new NeonString($this->value))->rendered();
+    }
+
+    /** Determines whether the raw payload can be emitted without surrounding quotes. */
+    private function bareSafe(): bool
+    {
+        $raw = $this->value->raw;
+
+        return $raw !== ''
+            && !in_array($raw, ['true', 'false', 'null', 'yes', 'no', 'on', 'off'], true)
+            && preg_match('/[\s"\'`#:,\[\]{}()]/u', $raw) !== 1
+            && preg_match('/[\x00-\x1F\x7F]/', $raw) !== 1
+            && !in_array($raw[0], ['-', '?', '@', '%', '!', '&', '*', '|', '>', '<', '='], true)
+            && !is_numeric($raw);
+    }
+}

--- a/src/Chain/Render/Neon/NeonBlockList.php
+++ b/src/Chain/Render/Neon/NeonBlockList.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Neon;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Override;
+use TypeError;
+
+/**
+ * Renders a ListValue as a neon block-style sequence at the given indent.
+ *
+ * Empty lists collapse to `[]`. Items render through NeonOf and sit at
+ * `depth + 1` indentation, prefixed with `- `.
+ *
+ * Example:
+ *
+ *     (new NeonBlockList(new ListValue([new StringValue('Foo')]), 1))->rendered();
+ *     // \n - Foo
+ */
+final readonly class NeonBlockList implements Rendered
+{
+    private const string INDENT = '    ';
+
+    /**
+     * Initializes with the list to render and the depth at which rendering starts.
+     *
+     * @param ListValue $value List payload rendered as a neon block sequence
+     * @param int $depth Indent level applied to each item
+     */
+    public function __construct(private ListValue $value, private int $depth = 0) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        if ($this->value->children === []) {
+            return '[]';
+        }
+
+        $prefix = str_repeat(self::INDENT, $this->depth + 1);
+        $lines = array_map(
+            fn(Value $child): string => sprintf('%s- %s', $prefix, $this->itemFor($child)),
+            $this->value->children,
+        );
+
+        return sprintf("\n%s", implode("\n", $lines));
+    }
+
+    /**
+     * Renders a single list item, preferring bare strings inside block lists.
+     *
+     * @throws TypeError
+     */
+    private function itemFor(Value $child): string
+    {
+        return $child instanceof StringValue
+            ? (new NeonBareString($child))->rendered()
+            : (new NeonOf($child))->renderer()->rendered();
+    }
+}

--- a/src/Chain/Render/Neon/NeonTree.php
+++ b/src/Chain/Render/Neon/NeonTree.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Chain\Render\Neon;
 
 use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
 use Haspadar\Sheriff\Settings\Value\Value;
 use Override;
@@ -64,12 +66,15 @@ final readonly class NeonTree implements Rendered
      */
     private function lineFor(Value $child): string
     {
-        if ($child instanceof TreeValue) {
-            return $child->entries === []
+        return match (true) {
+            $child instanceof TreeValue => $child->entries === []
                 ? ' {}'
-                : (new self($child, $this->depth + 1))->rendered();
-        }
-
-        return sprintf(' %s', (new NeonOf($child))->renderer()->rendered());
+                : (new self($child, $this->depth + 1))->rendered(),
+            $child instanceof ListValue => $child->children === []
+                ? ' []'
+                : (new NeonBlockList($child, $this->depth + 1))->rendered(),
+            $child instanceof StringValue => sprintf(' %s', (new NeonBareString($child))->rendered()),
+            default => sprintf(' %s', (new NeonOf($child))->renderer()->rendered()),
+        };
     }
 }

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -91,12 +91,22 @@ defaults:
   phpmetrics.structure.max_methods_per_class: 10
 
   phpstan.cli: true
-  phpstan.level: 9
   phpstan.memory: "1G"
-  phpstan.checked_exceptions: ['\Throwable']
   phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
-  phpstan.afferent_coupling.ignore_interfaces: true
-  phpstan.afferent_coupling.excluded_classes: []
+  phpstan.parameters:
+    level: 9
+    errorFormat: table
+    reportUnmatchedIgnoredErrors: true
+    checkUninitializedProperties: true
+    checkClassCaseSensitivity: true
+    checkDynamicProperties: true
+    exceptions:
+      checkedExceptionClasses:
+        - '\Throwable'
+    haspadar:
+      afferentCoupling:
+        ignoreInterfaces: true
+        excludedClasses: []
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/templates/always/.sheriff/phpstan/phpstan.neon
+++ b/templates/always/.sheriff/phpstan/phpstan.neon
@@ -2,23 +2,8 @@ includes:
 {% ListText(phpstan.neon_includes)|EachFormatted("    - %s")|Joined("\n") %}
 
 parameters:
-    level: {% IntText(phpstan.level) %}
-
+    # paths sit outside phpstan.parameters because they are derived from php.src
+    # rather than declared as a static tree leaf.
     paths:
 {% ListText(php.src)|EachFormatted("../../%s")|EachFormatted("        - %s")|Joined("\n") %}
-
-    errorFormat: table
-    reportUnmatchedIgnoredErrors: true
-
-    checkUninitializedProperties: true
-    checkClassCaseSensitivity: true
-    checkDynamicProperties: true
-
-    exceptions:
-        checkedExceptionClasses:
-{% ListText(phpstan.checked_exceptions)|EachFormatted("            - %s")|Joined("\n") %}
-
-    haspadar:
-        afferentCoupling:
-            ignoreInterfaces: {% BoolText(phpstan.afferent_coupling.ignore_interfaces) %}
-{% ListText(phpstan.afferent_coupling.excluded_classes)|EachFormatted("                - %s")|Joined("\n")|WhenNotEmpty("            excludedClasses:\n%s") %}
+{% NeonTree(phpstan.parameters) %}

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -32,10 +32,10 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('phpstan.neon', 'level: {% IntText(phpstan.level) %}'),
+                new TextFile('phpmd.xml', 'cyclomatic: {% IntText(phpmd.cyclomatic) %}'),
                 new DefaultSettings(),
             ),
-            new HasFileContents('level: 9'),
+            new HasFileContents('cyclomatic: 10'),
             'TemplateFile must render IntText key from DefaultSettings',
         );
     }
@@ -88,6 +88,34 @@ final class TemplateFileTest extends TestCase
             ),
             new HasFileContents('cloud: true'),
             'TemplateFile must render BoolText key from DefaultSettings',
+        );
+    }
+
+    #[Test]
+    public function rendersPhpstanParametersTreeAsNeonBlock(): void
+    {
+        self::assertThat(
+            new TemplateFile(
+                new TextFile('phpstan.neon', '{% NeonTree(phpstan.parameters) %}'),
+                new DefaultSettings(),
+            ),
+            new HasFileContents(
+                "\n"
+                . "    level: 9\n"
+                . "    errorFormat: table\n"
+                . "    reportUnmatchedIgnoredErrors: true\n"
+                . "    checkUninitializedProperties: true\n"
+                . "    checkClassCaseSensitivity: true\n"
+                . "    checkDynamicProperties: true\n"
+                . "    exceptions:\n"
+                . "        checkedExceptionClasses:\n"
+                . "            - \\Throwable\n"
+                . "    haspadar:\n"
+                . "        afferentCoupling:\n"
+                . "            ignoreInterfaces: true\n"
+                . "            excludedClasses: []",
+            ),
+            'TemplateFile must render the phpstan.parameters TreeValue as a nested neon block, including bare strings and block-style lists',
         );
     }
 }

--- a/tests/Unit/Chain/Render/Neon/NeonBareStringTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonBareStringTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Sheriff\Chain\Render\Neon\NeonBareString;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonBareStringTest extends TestCase
+{
+    /** @return iterable<string, array{string, string}> */
+    public static function safeStrings(): iterable
+    {
+        yield 'identifier' => ['table', 'table'];
+        yield 'leading-backslash class' => ['\\Throwable', '\\Throwable'];
+        yield 'fully qualified class' => ['\\Haspadar\\Sheriff\\SheriffException', '\\Haspadar\\Sheriff\\SheriffException'];
+        yield 'dotted path' => ['1G.alpha', '1G.alpha'];
+    }
+
+    #[Test]
+    #[DataProvider('safeStrings')]
+    public function rendersSafePayloadWithoutQuotes(string $raw, string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new NeonBareString(new StringValue($raw)))->rendered(),
+            'NeonBareString must emit safe payloads without surrounding quotes',
+        );
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function unsafeStrings(): iterable
+    {
+        yield 'whitespace' => ['error format', '"error format"'];
+        yield 'colon' => ['key:value', '"key:value"'];
+        yield 'pure number' => ['42', '"42"'];
+        yield 'reserved literal' => ['true', '"true"'];
+        yield 'leading dash' => ['-flag', '"-flag"'];
+        yield 'embedded quote' => ['a"b', '"a\\"b"'];
+        yield 'empty' => ['', '""'];
+    }
+
+    #[Test]
+    #[DataProvider('unsafeStrings')]
+    public function fallsBackToQuotedFormForUnsafePayload(string $raw, string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new NeonBareString(new StringValue($raw)))->rendered(),
+            'NeonBareString must fall back to NeonString quoting when the payload is not safe to emit bare',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Neon/NeonBlockListTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonBlockListTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Neon;
+
+use Haspadar\Sheriff\Chain\Render\Neon\NeonBlockList;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NeonBlockListTest extends TestCase
+{
+    #[Test]
+    public function rendersEmptyListAsFlowSequence(): void
+    {
+        self::assertSame(
+            '[]',
+            (new NeonBlockList(new ListValue([])))->rendered(),
+            'NeonBlockList must collapse an empty list to the neon empty-flow sequence',
+        );
+    }
+
+    #[Test]
+    public function rendersStringEntriesBareWithLeadingNewlineAndDepthIndent(): void
+    {
+        self::assertSame(
+            "\n        - \\Throwable\n        - \\App\\My",
+            (new NeonBlockList(
+                new ListValue([
+                    new StringValue('\\Throwable'),
+                    new StringValue('\\App\\My'),
+                ]),
+                1,
+            ))->rendered(),
+            'NeonBlockList must emit one item per line, indented by depth+1, with bare strings when safe',
+        );
+    }
+
+    #[Test]
+    public function rendersScalarMixWithMatchingNeonRenderers(): void
+    {
+        self::assertSame(
+            "\n    - true\n    - 8\n    - bare",
+            (new NeonBlockList(new ListValue([
+                new BoolValue(true),
+                new IntValue(8),
+                new StringValue('bare'),
+            ])))->rendered(),
+            'NeonBlockList must render each entry through its matching neon renderer',
+        );
+    }
+}


### PR DESCRIPTION
- Added `Chain\Render\Neon\NeonBareString` source op rendering safe `StringValue` payloads without surrounding quotes; falls back to `NeonString` for anything containing whitespace, neon structural characters, control characters, leading neon flag characters, reserved literals, or numeric strings
- Added `Chain\Render\Neon\NeonBlockList` source op rendering `ListValue` as a block-style sequence (`- item`) at the given depth, used by `NeonTree` for list-leaf entries
- Updated `Chain\Render\Neon\NeonTree::lineFor()` to dispatch `ListValue` to `NeonBlockList` and `StringValue` to `NeonBareString` so nested neon trees render in the hand-written style instead of the legacy `NeonList` flow / `NeonString` quoted form
- Replaced the flat `phpstan.level`, `phpstan.checked_exceptions`, `phpstan.afferent_coupling.*` defaults with one nested `phpstan.parameters` `TreeValue` carrying every neon-bound parameter (`level`, `errorFormat`, the boolean strict-checks, `exceptions.checkedExceptionClasses`, `haspadar.afferentCoupling.*`)
- Switched `templates/always/.sheriff/phpstan/phpstan.neon` from per-key markers to a single `{% NeonTree(phpstan.parameters) %}`; `paths` stays hand-rendered because it is derived from `php.src` rather than declared as a static tree leaf
- Reworked the local `.sheriff.yaml` to extend `phpstan.parameters.haspadar.afferentCoupling.excludedClasses` through nested `append:`, exercising the recursive `AppendTree` merged in #716
- Added unit tests for the two new neon ops and an integration test that locks in the full `phpstan.parameters` neon block produced from `DefaultSettings`
- Switched the existing `IntText` integration canary off the removed `phpstan.level` key onto `phpmd.cyclomatic`

Closes #653

**Breaking changes:**
- `phpstan.level`, `phpstan.checked_exceptions`, `phpstan.afferent_coupling.ignore_interfaces`, and `phpstan.afferent_coupling.excluded_classes` no longer exist as flat settings keys. Existing `.sheriff.yaml` overrides must move under the nested `phpstan.parameters` tree (e.g. `override: phpstan.parameters: level: 8`, `append: phpstan.parameters: haspadar: afferentCoupling: excludedClasses: ['\App\Foo']`).
- The benefit: any other phpstan parameter (e.g. `phpstan.parameters.ignoreErrors`, custom `haspadar.maxMethodLength`, etc.) is now reachable through the same `override:`/`append:`/`remove:` pipeline without changing Sheriff itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for rendering unquoted NEON bare strings with automatic fallback to quoted form for unsafe values
  * Introduced block list rendering for multi-line NEON configuration values

* **Refactor**
  * Reorganized PHPStan configuration structure to use nested parameter blocks for improved clarity
  * Enhanced rendering logic with explicit type-based handling

* **Chores**
  * Updated configuration templates with restructured PHPStan parameter format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->