### PR TITLE
Adopt Phpstan-Rules v0.51.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ vendor/bin/sheriff check
 
 | Tool          | Rules                                              |
 |---------------|----------------------------------------------------|
-| PHPStan       | 123 (48 strict + 75 [haspadar custom](https://github.com/haspadar/phpstan-rules)) at level 9 |
+| PHPStan       | 128 (48 strict + 80 [haspadar custom](https://github.com/haspadar/phpstan-rules)) at level 9 |
 | Psalm         | 331 issue types at level 1                         |
 | PHP_CodeSniffer | 382 sniffs ([Slevomat](https://github.com/slevomat/coding-standard) + core) |
 | PHP-CS-Fixer  | 364 fixers (303 core + 61 [kubawerlos](https://github.com/kubawerlos/php-cs-fixer-custom-fixers)) |
@@ -125,7 +125,7 @@ Do not edit `.sheriff/` or the GitHub workflow file `.github/workflows/sheriff.y
 
 ### PHP
 
-- PHPStan — level 9 with [strict rules](https://github.com/phpstan/phpstan-strict-rules) and [haspadar/phpstan-rules](https://github.com/haspadar/phpstan-rules) (75 custom rules for object-oriented strictness)
+- PHPStan — level 9 with [strict rules](https://github.com/phpstan/phpstan-strict-rules) and [haspadar/phpstan-rules](https://github.com/haspadar/phpstan-rules) (80 custom rules for object-oriented strictness)
 - Psalm
 - PHPUnit
 - Infection

--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.50.0",
+            "version": "v0.51.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "2990bdf4c5feed7cc8ea06d613b32e33d1fff140"
+                "reference": "5ce29874c716d34c2b2d275d73741e580bba82b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/2990bdf4c5feed7cc8ea06d613b32e33d1fff140",
-                "reference": "2990bdf4c5feed7cc8ea06d613b32e33d1fff140",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/5ce29874c716d34c2b2d275d73741e580bba82b9",
+                "reference": "5ce29874c716d34c2b2d275d73741e580bba82b9",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.50.0"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.51.1"
             },
-            "time": "2026-05-15T20:24:19+00:00"
+            "time": "2026-05-18T12:34:05+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
- Updated `haspadar/phpstan-rules` from v0.50.0 to v0.51.1
- Updated PHPStan rule counts in `README.md` to match the new default policy

Closes #749

Notes: v0.51.1 brings `NPathComplexityRule` and `TooManyFieldsRule` to the default policy; `BooleanArgumentFlagRule` was moved to `rules-experimental.neon` in v0.51.1 (opt-in) because it produced false positives on `bool` value-object constructors in EO-style code.