### PR TITLE
Promote README Tagline And Rule Count To Section Headlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Sheriff
 
+## Pre-configured strict quality gate for PHP
+
 [![CI](https://github.com/haspadar/sheriff/actions/workflows/sheriff.yml/badge.svg)](https://github.com/haspadar/sheriff/actions/workflows/sheriff.yml)
 [![Coverage](https://codecov.io/gh/haspadar/sheriff/branch/main/graph/badge.svg)](https://codecov.io/gh/haspadar/sheriff)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fhaspadar%2Fsheriff%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/haspadar/sheriff/main)
 [![PHPStan Level](https://img.shields.io/badge/PHPStan-Level%209-brightgreen)](https://phpstan.org/)
 [![Psalm](https://img.shields.io/badge/psalm-level%201-brightgreen)](https://psalm.dev)
-
-Pre-configured strict quality gate for PHP.
 
 ```bash
 composer require --dev haspadar/sheriff
@@ -27,7 +27,7 @@ vendor/bin/sheriff check
 [OK]   All checks passed    9.5s
 ```
 
-Over 1200 rules from 18 tools:
+## Over 1200 rules from 18 tools
 
 | Tool          | Rules                                              |
 |---------------|----------------------------------------------------|


### PR DESCRIPTION
- Promoted the strict-quality-gate tagline and the 1200+ rules claim to H2 headlines so the two main bets land at section weight in portfolio scans

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured the quality gate section of the README with improved formatting and clearer section headings to enhance readability and visual organization. The changes better organize information about the 1200+ rules available from 18 different tools, making it easier to understand the scope and breadth of quality assurance capabilities offered by the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->