### PR TITLE
Json Render Ops Mirroring The Neon Set

### DIFF
--- a/src/Chain/Render/Json/JsonBool.php
+++ b/src/Chain/Render/Json/JsonBool.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Override;
+
+/**
+ * Renders a BoolValue as a json `true` or `false` literal.
+ *
+ * Example:
+ *
+ *     (new JsonBool(new BoolValue(true)))->rendered(); // "true"
+ */
+final readonly class JsonBool implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param BoolValue $value Boolean payload rendered as a json literal
+     */
+    public function __construct(private BoolValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return $this->value->raw
+            ? 'true'
+            : 'false';
+    }
+}

--- a/src/Chain/Render/Json/JsonFloat.php
+++ b/src/Chain/Render/Json/JsonFloat.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\FloatValue;
+use Override;
+use UnexpectedValueException;
+
+/**
+ * Renders a FloatValue as a json number literal.
+ *
+ * Json forbids `INF` / `NAN`, so non-finite payloads are rejected loudly.
+ *
+ * Example:
+ *
+ *     (new JsonFloat(new FloatValue(0.5)))->rendered(); // "0.5"
+ */
+final readonly class JsonFloat implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param FloatValue $value Float payload rendered as a json number
+     */
+    public function __construct(private FloatValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        if (!is_finite($this->value->raw)) {
+            throw new UnexpectedValueException(
+                sprintf('JsonFloat cannot render non-finite payload: %s', (string) $this->value->raw),
+            );
+        }
+
+        $rendered = (string) $this->value->raw;
+
+        return str_contains($rendered, '.')
+            ? $rendered
+            : sprintf('%s.0', $rendered);
+    }
+}

--- a/src/Chain/Render/Json/JsonInt.php
+++ b/src/Chain/Render/Json/JsonInt.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Override;
+
+/**
+ * Renders an IntValue as a json integer literal.
+ *
+ * Example:
+ *
+ *     (new JsonInt(new IntValue(80)))->rendered(); // "80"
+ */
+final readonly class JsonInt implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param IntValue $value Integer payload rendered as a json literal
+     */
+    public function __construct(private IntValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return (string) $this->value->raw;
+    }
+}

--- a/src/Chain/Render/Json/JsonList.php
+++ b/src/Chain/Render/Json/JsonList.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Override;
+
+/**
+ * Renders a ListValue as a json block-style array at the given indent.
+ *
+ * Empty lists collapse to `[]`. Items render through `JsonOf` and sit at
+ * `depth + 1` indentation, comma-separated.
+ *
+ * Example:
+ *
+ *     (new JsonList(new ListValue([new StringValue('a')])))->rendered();
+ *     // [
+ *     // "a"
+ *     // ]
+ */
+final readonly class JsonList implements Rendered
+{
+    private const string INDENT = '    ';
+
+    /**
+     * Initializes with the list to render and the depth at which rendering starts.
+     *
+     * @param ListValue $value List payload rendered as a json array
+     * @param int $depth Indent level applied to each item
+     */
+    public function __construct(private ListValue $value, private int $depth = 0) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        if ($this->value->children === []) {
+            return '[]';
+        }
+
+        $itemPrefix = str_repeat(self::INDENT, $this->depth + 1);
+        $closePrefix = str_repeat(self::INDENT, $this->depth);
+
+        $lines = array_map(
+            fn(Value $child): string => sprintf(
+                '%s%s',
+                $itemPrefix,
+                (new JsonOf($child, $this->depth + 1))->renderer()->rendered(),
+            ),
+            $this->value->children,
+        );
+
+        return sprintf("[\n%s\n%s]", implode(",\n", $lines), $closePrefix);
+    }
+}

