### PR TITLE
Disable Phpmd in the Default Check Pipeline

### DIFF
--- a/.github/workflows/sheriff.yml
+++ b/.github/workflows/sheriff.yml
@@ -82,7 +82,6 @@ jobs:
           - phpcs
           - phpstan
           - psalm
-          - phpmd
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -64,7 +64,7 @@ defaults:
   phpcs.cli: true
   phpcs.extend: ""
 
-  phpmd.cli: true
+  phpmd.cli: false
   phpmd.class_complexity: 50
   phpmd.class_length: 200
   phpmd.cyclomatic: 10

--- a/DEV.md
+++ b/DEV.md
@@ -491,7 +491,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `phpmd.cli` | `true` | Enable PHP Mess Detector |
+| `phpmd.cli` | `false` | Enable PHP Mess Detector (opt-in: checks duplicate haspadar/phpstan-rules) |
 | `phpmd.class_complexity` | `50` | Max class complexity |
 | `phpmd.class_length` | `200` | Max class length |
 | `phpmd.cyclomatic` | `10` | Max cyclomatic complexity |

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -64,7 +64,7 @@ defaults:
   phpcs.cli: true
   phpcs.extend: ""
 
-  phpmd.cli: true
+  phpmd.cli: false
   phpmd.class_complexity: 50
   phpmd.class_length: 200
   phpmd.cyclomatic: 10


### PR DESCRIPTION
- Updated `phpmd.cli` default from `true` to `false`
- Updated configuration reference in `DEV.md` with the new default and opt-in note

Closes #751

**Breaking changes:**
- Default `sheriff check` no longer runs phpmd. To restore previous behavior, set `override: { phpmd.cli: true }` in `.sheriff.yaml`. Templates and threshold keys are preserved.