### PR TITLE
Drop Broken CodeRabbit Badge From README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fhaspadar%2Fsheriff%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/haspadar/sheriff/main)
 [![PHPStan Level](https://img.shields.io/badge/PHPStan-Level%209-brightgreen)](https://phpstan.org/)
 [![Psalm](https://img.shields.io/badge/psalm-level%201-brightgreen)](https://psalm.dev)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/haspadar/sheriff?utm_source=oss&utm_medium=github&utm_campaign=haspadar%2Fsheriff&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 Pre-configured strict quality gate for PHP.
 


### PR DESCRIPTION
- Removed the CodeRabbit reviews badge whose shields.io endpoint returns "provider or repo not found" after the repository was renamed and CodeRabbit's index lost the link