### PR TITLE
Make RemoveTree Recursive for Nested List Leaves and Tree Keys

### DIFF
--- a/src/Settings/Patch/RemovePatches.php
+++ b/src/Settings/Patch/RemovePatches.php
@@ -7,21 +7,28 @@ namespace Haspadar\Sheriff\Settings\Patch;
 use Haspadar\Sheriff\Settings\Patch;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\RawValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
 use Haspadar\Sheriff\SheriffException;
 use TypeError;
 
 /**
  * Translates the `remove` section of `.sheriff.yaml` into Patch instances.
  *
- * Yaml input always produces RemoveList. RemoveTree (drop named keys from a
- * tree) is constructed programmatically because the parser cannot tell a
- * list of items from a list of key names without knowing the configured
- * key's default type.
+ * A list payload becomes a `RemoveList` that drops elements from the base
+ * list at the same key. A mapping payload becomes a `RemoveTree` whose
+ * recursive walk filters nested trees and lists in lockstep with the base.
  *
  * Example:
  *
  *     (new RemovePatches([
  *         'phpstan.checked_exceptions' => ['\\Throwable'],
+ *         'phpstan.parameters' => [
+ *             'haspadar' => [
+ *                 'afferentCoupling' => [
+ *                     'excludedClasses' => ['\\App\\Foo'],
+ *                 ],
+ *             ],
+ *         ],
  *     ]))->patches();
  */
 final readonly class RemovePatches
@@ -52,7 +59,7 @@ final readonly class RemovePatches
     }
 
     /**
-     * Builds a RemoveList patch from a yaml list payload.
+     * Builds the matching Remove patch from the runtime type of the payload.
      *
      * @throws SheriffException|TypeError
      */
@@ -60,12 +67,12 @@ final readonly class RemovePatches
     {
         $value = (new RawValue($raw))->value();
 
-        if (!$value instanceof ListValue) {
-            throw new SheriffException(
-                sprintf('Remove "%s" expects a list of items to drop', $key),
-            );
-        }
-
-        return new RemoveList($key, $value);
+        return match (true) {
+            $value instanceof ListValue => new RemoveList($key, $value),
+            $value instanceof TreeValue => new RemoveTree($key, $value),
+            default => throw new SheriffException(
+                sprintf('Remove "%s" expects a list or mapping', $key),
+            ),
+        };
     }
 }

--- a/src/Settings/Patch/RemoveTree.php
+++ b/src/Settings/Patch/RemoveTree.php
@@ -5,27 +5,43 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Settings\Patch;
 
 use Haspadar\Sheriff\Settings\Patch;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\RemovedTree;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
 use Haspadar\Sheriff\Settings\Value\Value;
 use Override;
 use TypeError;
 
 /**
- * Removes the named keys from a tree configuration value at the given key.
+ * Deep-removes entries from a tree configuration value.
+ *
+ * Walks the spec in parallel with the base tree: matching subtrees recurse,
+ * a list-of-strings spec drops elements from a base list (or keys from a
+ * base tree). Missing keys are tolerated so the patch stays idempotent.
+ *
+ * An empty ListValue base is accepted as an empty tree because the YAML
+ * default `key: {}` collapses to `[]` in PHP/Symfony, and RawValue wraps
+ * it as ListValue rather than TreeValue.
  *
  * Example:
  *
- *     new RemoveTree('phpstan.parameters', ['reportUnmatchedIgnoredErrors']);
+ *     new RemoveTree('phpstan.parameters', new TreeValue([
+ *         'haspadar' => new TreeValue([
+ *             'afferentCoupling' => new TreeValue([
+ *                 'excludedClasses' => new ListValue([new StringValue('\\App\\Foo')]),
+ *             ]),
+ *         ]),
+ *     ]));
  */
 final readonly class RemoveTree implements Patch
 {
     /**
-     * Initializes with the target key and the names of entries to drop.
+     * Initializes with the target key and the spec describing what to remove.
      *
-     * @param string $key Configuration key whose tree value loses the named entries
-     * @param list<string> $keys Names of entries removed from the base tree when present
+     * @param string $key Configuration key whose tree value is filtered down
+     * @param TreeValue $spec Tree describing which subtrees to recurse into and which leaves to drop
      */
-    public function __construct(private string $key, private array $keys) {}
+    public function __construct(private string $key, private TreeValue $spec) {}
 
     #[Override]
     public function key(): string
@@ -36,18 +52,16 @@ final readonly class RemoveTree implements Patch
     #[Override]
     public function applied(Value $base): Value
     {
+        if ($base instanceof ListValue && $base->children === []) {
+            return new TreeValue([]);
+        }
+
         if (!$base instanceof TreeValue) {
             throw new TypeError(
                 sprintf('RemoveTree expects TreeValue at "%s"', $this->key),
             );
         }
 
-        $entries = $base->entries;
-
-        foreach ($this->keys as $name) {
-            unset($entries[$name]);
-        }
-
-        return new TreeValue($entries);
+        return (new RemovedTree($base, $this->spec))->value();
     }
 }

