### PR TITLE
Mixed Other Parameter In Custom PHPUnit Constraints

### DIFF
--- a/tests/Constraint/Files/HasFileContents.php
+++ b/tests/Constraint/Files/HasFileContents.php
@@ -13,7 +13,8 @@ final class HasFileContents extends Constraint
         private readonly string $expected,
     ) {}
 
-    protected function matches($other): bool
+    #[\Override]
+    protected function matches(mixed $other): bool
     {
         return $other instanceof File
             && $other->contents() === $this->expected;
@@ -24,7 +25,8 @@ final class HasFileContents extends Constraint
         return 'has contents ' . var_export($this->expected, true);
     }
 
-    protected function additionalFailureDescription($other): string
+    #[\Override]
+    protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof File) {
             return "\nBut object of type "

--- a/tests/Constraint/Files/HasFiles.php
+++ b/tests/Constraint/Files/HasFiles.php
@@ -22,7 +22,8 @@ final class HasFiles extends Constraint
         return 'has files ' . $this->export($this->expected);
     }
 
-    protected function matches($other): bool
+    #[\Override]
+    protected function matches(mixed $other): bool
     {
         if (!$other instanceof Files) {
             return false;
@@ -45,12 +46,14 @@ final class HasFiles extends Constraint
         return $actual === $expected;
     }
 
-    protected function failureDescription($other): string
+    #[\Override]
+    protected function failureDescription(mixed $other): string
     {
         return 'files ' . $this->toString();
     }
 
-    protected function additionalFailureDescription($other): string
+    #[\Override]
+    protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof Files) {
             return "\nBut object of type "

--- a/tests/Constraint/HasFormulaError.php
+++ b/tests/Constraint/HasFormulaError.php
@@ -16,7 +16,8 @@ final class HasFormulaError extends Constraint
         private readonly string $reasonPart,
     ) {}
 
-    protected function matches($other): bool
+    #[\Override]
+    protected function matches(mixed $other): bool
     {
         if (!$other instanceof File) {
             return false;

--- a/tests/Constraint/Storage/HasEntries.php
+++ b/tests/Constraint/Storage/HasEntries.php
@@ -22,7 +22,8 @@ final class HasEntries extends Constraint
         return "has entries {$this->export($this->expected)} under {$this->export($this->location)}";
     }
 
-    protected function matches($other): bool
+    #[\Override]
+    protected function matches(mixed $other): bool
     {
         if (!$other instanceof Storage) {
             return false;
@@ -39,12 +40,14 @@ final class HasEntries extends Constraint
         return $actual === $expected;
     }
 
-    protected function failureDescription($other): string
+    #[\Override]
+    protected function failureDescription(mixed $other): string
     {
         return 'storage ' . $this->toString();
     }
 
-    protected function additionalFailureDescription($other): string
+    #[\Override]
+    protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof Storage) {
             return "\nBut object of type "

--- a/tests/Constraint/Storage/HasEntry.php
+++ b/tests/Constraint/Storage/HasEntry.php
@@ -22,7 +22,8 @@ final class HasEntry extends Constraint
             . "and mode {$this->export($this->mode)}";
     }
 
-    protected function matches($other): bool
+    #[\Override]
+    protected function matches(mixed $other): bool
     {
         return $other instanceof Storage
             && $other->exists($this->location)
@@ -30,12 +31,14 @@ final class HasEntry extends Constraint
             && $other->mode($this->location) === $this->mode;
     }
 
-    protected function failureDescription($other): string
+    #[\Override]
+    protected function failureDescription(mixed $other): string
     {
         return 'storage ' . $this->toString();
     }
 
-    protected function additionalFailureDescription($other): string
+    #[\Override]
+    protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof Storage) {
             return "\nBut object of type "

--- a/tests/Constraint/Storage/ReactionWasSilent.php
+++ b/tests/Constraint/Storage/ReactionWasSilent.php
@@ -14,19 +14,22 @@ final class ReactionWasSilent extends Constraint
         return 'recorded no created or updated paths';
     }
 
-    protected function matches($other): bool
+    #[\Override]
+    protected function matches(mixed $other): bool
     {
         return $other instanceof FakeStorageReaction
             && $other->createdPaths() === []
             && $other->updatedPaths() === [];
     }
 
-    protected function failureDescription($other): string
+    #[\Override]
+    protected function failureDescription(mixed $other): string
     {
         return 'reaction ' . $this->toString();
     }
 
-    protected function additionalFailureDescription($other): string
+    #[\Override]
+    protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof FakeStorageReaction) {
             return "\nBut object of type " . get_debug_type($other) . ' was given';


### PR DESCRIPTION
- Added mixed type to $other parameter in matches, failureDescription and additionalFailureDescription of custom PHPUnit Constraint subclasses
- Added #[\Override] attribute to the same overridden methods

Part of #763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to use modern PHP 8.3+ syntax and stronger type declarations for improved code consistency and maintainability across the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->