### PR TITLE
Generate CI Check Matrix From Per-Tool Cli Flags

### DIFF
--- a/.github/workflows/sheriff.yml
+++ b/.github/workflows/sheriff.yml
@@ -83,7 +83,6 @@ jobs:
           - phpstan
           - psalm
           - phpmd
-          - phpmetrics
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -21,6 +21,8 @@ defaults:
 
   ci.sheriff_bin: "vendor/bin/sheriff"
   ci.pr.max_lines_changed: 250
+  ci.infra_checks: ["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]
+  ci.php_checks: ["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]
 
   coverage.patch.target: 80
   coverage.patch.threshold: 5

--- a/DEV.md
+++ b/DEV.md
@@ -400,8 +400,8 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 |-----|---------|-------------|
 | `ci.sheriff_bin` | `"vendor/bin/sheriff"` | Path to Sheriff binary in CI |
 | `ci.pr.max_lines_changed` | `250` | Maximum lines changed per PR |
-| `ci.infra_checks` | `["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]` | Tools placed into the infra CI matrix; filtered by each tool's `<name>.cli` flag |
-| `ci.php_checks` | `["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]` | Tools placed into the PHP-static CI matrix; filtered by each tool's `<name>.cli` flag |
+| `ci.infra_checks` | `["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]` | Tools placed into the infra CI matrix; filtered by each tool's `<name>.cli` flag. Override or `append` in `.sheriff.yaml` to extend the matrix |
+| `ci.php_checks` | `["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]` | Tools placed into the PHP-static CI matrix; filtered by each tool's `<name>.cli` flag. Override or `append` in `.sheriff.yaml` to extend the matrix |
 
 ### Coverage
 

--- a/DEV.md
+++ b/DEV.md
@@ -123,6 +123,7 @@ Example:
 | `ListText(key)` | `ListValue` | Listed pipeline of per-item sources |
 | `EnvsText(key, indent)` | `TreeValue` (or empty `ListValue`) | GitHub Actions step exporting env vars; empty tree → empty string |
 | `NeonTree(key, depth)` | `TreeValue` | nested neon block mapping; `depth` is optional (default `0`) and controls indentation |
+| `EnabledTools(key)` | `ListValue` of tool names | Listed pipeline of names whose `<name>.cli` flag is `true`; fails fast on missing or non-boolean flags, and when the resolved list is empty |
 
 ### Map ops
 
@@ -399,6 +400,8 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 |-----|---------|-------------|
 | `ci.sheriff_bin` | `"vendor/bin/sheriff"` | Path to Sheriff binary in CI |
 | `ci.pr.max_lines_changed` | `250` | Maximum lines changed per PR |
+| `ci.infra_checks` | `["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]` | Tools placed into the infra CI matrix; filtered by each tool's `<name>.cli` flag |
+| `ci.php_checks` | `["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]` | Tools placed into the PHP-static CI matrix; filtered by each tool's `<name>.cli` flag |
 
 ### Coverage
 

--- a/src/Chain/Parse/EnabledToolsFormula.php
+++ b/src/Chain/Parse/EnabledToolsFormula.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\Chain\Plain\ListText;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+
+/**
+ * Filters a tool-name list down to those whose `<name>.cli` flag is true.
+ *
+ * Reads a `ListValue` of `StringValue` tool names from settings, then keeps
+ * only the names whose corresponding `<name>.cli` setting is `true`. Missing
+ * `<name>.cli` declarations and non-boolean values fail fast at template render
+ * time. The result is a `ListText` source op that downstream pipeline stages
+ * (`EachFormatted`, `Joined`) consume as a plain list.
+ *
+ * Example:
+ *
+ *     (new EnabledToolsFormula(['ci.infra_checks']))
+ *         ->op([], $settings); // ListText over the tools whose cli flag is true
+ */
+final readonly class EnabledToolsFormula implements Formula
+{
+    /**
+     * Initializes with the raw template arguments — the single settings key.
+     *
+     * @param list<string> $args Raw template arguments; expects exactly one settings key referencing a ListValue of tool names
+     */
+    public function __construct(private array $args) {}
+
+    #[Override]
+    public function op(array $previous, Settings $settings): Op
+    {
+        if (count($this->args) !== 1) {
+            throw new SheriffException(
+                sprintf('EnabledTools expects exactly one settings key, got %d', count($this->args)),
+            );
+        }
+
+        $key = $this->args[0];
+
+        if (!$settings->has($key)) {
+            throw new SheriffException(
+                sprintf('EnabledTools cannot find settings key "%s"', $key),
+            );
+        }
+
+        $list = $settings->value($key);
+
+        if (!$list instanceof ListValue) {
+            throw new SheriffException(
+                sprintf('EnabledTools expects "%s" to be a list, got %s', $key, $list::class),
+            );
+        }
+
+        $kept = [];
+
+        foreach ($list->children as $child) {
+            $kept = $this->keepWhenEnabled($child, $settings, $kept);
+        }
+
+        if ($kept === []) {
+            throw new SheriffException(
+                sprintf('EnabledTools resolved no enabled tools in "%s"', $key),
+            );
+        }
+
+        return new ListText(new ListValue($kept));
+    }
+
+    /**
+     * Appends the child to the accumulator when its `<name>.cli` flag is true.
+     *
+     * @param Value $child One element from the source ListValue, must be a StringValue
+     * @param Settings $settings Settings context the formula reads from
+     * @param list<StringValue> $kept Accumulator of already-kept names
+     * @throws SheriffException
+     * @return list<StringValue> Updated accumulator
+     */
+    private function keepWhenEnabled(Value $child, Settings $settings, array $kept): array
+    {
+        if (!$child instanceof StringValue) {
+            throw new SheriffException(
+                sprintf('EnabledTools expects string tool names, got %s', $child::class),
+            );
+        }
+
+        $flag = sprintf('%s.cli', $child->raw);
+
+        if (!$settings->has($flag)) {
+            throw new SheriffException(
+                sprintf('EnabledTools: setting "%s" not declared', $flag),
+            );
+        }
+
+        $value = $settings->value($flag);
+
+        if (!$value instanceof BoolValue) {
+            throw new SheriffException(
+                sprintf('EnabledTools expects "%s" to be a boolean, got %s', $flag, $value::class),
+            );
+        }
+
+        if ($value->raw) {
+            $kept[] = $child;
+        }
+
+        return $kept;
+    }
+}

--- a/src/Chain/Parse/FormulaTarget.php
+++ b/src/Chain/Parse/FormulaTarget.php
@@ -31,6 +31,10 @@ final readonly class FormulaTarget
      */
     public function formula(): Formula
     {
+        if ($this->name === 'EnabledTools') {
+            return new EnabledToolsFormula($this->args);
+        }
+
         foreach ($this->candidates() as $candidate) {
             /** @var class-string<Op> $target */
             $target = sprintf('%s%s', $candidate['namespace'], $this->name);

--- a/templates/always/.github/workflows/sheriff.yml
+++ b/templates/always/.github/workflows/sheriff.yml
@@ -42,13 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         check:
-          - actionlint
-          - hadolint
-          - markdownlint
-          - yamllint
-          - typos
-          - shellcheck
-          - jsonlint
+{% EnabledTools(ci.infra_checks)|EachFormatted("          - %s")|Joined("\n") %}
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -79,11 +73,7 @@ jobs:
       matrix:
         php: [{% ListText(php.versions)|EachFormatted('"%s"')|Joined(", ") %}]
         check:
-          - phpcs
-          - phpstan
-          - psalm
-          - phpmd
-          - phpmetrics
+{% EnabledTools(ci.php_checks)|EachFormatted("          - %s")|Joined("\n") %}
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -21,6 +21,8 @@ defaults:
 
   ci.sheriff_bin: "vendor/bin/sheriff"
   ci.pr.max_lines_changed: 250
+  ci.infra_checks: ["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]
+  ci.php_checks: ["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]
 
   coverage.patch.target: 80
   coverage.patch.threshold: 5

--- a/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
+++ b/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Listed;
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\Chain\Parse\EnabledToolsFormula;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EnabledToolsFormulaTest extends TestCase
+{
+    #[Test]
+    public function keepsToolWhenCliFlagTrue(): void
+    {
+        self::assertSame(
+            ['actionlint'],
+            self::names(
+                (new EnabledToolsFormula(['ci.infra_checks']))
+                    ->op([], self::settings([
+                        'ci.infra_checks' => new ListValue([new StringValue('actionlint')]),
+                        'actionlint.cli' => new BoolValue(true),
+                    ])),
+            ),
+            'EnabledTools must keep names whose <name>.cli flag is true',
+        );
+    }
+
+    #[Test]
+    public function dropsToolWhenCliFlagFalse(): void
+    {
+        self::assertSame(
+            ['phpstan'],
+            self::names(
+                (new EnabledToolsFormula(['ci.php_checks']))
+                    ->op([], self::settings([
+                        'ci.php_checks' => new ListValue([
+                            new StringValue('phpstan'),
+                            new StringValue('phpmetrics'),
+                        ]),
+                        'phpstan.cli' => new BoolValue(true),
+                        'phpmetrics.cli' => new BoolValue(false),
+                    ])),
+            ),
+            'EnabledTools must drop names whose <name>.cli flag is false',
+        );
+    }
+
+    #[Test]
+    public function preservesOrderOfKeptTools(): void
+    {
+        self::assertSame(
+            ['actionlint', 'yamllint', 'shellcheck'],
+            self::names(
+                (new EnabledToolsFormula(['ci.infra_checks']))
+                    ->op([], self::settings([
+                        'ci.infra_checks' => new ListValue([
+                            new StringValue('actionlint'),
+                            new StringValue('hadolint'),
+                            new StringValue('yamllint'),
+                            new StringValue('shellcheck'),
+                        ]),
+                        'actionlint.cli' => new BoolValue(true),
+                        'hadolint.cli' => new BoolValue(false),
+                        'yamllint.cli' => new BoolValue(true),
+                        'shellcheck.cli' => new BoolValue(true),
+                    ])),
+            ),
+            'EnabledTools must preserve the original order of kept names',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenCliFlagNotDeclared(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('setting "ghost.cli" not declared');
+
+        (new EnabledToolsFormula(['ci.infra_checks']))
+            ->op([], self::settings([
+                'ci.infra_checks' => new ListValue([new StringValue('ghost')]),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenAllToolsDisabled(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('resolved no enabled tools in "ci.infra_checks"');
+
+        (new EnabledToolsFormula(['ci.infra_checks']))
+            ->op([], self::settings([
+                'ci.infra_checks' => new ListValue([new StringValue('actionlint')]),
+                'actionlint.cli' => new BoolValue(false),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenSettingsKeyAbsent(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('cannot find settings key "ci.missing"');
+
+        (new EnabledToolsFormula(['ci.missing']))
+            ->op([], self::settings([]));
+    }
+
+    #[Test]
+    public function throwsWhenArgumentCountWrong(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('expects exactly one settings key, got 2');
+
+        (new EnabledToolsFormula(['ci.a', 'ci.b']))
+            ->op([], self::settings([]));
+    }
+
+    #[Test]
+    public function throwsWhenSourceKeyIsNotAList(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EnabledToolsFormula(['ci.infra_checks']))
+            ->op([], self::settings([
+                'ci.infra_checks' => new BoolValue(true),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenCliFlagIsNotBoolean(): void
+    {
+        $this->expectException(SheriffException::class);
+
+        (new EnabledToolsFormula(['ci.infra_checks']))
+            ->op([], self::settings([
+                'ci.infra_checks' => new ListValue([new StringValue('actionlint')]),
+                'actionlint.cli' => new IntValue(1),
+            ]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function names(Op $op): array
+    {
+        if (!$op instanceof Listed) {
+            throw new SheriffException('EnabledTools must produce a Listed pipeline source');
+        }
+
+        return array_map(
+            static fn(Op $part): string => $part->rendered(),
+            $op->parts(),
+        );
+    }
+
+    /**
+     * @param array<string, Value> $values
+     */
+    private static function settings(array $values): Settings
+    {
+        return new readonly class ($values) implements Settings {
+            /**
+             * @param array<string, Value> $values
+             */
+            public function __construct(private array $values) {}
+
+            #[Override]
+            public function has(string $name): bool
+            {
+                return array_key_exists($name, $this->values);
+            }
+
+            #[Override]
+            public function value(string $name): Value
+            {
+                return $this->values[$name];
+            }
+
+            #[Override]
+            public function keys(): array
+            {
+                return array_keys($this->values);
+            }
+        };
+    }
+}

--- a/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
+++ b/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
@@ -129,6 +129,7 @@ final class EnabledToolsFormulaTest extends TestCase
     public function throwsWhenSourceKeyIsNotAList(): void
     {
         $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('to be a list');
 
         (new EnabledToolsFormula(['ci.infra_checks']))
             ->op([], self::settings([
@@ -140,6 +141,7 @@ final class EnabledToolsFormulaTest extends TestCase
     public function throwsWhenCliFlagIsNotBoolean(): void
     {
         $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('to be a boolean');
 
         (new EnabledToolsFormula(['ci.infra_checks']))
             ->op([], self::settings([

--- a/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
+++ b/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
@@ -138,6 +138,18 @@ final class EnabledToolsFormulaTest extends TestCase
     }
 
     #[Test]
+    public function throwsWhenToolNameIsNotString(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('expects string tool names');
+
+        (new EnabledToolsFormula(['ci.infra_checks']))
+            ->op([], self::settings([
+                'ci.infra_checks' => new ListValue([new IntValue(42)]),
+            ]));
+    }
+
+    #[Test]
     public function throwsWhenCliFlagIsNotBoolean(): void
     {
         $this->expectException(SheriffException::class);


### PR DESCRIPTION
- Added `EnabledTools` formula that filters a tool list by `<name>.cli` flag
- Added `ci.infra_checks` and `ci.php_checks` keys driving the two CI matrices
- Updated the CI workflow template to feed both matrices through `EnabledTools`
- Updated the configuration reference and formula reference in `DEV.md`

Closes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI tool checks are now dynamically configured through configuration files instead of hardcoded in workflows, enabling flexible control over which linters and analysis tools run.

* **Chores**
  * Removed phpmetrics from default static analysis tools.
  * Introduced configurable infrastructure and PHP check lists.

* **Documentation**
  * Updated documentation with new configuration references for CI check sets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->