--- a/src/Settings/Value/RemovedTree.php
+++ b/src/Settings/Value/RemovedTree.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Settings\Value;
+
+use Haspadar\Sheriff\SheriffException;
+
+/**
+ * Tree produced by deep-removing entries from a base tree.
+ *
+ * The remove spec walks the same shape as the base tree:
+ *   * a TreeValue under a key recurses into the matching base subtree;
+ *   * a ListValue of strings under a key drops those entries from a base
+ *     ListValue, or those keys from a base TreeValue;
+ *   * any other shape collision is a configuration error.
+ *
+ * Removing a key that is absent from the base is silently ignored so that
+ * `.sheriff.yaml` stays idempotent across upgrades.
+ *
+ * Example:
+ *
+ *     (new RemovedTree($base, $spec))->value();
+ */
+final readonly class RemovedTree
+{
+    /**
+     * Initializes with the base tree, the remove spec, and the parent path used in error messages.
+     *
+     * @param TreeValue $base Tree whose entries are filtered down by the spec
+     * @param TreeValue $spec Tree describing which subtrees to recurse into and which leaves to drop
+     * @param string $path Dot-separated parent path threaded through nested removals for diagnostics; empty at the top level
+     */
+    public function __construct(
+        private TreeValue $base,
+        private TreeValue $spec,
+        private string $path = '',
+    ) {}
+
+    /**
+     * Returns the merged tree with spec entries removed from matching leaves.
+     *
+     * @throws SheriffException
+     */
+    public function value(): TreeValue
+    {
+        $entries = $this->base->entries;
+
+        foreach ($this->spec->entries as $key => $instruction) {
+            if (!array_key_exists($key, $entries)) {
+                continue;
+            }
+
+            $entries[$key] = $this->resolved($key, $entries[$key], $instruction);
+        }
+
+        return new TreeValue($entries);
+    }
+
+    /**
+     * Combines the base value with the remove instruction at the same key.
+     *
+     * @throws SheriffException
+     */
+    private function resolved(string $key, Value $current, Value $instruction): Value
+    {
+        if ($instruction instanceof TreeValue && $current instanceof TreeValue) {
+            return (new self($current, $instruction, $this->qualified($key)))->value();
+        }
+
+        if ($instruction instanceof ListValue && $current instanceof ListValue) {
+            return $this->prunedList($current, $instruction, $key);
+        }
+
+        if ($instruction instanceof ListValue && $current instanceof TreeValue) {
+            return $this->prunedTree($current, $instruction, $key);
+        }
+
+        throw new SheriffException(
+            sprintf(
+                'RemovedTree cannot remove "%s": base is %s but spec is %s; expected matching trees, lists, or a list of keys to drop from a tree',
+                $this->qualified($key),
+                get_debug_type($current),
+                get_debug_type($instruction),
+            ),
+        );
+    }
+
+    /**
+     * Returns the source list with every string element listed in the drop list removed.
+     *
+     * @throws SheriffException
+     */
+    private function prunedList(ListValue $source, ListValue $drop, string $key): ListValue
+    {
+        $names = [];
+
+        foreach ($drop->children as $entry) {
+            if (!$entry instanceof StringValue) {
+                throw new SheriffException(
+                    sprintf(
+                        'RemovedTree cannot remove from "%s": list drop entries must be strings',
+                        $this->qualified($key),
+                    ),
+                );
+            }
+
+            $names[] = $entry->raw;
+        }
+
+        return new ListValue(array_values(array_filter(
+            $source->children,
+            static fn(Value $child): bool => !($child instanceof StringValue) || !in_array($child->raw, $names, true),
+        )));
+    }
+
+    /**
+     * Returns the source tree with every key listed in the drop list removed.
+     *
+     * @throws SheriffException
+     */
+    private function prunedTree(TreeValue $source, ListValue $drop, string $key): TreeValue
+    {
+        $entries = $source->entries;
+
+        foreach ($drop->children as $name) {
+            if (!$name instanceof StringValue) {
+                throw new SheriffException(
+                    sprintf(
+                        'RemovedTree cannot remove from "%s": tree-key drop list must contain only strings',
+                        $this->qualified($key),
+                    ),
+                );
+            }
+
+            unset($entries[$name->raw]);
+        }
+
+        return new TreeValue($entries);
+    }
+
+    /** Joins the current path with the given key for a fully-qualified diagnostic. */
+    private function qualified(string $key): string
+    {
+        return $this->path === ''
+            ? $key
+            : sprintf('%s.%s', $this->path, $key);
+    }
+}