--- a/src/Chain/Render/Json/JsonOf.php
+++ b/src/Chain/Render/Json/JsonOf.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\FloatValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use TypeError;
+
+/**
+ * Picks the matching Json renderer for a configuration value.
+ *
+ * Container renderers (`JsonList`, `JsonTree`) carry the surrounding indent
+ * depth so nested structures stay aligned with their parent.
+ *
+ * Example:
+ *
+ *     (new JsonOf(new BoolValue(true)))->renderer()->rendered(); // "true"
+ */
+final readonly class JsonOf
+{
+    /**
+     * Initializes with the value to render and the indent depth used by container renderers.
+     *
+     * @param Value $value Configuration value resolved into a json-format renderer
+     * @param int $depth Indent depth threaded into list / tree renderers; ignored by scalar renderers
+     */
+    public function __construct(private Value $value, private int $depth = 0) {}
+
+    /**
+     * Returns the Rendered op that knows how to render this value as json.
+     *
+     * @throws TypeError
+     */
+    public function renderer(): Rendered
+    {
+        return match (true) {
+            $this->value instanceof BoolValue => new JsonBool($this->value),
+            $this->value instanceof IntValue => new JsonInt($this->value),
+            $this->value instanceof FloatValue => new JsonFloat($this->value),
+            $this->value instanceof StringValue => new JsonString($this->value),
+            $this->value instanceof ListValue => new JsonList($this->value, $this->depth),
+            $this->value instanceof TreeValue => new JsonTree($this->value, $this->depth),
+            default => throw new TypeError(
+                sprintf('Unsupported Value subtype: %s', $this->value::class),
+            ),
+        };
+    }
+}

--- a/src/Chain/Render/Json/JsonString.php
+++ b/src/Chain/Render/Json/JsonString.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Override;
+
+/**
+ * Renders a StringValue as a json string literal in double quotes.
+ *
+ * Uses `json_encode` with `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR`
+ * so paths and non-ASCII text round-trip readably and malformed UTF-8 surfaces as a JsonException.
+ *
+ * Example:
+ *
+ *     (new JsonString(new StringValue('json5')))->rendered(); // "\"json5\""
+ */
+final readonly class JsonString implements Rendered
+{
+    /**
+     * Initializes with the value to render.
+     *
+     * @param StringValue $value String payload rendered as a quoted json literal
+     */
+    public function __construct(private StringValue $value) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        return json_encode(
+            $this->value->raw,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
+    }
+}

--- a/src/Chain/Render/Json/JsonTree.php
+++ b/src/Chain/Render/Json/JsonTree.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use JsonException;
+use Override;
+
+/**
+ * Renders a TreeValue as a json block-style object at the given indent.
+ *
+ * Empty trees collapse to `{}`. Keys are rendered through `JsonString`,
+ * values through `JsonOf`. Entries are separated by `,\n` and indented
+ * by `depth + 1`.
+ *
+ * Example:
+ *
+ *     (new JsonTree(new TreeValue(['a' => new IntValue(1)])))->rendered();
+ *     // {
+ *     // "a": 1
+ *     // }
+ */
+final readonly class JsonTree implements Rendered
+{
+    private const string INDENT = '    ';
+
+    /**
+     * Initializes with the tree to render and the depth at which rendering starts.
+     *
+     * @param TreeValue $value Tree payload rendered as a json object
+     * @param int $depth Indent level applied to nested entries
+     */
+    public function __construct(private TreeValue $value, private int $depth = 0) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        if ($this->value->entries === []) {
+            return '{}';
+        }
+
+        $entryPrefix = str_repeat(self::INDENT, $this->depth + 1);
+        $closePrefix = str_repeat(self::INDENT, $this->depth);
+        $lines = [];
+
+        foreach ($this->value->entries as $key => $child) {
+            $lines[] = sprintf(
+                '%s%s: %s',
+                $entryPrefix,
+                $this->keyLiteral($key),
+                (new JsonOf($child, $this->depth + 1))->renderer()->rendered(),
+            );
+        }
+
+        return sprintf("{\n%s\n%s}", implode(",\n", $lines), $closePrefix);
+    }
+
+    /**
+     * Encodes the key as a json string literal.
+     *
+     * @throws JsonException
+     */
+    private function keyLiteral(string $key): string
+    {
+        return (new JsonString(new StringValue($key)))->rendered();
+    }
+}

