### PR TITLE
Update infra image digest

### DIFF
--- a/.sheriff/_docker.sh
+++ b/.sheriff/_docker.sh
@@ -7,7 +7,7 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 PROJECT_ROOT="$(pwd)"
-DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:88c76164614b7a8eaa26db74470966458389c237bbf2d6e819ac222cd2ac3762"
+DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:3c15f3419f6e417c345fe22eded042146a11cdba4cd9032cdc4355f7036215d0"
 IMAGE="${SHERIFF_INFRA_IMAGE:-$DEFAULT_IMAGE}"
 
 docker run --rm \

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -33,7 +33,7 @@ defaults:
   coderabbit.cloud: true
   coderabbit.cli: false
 
-  docker.image: "ghcr.io/haspadar/sheriff-infra@sha256:88c76164614b7a8eaa26db74470966458389c237bbf2d6e819ac222cd2ac3762"
+  docker.image: "ghcr.io/haspadar/sheriff-infra@sha256:3c15f3419f6e417c345fe22eded042146a11cdba4cd9032cdc4355f7036215d0"
 
   actionlint.cli: true
 

--- a/.sheriff/sonar/command.sh
+++ b/.sheriff/sonar/command.sh
@@ -37,7 +37,7 @@ else
 fi
 
 PROJECT_ROOT="$(pwd)"
-DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:88c76164614b7a8eaa26db74470966458389c237bbf2d6e819ac222cd2ac3762"
+DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:3c15f3419f6e417c345fe22eded042146a11cdba4cd9032cdc4355f7036215d0"
 IMAGE="${SHERIFF_INFRA_IMAGE:-$DEFAULT_IMAGE}"
 
 docker run --rm \

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -33,7 +33,7 @@ defaults:
   coderabbit.cloud: true
   coderabbit.cli: false
 
-  docker.image: "ghcr.io/haspadar/sheriff-infra@sha256:88c76164614b7a8eaa26db74470966458389c237bbf2d6e819ac222cd2ac3762"
+  docker.image: "ghcr.io/haspadar/sheriff-infra@sha256:3c15f3419f6e417c345fe22eded042146a11cdba4cd9032cdc4355f7036215d0"
 
   actionlint.cli: true
 


### PR DESCRIPTION
Auto-generated: pin digest to sha256:3c15f3419f6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image versions used in the Sheriff CI infrastructure tooling and SonarCloud analysis environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->