### PR TITLE
Disable PHPMetrics in the Default Check Pipeline

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -72,7 +72,7 @@ defaults:
   phpmd.method_length: 50
   phpmd.npath: 200
 
-  phpmetrics.cli: true
+  phpmetrics.cli: false
   phpmetrics.extensions: ["php"]
   phpmetrics.complexity.max_cyclomatic_per_method: 10
   phpmetrics.complexity.max_weighted_methods_per_class: 20

--- a/DEV.md
+++ b/DEV.md
@@ -502,7 +502,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `phpmetrics.cli` | `true` | Enable PHP Metrics |
+| `phpmetrics.cli` | `false` | Enable PHP Metrics (opt-in: checks largely duplicate haspadar/phpstan-rules; enable for HTML/Halstead reports) |
 | `phpmetrics.includes` | `["../../src"]` | Included directories |
 | `phpmetrics.excludes` | `["vendor", "tests", ".git"]` | Excluded directories |
 | `phpmetrics.extensions` | `["php"]` | File extensions |

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -72,7 +72,7 @@ defaults:
   phpmd.method_length: 50
   phpmd.npath: 200
 
-  phpmetrics.cli: true
+  phpmetrics.cli: false
   phpmetrics.extensions: ["php"]
   phpmetrics.complexity.max_cyclomatic_per_method: 10
   phpmetrics.complexity.max_weighted_methods_per_class: 20


### PR DESCRIPTION
- Updated `phpmetrics.cli` default from `true` to `false`
- Updated configuration reference in `DEV.md` with the new default and opt-in note

Closes #743

**Breaking changes:**
- Default `sheriff check` no longer runs phpmetrics. To restore previous behavior, set `override: { phpmetrics.cli: true }` in `.sheriff.yaml`. Templates and threshold keys are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * PHP metrics CLI checks are now disabled by default. Explicitly enable them in your configuration to continue using this feature.

* **Documentation**
  * Updated configuration reference to reflect that PHP metrics is now opt-in.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->