### PR TITLE
Silence PHP 8.5 NAN Coercion Warning in Float Renderers

### DIFF
--- a/src/Chain/Plain/FloatText.php
+++ b/src/Chain/Plain/FloatText.php
@@ -35,7 +35,7 @@ final readonly class FloatText implements Op
 
         if (!is_finite($raw)) {
             throw new SheriffException(
-                sprintf('FloatText cannot render non-finite value "%s"', (string) $raw),
+                sprintf('FloatText cannot render non-finite value "%s"', var_export($raw, true)),
             );
         }
 

--- a/src/Chain/Render/Json/JsonFloat.php
+++ b/src/Chain/Render/Json/JsonFloat.php
@@ -32,7 +32,7 @@ final readonly class JsonFloat implements Rendered
     {
         if (!is_finite($this->value->raw)) {
             throw new UnexpectedValueException(
-                sprintf('JsonFloat cannot render non-finite payload: %s', (string) $this->value->raw),
+                sprintf('JsonFloat cannot render non-finite payload: %s', var_export($this->value->raw, true)),
             );
         }
 

--- a/src/Chain/Render/Neon/NeonFloat.php
+++ b/src/Chain/Render/Neon/NeonFloat.php
@@ -30,7 +30,7 @@ final readonly class NeonFloat implements Rendered
     {
         if (!is_finite($this->value->raw)) {
             throw new UnexpectedValueException(
-                sprintf('NeonFloat cannot render non-finite payload: %s', (string) $this->value->raw),
+                sprintf('NeonFloat cannot render non-finite payload: %s', var_export($this->value->raw, true)),
             );
         }
 


### PR DESCRIPTION
- Updated float renderers to stringify rejected non-finite payloads with `var_export` instead of an implicit `(string)` cast

Closes #746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting when non-finite float values are rejected during serialization operations across multiple formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->