--- a/tests/Unit/Chain/Render/Json/JsonBoolTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonBoolTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Render\Json\JsonBool;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonBoolTest extends TestCase
+{
+    #[Test]
+    public function rendersTrueAsLiteralTrue(): void
+    {
+        self::assertSame(
+            'true',
+            (new JsonBool(new BoolValue(true)))->rendered(),
+            'JsonBool must render true as the json literal true',
+        );
+    }
+
+    #[Test]
+    public function rendersFalseAsLiteralFalse(): void
+    {
+        self::assertSame(
+            'false',
+            (new JsonBool(new BoolValue(false)))->rendered(),
+            'JsonBool must render false as the json literal false',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Json/JsonFloatTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonFloatTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Render\Json\JsonFloat;
+use Haspadar\Sheriff\Settings\Value\FloatValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+final class JsonFloatTest extends TestCase
+{
+    #[Test]
+    public function rendersFractionalPayloadVerbatim(): void
+    {
+        self::assertSame(
+            '0.5',
+            (new JsonFloat(new FloatValue(0.5)))->rendered(),
+            'JsonFloat must render fractional payloads as their decimal representation',
+        );
+    }
+
+    #[Test]
+    public function appendsDotZeroToWholeFloatToKeepItDistinctFromInteger(): void
+    {
+        self::assertSame(
+            '80.0',
+            (new JsonFloat(new FloatValue(80.0)))->rendered(),
+            'JsonFloat must append `.0` so a whole-number float stays distinguishable from a json integer',
+        );
+    }
+
+    #[Test]
+    public function rejectsInfinityPayload(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        (new JsonFloat(new FloatValue(INF)))->rendered();
+    }
+
+    #[Test]
+    public function rejectsNanPayload(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        (new JsonFloat(new FloatValue(NAN)))->rendered();
+    }
+}

--- a/tests/Unit/Chain/Render/Json/JsonIntTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonIntTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Render\Json\JsonInt;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonIntTest extends TestCase
+{
+    #[Test]
+    public function rendersPositiveIntegerAsBareNumber(): void
+    {
+        self::assertSame(
+            '80',
+            (new JsonInt(new IntValue(80)))->rendered(),
+            'JsonInt must render the integer payload as a bare json number',
+        );
+    }
+
+    #[Test]
+    public function rendersNegativeIntegerAsBareNumber(): void
+    {
+        self::assertSame(
+            '-3',
+            (new JsonInt(new IntValue(-3)))->rendered(),
+            'JsonInt must keep the sign on negative integers',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Json/JsonListTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonListTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Render\Json\JsonList;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonListTest extends TestCase
+{
+    #[Test]
+    public function rendersEmptyListAsBracePair(): void
+    {
+        self::assertSame(
+            '[]',
+            (new JsonList(new ListValue([])))->rendered(),
+            'JsonList must render an empty list as the json empty array literal',
+        );
+    }
+
+    #[Test]
+    public function rendersStringEntriesAsBlockArrayWithDefaultIndent(): void
+    {
+        self::assertSame(
+            "[\n    \"a\",\n    \"b\"\n]",
+            (new JsonList(new ListValue([
+                new StringValue('a'),
+                new StringValue('b'),
+            ])))->rendered(),
+            'JsonList must place each item on its own line, indented one level deeper than the opening bracket',
+        );
+    }
+
+    #[Test]
+    public function rendersScalarMixWithMatchingJsonRenderers(): void
+    {
+        self::assertSame(
+            "[\n    true,\n    8,\n    \"x\"\n]",
+            (new JsonList(new ListValue([
+                new BoolValue(true),
+                new IntValue(8),
+                new StringValue('x'),
+            ])))->rendered(),
+            'JsonList must dispatch each item through its matching json renderer',
+        );
+    }
+
+    #[Test]
+    public function indentsMoreDeeplyAtHigherDepth(): void
+    {
+        self::assertSame(
+            "[\n        \"a\"\n    ]",
+            (new JsonList(new ListValue([new StringValue('a')]), 1))->rendered(),
+            'JsonList must indent items by depth+1 levels and the closing bracket by depth levels',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Json/JsonListTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonListTest.php
@@ -60,4 +60,16 @@ final class JsonListTest extends TestCase
             'JsonList must indent items by depth+1 levels and the closing bracket by depth levels',
         );
     }
+
+    #[Test]
+    public function passesIncrementedDepthToNestedList(): void
+    {
+        self::assertSame(
+            "[\n    [\n        \"x\"\n    ]\n]",
+            (new JsonList(new ListValue([
+                new ListValue([new StringValue('x')]),
+            ])))->rendered(),
+            'JsonList must forward depth+1 to nested containers so inner items sit at depth+2 indentation',
+        );
+    }
 }

--- a/tests/Unit/Chain/Render/Json/JsonOfTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonOfTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Render\Json\JsonBool;
+use Haspadar\Sheriff\Chain\Render\Json\JsonFloat;
+use Haspadar\Sheriff\Chain\Render\Json\JsonInt;
+use Haspadar\Sheriff\Chain\Render\Json\JsonList;
+use Haspadar\Sheriff\Chain\Render\Json\JsonOf;
+use Haspadar\Sheriff\Chain\Render\Json\JsonString;
+use Haspadar\Sheriff\Chain\Render\Json\JsonTree;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\FloatValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+final class JsonOfTest extends TestCase
+{
+    /** @return iterable<string, array{Value, class-string}> */
+    public static function valueRendererPairs(): iterable
+    {
+        yield 'bool' => [new BoolValue(true), JsonBool::class];
+        yield 'int' => [new IntValue(8), JsonInt::class];
+        yield 'float' => [new FloatValue(0.5), JsonFloat::class];
+        yield 'string' => [new StringValue('x'), JsonString::class];
+        yield 'list' => [new ListValue([]), JsonList::class];
+        yield 'tree' => [new TreeValue([]), JsonTree::class];
+    }
+
+    #[Test]
+    #[DataProvider('valueRendererPairs')]
+    public function dispatchesEachValueSubtypeToTheMatchingRenderer(
+        Value $value,
+        string $expected,
+    ): void {
+        self::assertInstanceOf(
+            $expected,
+            (new JsonOf($value))->renderer(),
+            sprintf('JsonOf must dispatch %s to %s', $value::class, $expected),
+        );
+    }
+
+    #[Test]
+    public function rejectsValueSubtypeWithoutMatchingRenderer(): void
+    {
+        $this->expectException(TypeError::class);
+
+        $unknown = new class () implements Value {
+        };
+
+        (new JsonOf($unknown))->renderer();
+    }
+}

--- a/tests/Unit/Chain/Render/Json/JsonOfTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonOfTest.php
@@ -59,4 +59,14 @@ final class JsonOfTest extends TestCase
 
         (new JsonOf($unknown))->renderer();
     }
+
+    #[Test]
+    public function threadsDefaultDepthZeroIntoContainerRenderer(): void
+    {
+        self::assertSame(
+            "[\n    \"x\"\n]",
+            (new JsonOf(new ListValue([new StringValue('x')])))->renderer()->rendered(),
+            'JsonOf must thread depth=0 by default so a top-level list indents items one level',
+        );
+    }
 }

--- a/tests/Unit/Chain/Render/Json/JsonStringTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonStringTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Render\Json\JsonString;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonStringTest extends TestCase
+{
+    #[Test]
+    public function rendersPlainStringInDoubleQuotes(): void
+    {
+        self::assertSame(
+            '"json5"',
+            (new JsonString(new StringValue('json5')))->rendered(),
+            'JsonString must render the payload as a quoted json literal',
+        );
+    }
+
+    #[Test]
+    public function escapesEmbeddedDoubleQuote(): void
+    {
+        self::assertSame(
+            '"a\"b"',
+            (new JsonString(new StringValue('a"b')))->rendered(),
+            'JsonString must backslash-escape an embedded double quote',
+        );
+    }
+
+    #[Test]
+    public function keepsForwardSlashUnescaped(): void
+    {
+        self::assertSame(
+            '"a/b"',
+            (new JsonString(new StringValue('a/b')))->rendered(),
+            'JsonString must keep forward slashes unescaped to preserve readable paths',
+        );
+    }
+
+    #[Test]
+    public function escapesEmbeddedNewline(): void
+    {
+        self::assertSame(
+            '"a\nb"',
+            (new JsonString(new StringValue("a\nb")))->rendered(),
+            'JsonString must escape control characters so the literal stays single-line valid json',
+        );
+    }
+}

--- a/tests/Unit/Chain/Render/Json/JsonStringTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonStringTest.php
@@ -6,6 +6,7 @@ namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
 
 use Haspadar\Sheriff\Chain\Render\Json\JsonString;
 use Haspadar\Sheriff\Settings\Value\StringValue;
+use JsonException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -49,5 +50,13 @@ final class JsonStringTest extends TestCase
             (new JsonString(new StringValue("a\nb")))->rendered(),
             'JsonString must escape control characters so the literal stays single-line valid json',
         );
+    }
+
+    #[Test]
+    public function throwsJsonExceptionForMalformedUtf8(): void
+    {
+        $this->expectException(JsonException::class);
+
+        (new JsonString(new StringValue("\xFF\xFE")))->rendered();
     }
 }

--- a/tests/Unit/Chain/Render/Json/JsonTreeTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonTreeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Json;
+
+use Haspadar\Sheriff\Chain\Render\Json\JsonTree;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonTreeTest extends TestCase
+{
+    #[Test]
+    public function rendersEmptyTreeAsBracePair(): void
+    {
+        self::assertSame(
+            '{}',
+            (new JsonTree(new TreeValue([])))->rendered(),
+            'JsonTree must render an empty tree as the json empty object literal',
+        );
+    }
+
+    #[Test]
+    public function rendersScalarsAsBlockObjectWithDefaultIndent(): void
+    {
+        self::assertSame(
+            "{\n    \"compact\": true,\n    \"timeout\": 30\n}",
+            (new JsonTree(new TreeValue([
+                'compact' => new BoolValue(true),
+                'timeout' => new IntValue(30),
+            ])))->rendered(),
+            'JsonTree must place each entry on its own indented line, with comma between entries',
+        );
+    }
+
+    #[Test]
+    public function recursesIntoNestedTreesAndLists(): void
+    {
+        self::assertSame(
+            "{\n    \"logs\": {\n        \"text\": \"infection.log\"\n    },\n    \"patterns\": [\n        \"a\"\n    ]\n}",
+            (new JsonTree(new TreeValue([
+                'logs' => new TreeValue([
+                    'text' => new StringValue('infection.log'),
+                ]),
+                'patterns' => new ListValue([new StringValue('a')]),
+            ])))->rendered(),
+            'JsonTree must align nested objects and arrays using their own depth',
+        );
+    }
+}


### PR DESCRIPTION
- Added JsonBool, JsonInt, JsonFloat, JsonString, JsonList, JsonTree render ops covering scalar, list and tree values
- Added JsonOf dispatcher that pairs each Value subtype with its matching json renderer and threads indent depth into containers
- Added unit tests covering each renderer plus the dispatch and rejection paths

Part of #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSON rendering support for booleans, integers, floats, strings, arrays, and objects
  * Includes proper indentation and formatting for nested structures
  * Non-finite float values are properly rejected with error handling

* **Tests**
  * Added comprehensive unit test coverage for all JSON rendering functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->