--- a/tests/Unit/Settings/Patch/RemovePatchesTest.php
+++ b/tests/Unit/Settings/Patch/RemovePatchesTest.php
@@ -7,6 +7,7 @@ namespace Haspadar\Sheriff\Tests\Unit\Settings\Patch;
 use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Patch\RemoveList;
 use Haspadar\Sheriff\Settings\Patch\RemovePatches;
+use Haspadar\Sheriff\Settings\Patch\RemoveTree;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -55,10 +56,22 @@ final class RemovePatchesTest extends TestCase
     }
 
     #[Test]
-    public function rejectsMappingPayloadAsConfigError(): void
+    public function buildsRemoveTreeForMappingPayload(): void
     {
-        $this->expectException(SheriffException::class);
+        $patches = (new RemovePatches([
+            'phpstan.parameters' => [
+                'haspadar' => [
+                    'afferentCoupling' => [
+                        'excludedClasses' => ['\\App\\Foo'],
+                    ],
+                ],
+            ],
+        ]))->patches();
 
-        (new RemovePatches(['phpstan.parameters' => ['nested' => true]]))->patches();
+        self::assertInstanceOf(
+            RemoveTree::class,
+            $patches[0],
+            'RemovePatches must produce RemoveTree for a yaml mapping that walks into nested leaves',
+        );
     }
 }

--- a/tests/Unit/Settings/Patch/RemoveTreeTest.php
+++ b/tests/Unit/Settings/Patch/RemoveTreeTest.php
@@ -7,6 +7,8 @@ namespace Haspadar\Sheriff\Tests\Unit\Settings\Patch;
 use Haspadar\Sheriff\Settings\Patch\RemoveTree;
 use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -19,23 +21,66 @@ final class RemoveTreeTest extends TestCase
     {
         self::assertSame(
             'phpstan.parameters',
-            (new RemoveTree('phpstan.parameters', []))->key(),
+            (new RemoveTree('phpstan.parameters', new TreeValue([])))->key(),
             'RemoveTree must expose the configuration key it targets',
         );
     }
 
     #[Test]
-    public function dropsNamedKeyFromBase(): void
+    public function recursesIntoNestedTreeAndDropsListEntries(): void
     {
-        $base = new TreeValue([
-            'kept' => new IntValue(1),
-            'removed' => new BoolValue(true),
-        ]);
-
         self::assertEquals(
-            new TreeValue(['kept' => new IntValue(1)]),
-            (new RemoveTree('phpstan.parameters', ['removed']))->applied($base),
-            'RemoveTree must drop the entry whose key is listed for removal',
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'excludedClasses' => new ListValue([new StringValue('\\Kept')]),
+                    ]),
+                ]),
+            ]),
+            (new RemoveTree(
+                'phpstan.parameters',
+                new TreeValue([
+                    'haspadar' => new TreeValue([
+                        'afferentCoupling' => new TreeValue([
+                            'excludedClasses' => new ListValue([new StringValue('\\Dropped')]),
+                        ]),
+                    ]),
+                ]),
+            ))->applied(new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'excludedClasses' => new ListValue([
+                            new StringValue('\\Kept'),
+                            new StringValue('\\Dropped'),
+                        ]),
+                    ]),
+                ]),
+            ])),
+            'RemoveTree must walk through nested trees and prune matching list leaves',
+        );
+    }
+
+    #[Test]
+    public function dropsNamedKeysFromTreeWhenSpecAtSameKeyIsAListOfStrings(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'flags' => new TreeValue([
+                    'kept' => new IntValue(1),
+                ]),
+            ]),
+            (new RemoveTree(
+                'phpstan.parameters',
+                new TreeValue([
+                    'flags' => new ListValue([new StringValue('removed')]),
+                ]),
+            ))->applied(new TreeValue([
+                'flags' => new TreeValue([
+                    'kept' => new IntValue(1),
+                    'removed' => new BoolValue(true),
+                ]),
+            ])),
+            'RemoveTree must drop named keys from a base tree when the spec at the same key is a list of strings',
         );
     }
 
