### PR TITLE
Permit Private Static Helpers Under Named Constructor Delegation

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -111,6 +111,7 @@ defaults:
         excludedClasses: []
       prohibitStaticMethods:
         allowNamedConstructors: true
+        onlyPublic: true
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -24,3 +24,4 @@ parameters:
                 - \Haspadar\Sheriff\SheriffException
         prohibitStaticMethods:
             allowNamedConstructors: true
+            onlyPublic: true

--- a/DEV.md
+++ b/DEV.md
@@ -542,6 +542,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `phpstan.parameters.haspadar.afferentCoupling.ignoreInterfaces` | `true` | Skip interfaces when counting afferent coupling (haspadar rule) |
 | `phpstan.parameters.haspadar.afferentCoupling.excludedClasses` | `[]` | FQCNs excluded from the haspadar afferent coupling rule |
 | `phpstan.parameters.haspadar.prohibitStaticMethods.allowNamedConstructors` | `true` | Allow named constructors (e.g. `public static function fromX(...): self { return new self(...); }` or `public static function fromX(...): static { return new static(...); }`) as the only sanctioned static methods |
+| `phpstan.parameters.haspadar.prohibitStaticMethods.onlyPublic` | `true` | Restrict the check to public static methods, permitting private static helpers (e.g. for delegation from named constructors) |
 
 `phpstan.parameters` is a nested tree merged into the rendered `phpstan.neon` under `parameters:`. Use `override:` / `append:` / `remove:` on any leaf to customise the analysis without rewriting the file.
 

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -111,6 +111,7 @@ defaults:
         excludedClasses: []
       prohibitStaticMethods:
         allowNamedConstructors: true
+        onlyPublic: true
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -115,7 +115,8 @@ final class TemplateFileTest extends TestCase
                 . "            ignoreInterfaces: true\n"
                 . "            excludedClasses: []\n"
                 . "        prohibitStaticMethods:\n"
-                . "            allowNamedConstructors: true",
+                . "            allowNamedConstructors: true\n"
+                . "            onlyPublic: true",
             ),
             'TemplateFile must render the phpstan.parameters TreeValue as a nested neon block, including bare strings and block-style lists',
         );


### PR DESCRIPTION
- Added onlyPublic: true to the default prohibitStaticMethods config
- Updated DEV.md with the new configuration key
- Updated the template snapshot test fixture

Closes #757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated PHPStan static method analysis configuration to restrict checks to public methods only, allowing private static methods to be used as internal helpers.
  * Updated documentation and tests to reflect the new configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->