### PR TITLE
Drop onlyPublic Default After phpstan-rules v0.52.1

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -111,7 +111,6 @@ defaults:
         excludedClasses: []
       prohibitStaticMethods:
         allowNamedConstructors: true
-        onlyPublic: true
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -24,4 +24,3 @@ parameters:
                 - \Haspadar\Sheriff\SheriffException
         prohibitStaticMethods:
             allowNamedConstructors: true
-            onlyPublic: true

--- a/DEV.md
+++ b/DEV.md
@@ -542,7 +542,6 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `phpstan.parameters.haspadar.afferentCoupling.ignoreInterfaces` | `true` | Skip interfaces when counting afferent coupling (haspadar rule) |
 | `phpstan.parameters.haspadar.afferentCoupling.excludedClasses` | `[]` | FQCNs excluded from the haspadar afferent coupling rule |
 | `phpstan.parameters.haspadar.prohibitStaticMethods.allowNamedConstructors` | `true` | Allow named constructors (e.g. `public static function fromX(...): self { return new self(...); }` or `public static function fromX(...): static { return new static(...); }`) as the only sanctioned static methods |
-| `phpstan.parameters.haspadar.prohibitStaticMethods.onlyPublic` | `true` | Restrict the check to public static methods, permitting private static helpers (e.g. for delegation from named constructors) |
 
 `phpstan.parameters` is a nested tree merged into the rendered `phpstan.neon` under `parameters:`. Use `override:` / `append:` / `remove:` on any leaf to customise the analysis without rewriting the file.
 

--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.52.0",
+            "version": "v0.52.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "adb92b54bcde1a07e10a5daee57119c9e1d199a2"
+                "reference": "13391b5fabc81559010935c02ee01f8ede91a288"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/adb92b54bcde1a07e10a5daee57119c9e1d199a2",
-                "reference": "adb92b54bcde1a07e10a5daee57119c9e1d199a2",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/13391b5fabc81559010935c02ee01f8ede91a288",
+                "reference": "13391b5fabc81559010935c02ee01f8ede91a288",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.52.0"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.52.1"
             },
-            "time": "2026-05-19T06:52:08+00:00"
+            "time": "2026-05-19T14:06:31+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -111,7 +111,6 @@ defaults:
         excludedClasses: []
       prohibitStaticMethods:
         allowNamedConstructors: true
-        onlyPublic: true
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -115,8 +115,7 @@ final class TemplateFileTest extends TestCase
                 . "            ignoreInterfaces: true\n"
                 . "            excludedClasses: []\n"
                 . "        prohibitStaticMethods:\n"
-                . "            allowNamedConstructors: true\n"
-                . "            onlyPublic: true",
+                . "            allowNamedConstructors: true",
             ),
             'TemplateFile must render the phpstan.parameters TreeValue as a nested neon block, including bare strings and block-style lists',
         );


### PR DESCRIPTION
- Removed `prohibitStaticMethods.onlyPublic` default from configuration, generated PHPStan parameters, and reference docs
- Updated template rendering test fixture to drop the obsolete option
- Updated `haspadar/phpstan-rules` to v0.52.1 where the option no longer exists

Closes #759