@@ -46,36 +91,34 @@ final class RemoveTreeTest extends TestCase
 
         self::assertEquals(
             $base,
-            (new RemoveTree('phpstan.parameters', ['absent']))->applied($base),
-            'RemoveTree must keep base entries when removal targets keys absent from base',
+            (new RemoveTree(
+                'phpstan.parameters',
+                new TreeValue(['absent' => new ListValue([])]),
+            ))->applied($base),
+            'RemoveTree must keep base entries when the spec targets keys absent from base',
         );
     }
 
     #[Test]
-    public function dropsEveryListedKeyAtOnce(): void
+    public function acceptsEmptyListBaseAsEmptyTree(): void
     {
-        $base = new TreeValue([
-            'kept' => new IntValue(1),
-            'first' => new BoolValue(true),
-            'second' => new BoolValue(false),
-        ]);
-
-        self::assertEquals(
-            new TreeValue(['kept' => new IntValue(1)]),
-            (new RemoveTree('phpstan.parameters', ['first', 'second']))->applied($base),
-            'RemoveTree must drop every key listed for removal in a single application',
-        );
-    }
-
-    #[Test]
-    public function returnsEmptyTreeWhenAllKeysRemoved(): void
-    {
-        $base = new TreeValue(['only' => new IntValue(1)]);
-
         self::assertEquals(
             new TreeValue([]),
-            (new RemoveTree('phpstan.parameters', ['only']))->applied($base),
-            'RemoveTree must return an empty tree when every base entry is removed',
+            (new RemoveTree('envs', new TreeValue([])))->applied(new ListValue([])),
+            'RemoveTree must accept an empty ListValue base because YAML `{}` parses as `[]`',
+        );
+    }
+
+    #[Test]
+    public function dropsNothingFromEmptyListBaseEvenWithNonEmptySpec(): void
+    {
+        self::assertEquals(
+            new TreeValue([]),
+            (new RemoveTree(
+                'envs',
+                new TreeValue(['absent' => new ListValue([new StringValue('foo')])]),
+            ))->applied(new ListValue([])),
+            'RemoveTree must treat an empty ListValue base as an empty TreeValue regardless of spec contents',
         );
     }
 
@@ -85,6 +128,6 @@ final class RemoveTreeTest extends TestCase
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('phpstan.parameters');
 
-        (new RemoveTree('phpstan.parameters', []))->applied(new IntValue(8));
+        (new RemoveTree('phpstan.parameters', new TreeValue([])))->applied(new IntValue(8));
     }
 }

