### PR TITLE
Move BoolSetting Out Of The Value Namespace

### DIFF
--- a/src/Check/ConfigDefault.php
+++ b/src/Check/ConfigDefault.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Check;
 
+use Haspadar\Sheriff\Settings\BoolSetting;
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**

--- a/src/Check/EnabledChecks.php
+++ b/src/Check/EnabledChecks.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Check;
 
+use Haspadar\Sheriff\Settings\BoolSetting;
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**

--- a/src/EnvVar/SonarEnvVar.php
+++ b/src/EnvVar/SonarEnvVar.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\EnvVar;
 
+use Haspadar\Sheriff\Settings\BoolSetting;
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**

--- a/src/Secret/CodecovSecret.php
+++ b/src/Secret/CodecovSecret.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Secret;
 
+use Haspadar\Sheriff\Settings\BoolSetting;
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**

--- a/src/Secret/InfectionSecret.php
+++ b/src/Secret/InfectionSecret.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Secret;
 
+use Haspadar\Sheriff\Settings\BoolSetting;
 use Haspadar\Sheriff\Settings\Settings;
-use Haspadar\Sheriff\Settings\Value\BoolSetting;
 use Override;
 
 /**

--- a/src/Settings/BoolSetting.php
+++ b/src/Settings/BoolSetting.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Haspadar\Sheriff\Settings\Value;
+namespace Haspadar\Sheriff\Settings;
 
-use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\SheriffException;
 
 /**

--- a/tests/Unit/Settings/BoolSettingTest.php
+++ b/tests/Unit/Settings/BoolSettingTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Haspadar\Sheriff\Tests\Unit\Settings\Value;
+namespace Haspadar\Sheriff\Tests\Unit\Settings;
 
-use Haspadar\Sheriff\Settings\Value\BoolSetting;
+use Haspadar\Sheriff\Settings\BoolSetting;
 use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;


### PR DESCRIPTION
- Refactored BoolSetting placement so it sits with other Settings utilities instead of pretending to be a Value type
- Updated namespace and use statements across the five callsites that read boolean toggles through it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of settings configuration system for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->