### PR TITLE
Bump phpstan-rules to v0.52.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.51.1",
+            "version": "v0.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "5ce29874c716d34c2b2d275d73741e580bba82b9"
+                "reference": "adb92b54bcde1a07e10a5daee57119c9e1d199a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/5ce29874c716d34c2b2d275d73741e580bba82b9",
-                "reference": "5ce29874c716d34c2b2d275d73741e580bba82b9",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/adb92b54bcde1a07e10a5daee57119c9e1d199a2",
+                "reference": "adb92b54bcde1a07e10a5daee57119c9e1d199a2",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.51.1"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.52.0"
             },
-            "time": "2026-05-18T12:34:05+00:00"
+            "time": "2026-05-19T06:52:08+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
- Updated haspadar/phpstan-rules from v0.51.1 to v0.52.0 for the Named Constructor Delegation rule

Closes #755