### PR TITLE
Allow Named Constructors in Default PHPStan Policy

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -107,6 +107,8 @@ defaults:
       afferentCoupling:
         ignoreInterfaces: true
         excludedClasses: []
+      prohibitStaticMethods:
+        allowNamedConstructors: true
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -22,3 +22,5 @@ parameters:
             ignoreInterfaces: true
             excludedClasses:
                 - \Haspadar\Sheriff\SheriffException
+        prohibitStaticMethods:
+            allowNamedConstructors: true

--- a/DEV.md
+++ b/DEV.md
@@ -538,7 +538,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `phpstan.parameters.exceptions.checkedExceptionClasses` | `['\Throwable']` | Checked exception classes for the strict-rules `throws` analysis |
 | `phpstan.parameters.haspadar.afferentCoupling.ignoreInterfaces` | `true` | Skip interfaces when counting afferent coupling (haspadar rule) |
 | `phpstan.parameters.haspadar.afferentCoupling.excludedClasses` | `[]` | FQCNs excluded from the haspadar afferent coupling rule |
-| `phpstan.parameters.haspadar.prohibitStaticMethods.allowNamedConstructors` | `true` | Allow named constructors (`static fromX(): self { return new self(...); }`) as the only sanctioned use of `static` |
+| `phpstan.parameters.haspadar.prohibitStaticMethods.allowNamedConstructors` | `true` | Allow named constructors (e.g. `public static function fromX(...): self { return new self(...); }` or `public static function fromX(...): static { return new static(...); }`) as the only sanctioned static methods |
 
 `phpstan.parameters` is a nested tree merged into the rendered `phpstan.neon` under `parameters:`. Use `override:` / `append:` / `remove:` on any leaf to customise the analysis without rewriting the file.
 

--- a/DEV.md
+++ b/DEV.md
@@ -538,6 +538,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `phpstan.parameters.exceptions.checkedExceptionClasses` | `['\Throwable']` | Checked exception classes for the strict-rules `throws` analysis |
 | `phpstan.parameters.haspadar.afferentCoupling.ignoreInterfaces` | `true` | Skip interfaces when counting afferent coupling (haspadar rule) |
 | `phpstan.parameters.haspadar.afferentCoupling.excludedClasses` | `[]` | FQCNs excluded from the haspadar afferent coupling rule |
+| `phpstan.parameters.haspadar.prohibitStaticMethods.allowNamedConstructors` | `true` | Allow named constructors (`static fromX(): self { return new self(...); }`) as the only sanctioned use of `static` |
 
 `phpstan.parameters` is a nested tree merged into the rendered `phpstan.neon` under `parameters:`. Use `override:` / `append:` / `remove:` on any leaf to customise the analysis without rewriting the file.
 

--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.49.1",
+            "version": "v0.50.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "76decd54d23bafa15969122799b5ba3990afef57"
+                "reference": "2990bdf4c5feed7cc8ea06d613b32e33d1fff140"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/76decd54d23bafa15969122799b5ba3990afef57",
-                "reference": "76decd54d23bafa15969122799b5ba3990afef57",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/2990bdf4c5feed7cc8ea06d613b32e33d1fff140",
+                "reference": "2990bdf4c5feed7cc8ea06d613b32e33d1fff140",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.49.1"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.50.0"
             },
-            "time": "2026-05-15T09:39:59+00:00"
+            "time": "2026-05-15T20:24:19+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -107,6 +107,8 @@ defaults:
       afferentCoupling:
         ignoreInterfaces: true
         excludedClasses: []
+      prohibitStaticMethods:
+        allowNamedConstructors: true
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -113,7 +113,9 @@ final class TemplateFileTest extends TestCase
                 . "    haspadar:\n"
                 . "        afferentCoupling:\n"
                 . "            ignoreInterfaces: true\n"
-                . "            excludedClasses: []",
+                . "            excludedClasses: []\n"
+                . "        prohibitStaticMethods:\n"
+                . "            allowNamedConstructors: true",
             ),
             'TemplateFile must render the phpstan.parameters TreeValue as a nested neon block, including bare strings and block-style lists',
         );


### PR DESCRIPTION
- Updated phpstan-rules to v0.50.0 to expose the named-constructor option
- Added `prohibitStaticMethods.allowNamedConstructors: true` to the default Sheriff phpstan template
- Updated the phpstan.parameters reference table in DEV.md with the new key
- Updated the NeonTree integration fixture to match the extended default tree

Closes #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `prohibitStaticMethods` configuration option for code quality checks with support for named constructor patterns.

* **Documentation**
  * Updated developer documentation to describe new configuration parameter and its behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->