### PR TITLE
Cover Tree-Patch Mutation Escapes

### DIFF
--- a/src/Chain/Render/Neon/NeonBareString.php
+++ b/src/Chain/Render/Neon/NeonBareString.php
@@ -45,7 +45,7 @@ final readonly class NeonBareString implements Rendered
 
         return $raw !== ''
             && !in_array($raw, ['true', 'false', 'null', 'yes', 'no', 'on', 'off'], true)
-            && preg_match('/[\s"\'`#:,\[\]{}()]/u', $raw) !== 1
+            && preg_match('/[\s"\'`#:,\[\]{}()]/', $raw) !== 1
             && preg_match('/[\x00-\x1F\x7F]/', $raw) !== 1
             && !in_array($raw[0], ['-', '?', '@', '%', '!', '&', '*', '|', '>', '<', '='], true)
             && !is_numeric($raw);

--- a/tests/Unit/Settings/Value/AppendedTreeTest.php
+++ b/tests/Unit/Settings/Value/AppendedTreeTest.php
@@ -70,17 +70,25 @@ final class AppendedTreeTest extends TestCase
                 'excludedClasses' => new ListValue([
                     new StringValue('A'),
                     new StringValue('B'),
+                    new StringValue('C'),
+                    new StringValue('D'),
                 ]),
             ]),
             (new AppendedTree(
                 new TreeValue([
-                    'excludedClasses' => new ListValue([new StringValue('A')]),
+                    'excludedClasses' => new ListValue([
+                        new StringValue('A'),
+                        new StringValue('B'),
+                    ]),
                 ]),
                 new TreeValue([
-                    'excludedClasses' => new ListValue([new StringValue('B')]),
+                    'excludedClasses' => new ListValue([
+                        new StringValue('C'),
+                        new StringValue('D'),
+                    ]),
                 ]),
             ))->value(),
-            'AppendedTree must concatenate matching list leaves in append order',
+            'AppendedTree must concatenate every item of both list leaves in append order',
         );
     }
 

--- a/tests/Unit/Settings/Value/RemovedTreeTest.php
+++ b/tests/Unit/Settings/Value/RemovedTreeTest.php
@@ -149,6 +149,54 @@ final class RemovedTreeTest extends TestCase
     }
 
     #[Test]
+    public function processesSubsequentSpecKeysAfterEncounteringAnAbsentOne(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'kept' => new IntValue(1),
+                'flags' => new TreeValue([]),
+            ]),
+            (new RemovedTree(
+                new TreeValue([
+                    'kept' => new IntValue(1),
+                    'flags' => new TreeValue(['removed' => new BoolValue(true)]),
+                ]),
+                new TreeValue([
+                    'absent' => new ListValue([]),
+                    'flags' => new ListValue([new StringValue('removed')]),
+                ]),
+            ))->value(),
+            'RemovedTree must keep iterating through spec keys after one targets a key absent from base',
+        );
+    }
+
+    #[Test]
+    public function reindexesListAfterDroppingNonTrailingItems(): void
+    {
+        self::assertEquals(
+            new TreeValue([
+                'items' => new ListValue([
+                    new StringValue('b'),
+                    new StringValue('c'),
+                ]),
+            ]),
+            (new RemovedTree(
+                new TreeValue([
+                    'items' => new ListValue([
+                        new StringValue('a'),
+                        new StringValue('b'),
+                        new StringValue('c'),
+                    ]),
+                ]),
+                new TreeValue([
+                    'items' => new ListValue([new StringValue('a')]),
+                ]),
+            ))->value(),
+            'RemovedTree must reindex the surviving list children so their keys stay sequential',
+        );
+    }
+
+    #[Test]
     public function reportsFullDottedPathOnNestedCollision(): void
     {
         $this->expectException(SheriffException::class);


### PR DESCRIPTION
- Removed the no-op /u flag from the NeonBareString safety regex since the character class is pure ASCII
- Updated AppendedTree concatenation fixture to 2+2 elements so spread-one-item mutants no longer survive on either side
- Added RemovedTree tests for absent spec keys followed by matching ones and for non-trailing list drops to lock array_values reindexing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted character detection in string parsing for improved handling.

* **Tests**
  * Enhanced test coverage for list value concatenation with multiple items.
  * Added tests to verify correct handling of list reindexing during removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->