--- a/tests/Unit/Settings/Value/RemovedTreeTest.php
+++ b/tests/Unit/Settings/Value/RemovedTreeTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Settings\Value;
+
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\RemovedTree;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RemovedTreeTest extends TestCase
+{
+    #[Test]
+    public function returnsBaseUnchangedWhenSpecIsEmpty(): void
+    {
+        $base = new TreeValue(['a' => new IntValue(1)]);
+
+        self::assertEquals(
+            $base,
+            (new RemovedTree($base, new TreeValue([])))->value(),
+            'RemovedTree must return the base tree when the spec is empty',
+        );
+    }
+
+    #[Test]
+    public function ignoresSpecKeysAbsentFromBase(): void
+    {
+        $base = new TreeValue(['kept' => new IntValue(1)]);
+
+        self::assertEquals(
+            $base,
+            (new RemovedTree(
+                $base,
+                new TreeValue(['absent' => new ListValue([])]),
+            ))->value(),
+            'RemovedTree must keep base entries when the spec targets keys absent from base',
+        );
+    }
+
+    #[Test]
+    public function dropsListEntriesAtMatchingListLeaves(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'excludedClasses' => new ListValue([new StringValue('\\Kept')]),
+            ]),
+            (new RemovedTree(
+                new TreeValue([
+                    'excludedClasses' => new ListValue([
+                        new StringValue('\\Kept'),
+                        new StringValue('\\Dropped'),
+                    ]),
+                ]),
+                new TreeValue([
+                    'excludedClasses' => new ListValue([new StringValue('\\Dropped')]),
+                ]),
+            ))->value(),
+            'RemovedTree must drop spec entries from a base list at the matching key',
+        );
+    }
+
+    #[Test]
+    public function recursesIntoNestedTrees(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'afferentCoupling' => new TreeValue([
+                        'excludedClasses' => new ListValue([new StringValue('\\Kept')]),
+                    ]),
+                ]),
+            ]),
+            (new RemovedTree(
+                new TreeValue([
+                    'haspadar' => new TreeValue([
+                        'afferentCoupling' => new TreeValue([
+                            'excludedClasses' => new ListValue([
+                                new StringValue('\\Kept'),
+                                new StringValue('\\Dropped'),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+                new TreeValue([
+                    'haspadar' => new TreeValue([
+                        'afferentCoupling' => new TreeValue([
+                            'excludedClasses' => new ListValue([new StringValue('\\Dropped')]),
+                        ]),
+                    ]),
+                ]),
+            ))->value(),
+            'RemovedTree must recurse into matching nested trees and prune list leaves at any depth',
+        );
+    }
+
+    #[Test]
+    public function dropsNamedKeysWhenSpecIsListOfStrings(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'flags' => new TreeValue(['kept' => new IntValue(1)]),
+            ]),
+            (new RemovedTree(
+                new TreeValue([
+                    'flags' => new TreeValue([
+                        'kept' => new IntValue(1),
+                        'removed' => new BoolValue(true),
+                    ]),
+                ]),
+                new TreeValue([
+                    'flags' => new ListValue([new StringValue('removed')]),
+                ]),
+            ))->value(),
+            'RemovedTree must drop named keys from a base tree when the spec at the same key is a list of strings',
+        );
+    }
+
+    #[Test]
+    public function rejectsNonStringEntryInListDropSpec(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('list drop entries must be strings');
+
+        (new RemovedTree(
+            new TreeValue([
+                'excludedClasses' => new ListValue([new StringValue('\\Foo')]),
+            ]),
+            new TreeValue([
+                'excludedClasses' => new ListValue([new IntValue(42)]),
+            ]),
+        ))->value();
+    }
+
+    #[Test]
+    public function rejectsTreeAndScalarCollision(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new RemovedTree(
+            new TreeValue(['flag' => new BoolValue(true)]),
+            new TreeValue(['flag' => new TreeValue([])]),
+        ))->value();
+    }
+
+    #[Test]
+    public function reportsFullDottedPathOnNestedCollision(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('RemovedTree cannot remove "haspadar.flag"');
+
+        (new RemovedTree(
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'flag' => new BoolValue(true),
+                ]),
+            ]),
+            new TreeValue([
+                'haspadar' => new TreeValue([
+                    'flag' => new ListValue([]),
+                ]),
+            ]),
+        ))->value();
+    }
+}


### PR DESCRIPTION
- Added `Settings\Value\RemovedTree` value object that recursively walks a base tree and a remove spec in lockstep: matching trees recurse, matching list leaves drop the named string entries, a list spec at a tree base drops the named keys. Any other shape collision raises `SheriffException` with the dotted parent path. Missing keys are tolerated so `.sheriff.yaml` stays idempotent
- Switched `Settings\Patch\RemoveTree` ctor from `(string, list<string>)` to `(string, TreeValue)` and delegated to `RemovedTree`. Empty-ListValue base shim mirrors the one in `OverrideTree`/`AppendTree`
- Updated `Settings\Patch\RemovePatches`: a list payload still becomes `RemoveList`; a mapping payload now becomes `RemoveTree` (no longer rejected)
- Rewrote `RemoveTreeTest` and `RemovePatchesTest` against the new ctor and recursive walker semantics
- Added `RemovedTreeTest` covering empty cases, missing keys, list-leaf prune, recursive walks, drop-keys-from-tree, scalar collisions, full-path diagnostics, and the non-string drop-spec guard

Closes the symmetry gap left after #716/#717: `override`, `append`, and `remove` now all reach arbitrary nested phpstan parameters via `.sheriff.yaml`.

**Breaking changes:**
- `Settings\Patch\RemoveTree::__construct` signature changed from `(string $key, list<string> $keys)` to `(string $key, TreeValue $spec)`. Programmatic constructors (none in core today) must update.
- The `remove:` section of `.sheriff.yaml` now accepts mapping payloads as well as list payloads. Previously such mappings raised `SheriffException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mapping-based removal specifications in configuration.
  * Enhanced removal functionality to recursively handle nested tree structures.

* **Bug Fixes**
  * Fixed removal validation to accept both list and mapping payloads instead of throwing errors on non-list formats.
  * Updated error messages to clarify expected payload formats for removal sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->