### PR TITLE
Joined Lists Pipeline Source

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -124,6 +124,7 @@ Example:
 | `EnvsText(key, indent)` | `TreeValue` (or empty `ListValue`) | GitHub Actions step exporting env vars; empty tree → empty string |
 | `NeonTree(key, depth)` | `TreeValue` | nested neon block mapping; `depth` is optional (default `0`) and controls indentation |
 | `EnabledTools(key)` | `ListValue` of tool names | Listed pipeline of names whose `<name>.cli` flag is `true`; fails fast on missing or non-boolean flags, and when the resolved list is empty |
+| `JoinedLists(left, right, "sep")` | two `ListValue` of strings keys | Listed pipeline of joined `<left><sep><right>` strings (left-major cartesian product); empty when either side resolves to no values |
 
 ### Map ops
 
@@ -147,6 +148,10 @@ Example:
 List formatting:
 
 `{% ListText(phpunit.testsuites.unit)|EachFormatted("            <directory>%s</directory>")|Joined("\n") %}`
+
+Path joining across configuration keys:
+
+`{% JoinedLists(php.tests, phpunit.testsuites.unit, "/")|EachFormatted("            <directory>%s</directory>")|Joined("\n") %}`
 
 Per-item rewriting before formatting:
 

--- a/src/Chain/Parse/FormulaTarget.php
+++ b/src/Chain/Parse/FormulaTarget.php
@@ -35,6 +35,10 @@ final readonly class FormulaTarget
             return new EnabledToolsFormula($this->args);
         }
 
+        if ($this->name === 'JoinedLists') {
+            return new JoinedListsFormula($this->args);
+        }
+
         foreach ($this->candidates() as $candidate) {
             /** @var class-string<Op> $target */
             $target = sprintf('%s%s', $candidate['namespace'], $this->name);

--- a/src/Chain/Parse/JoinedListsFormula.php
+++ b/src/Chain/Parse/JoinedListsFormula.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\Chain\Plain\ListText;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+
+/**
+ * Combines two list settings into the cartesian product joined by a separator.
+ *
+ * Reads two settings keys, each pointing to a ListValue of StringValues, and
+ * produces one StringValue per pair (left, right) joined by the literal
+ * separator. The order is left-major: every right is emitted for the first
+ * left, then for the second, and so on. When either side resolves to an empty
+ * list the result is empty as well; missing keys, non-list values and
+ * non-string elements fail fast. The result is a `ListText` source op that
+ * downstream pipeline stages consume as a plain list.
+ *
+ * Example:
+ *
+ *     (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+ *         ->op([], $settings);
+ *     // ListText over ["tests/Unit"] when php.tests=["tests"], unit=["Unit"]
+ */
+final readonly class JoinedListsFormula implements Formula
+{
+    private const int EXPECTED_ARGS = 3;
+
+    private const int SEPARATOR_INDEX = 2;
+
+    /**
+     * Initializes with the raw template arguments — two settings keys and a separator.
+     *
+     * @param list<string> $args Raw template arguments; expects two settings keys followed by the separator literal
+     */
+    public function __construct(private array $args) {}
+
+    #[Override]
+    public function op(array $previous, Settings $settings): Op
+    {
+        if (count($this->args) !== self::EXPECTED_ARGS) {
+            throw new SheriffException(
+                sprintf(
+                    'JoinedLists expects two settings keys and a separator, got %d arguments',
+                    count($this->args),
+                ),
+            );
+        }
+
+        $left = $this->stringList($this->args[0], $settings);
+        $right = $this->stringList($this->args[1], $settings);
+        $separator = $this->args[self::SEPARATOR_INDEX];
+
+        return new ListText(new ListValue($this->pairs($left, $right, $separator)));
+    }
+
+    /**
+     * Reads the named key as a list of StringValues.
+     *
+     * @throws SheriffException
+     * @return list<StringValue>
+     */
+    private function stringList(string $key, Settings $settings): array
+    {
+        if (!$settings->has($key)) {
+            throw new SheriffException(
+                sprintf('JoinedLists cannot find settings key "%s"', $key),
+            );
+        }
+
+        $value = $settings->value($key);
+
+        if (!$value instanceof ListValue) {
+            throw new SheriffException(
+                sprintf('JoinedLists expects "%s" to be a list, got %s', $key, $value::class),
+            );
+        }
+
+        $strings = [];
+
+        foreach ($value->children as $child) {
+            $strings[] = $this->asString($key, $child);
+        }
+
+        return $strings;
+    }
+
+    /**
+     * Asserts the child is a StringValue, returning it unchanged.
+     *
+     * @throws SheriffException
+     */
+    private function asString(string $key, Value $child): StringValue
+    {
+        if (!$child instanceof StringValue) {
+            throw new SheriffException(
+                sprintf('JoinedLists expects "%s" to contain strings, got %s', $key, $child::class),
+            );
+        }
+
+        return $child;
+    }
+
+    /**
+     * Builds the left-major cartesian product joined by the separator.
+     *
+     * @param list<StringValue> $left
+     * @param list<StringValue> $right
+     * @return list<StringValue>
+     */
+    private function pairs(array $left, array $right, string $separator): array
+    {
+        $result = [];
+
+        foreach ($left as $leftPart) {
+            foreach ($right as $rightPart) {
+                $result[] = new StringValue(sprintf('%s%s%s', $leftPart->raw, $separator, $rightPart->raw));
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Chain/Parse/JoinedListsFormulaTest.php
+++ b/tests/Unit/Chain/Parse/JoinedListsFormulaTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Listed;
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\Chain\Parse\JoinedListsFormula;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\BoolValue;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JoinedListsFormulaTest extends TestCase
+{
+    #[Test]
+    public function joinsSingleLeftWithSingleRight(): void
+    {
+        self::assertSame(
+            ['tests/Unit'],
+            self::strings(
+                (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+                    ->op([], self::settings([
+                        'php.tests' => new ListValue([new StringValue('tests')]),
+                        'phpunit.testsuites.unit' => new ListValue([new StringValue('Unit')]),
+                    ])),
+            ),
+            'JoinedLists must join one-to-one pairs with the separator',
+        );
+    }
+
+    #[Test]
+    public function emitsCartesianProductOfBothLists(): void
+    {
+        self::assertSame(
+            ['tests/Unit', 'tests/Integration', 'spec/Unit', 'spec/Integration'],
+            self::strings(
+                (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+                    ->op([], self::settings([
+                        'php.tests' => new ListValue([
+                            new StringValue('tests'),
+                            new StringValue('spec'),
+                        ]),
+                        'phpunit.testsuites.unit' => new ListValue([
+                            new StringValue('Unit'),
+                            new StringValue('Integration'),
+                        ]),
+                    ])),
+            ),
+            'JoinedLists must emit a left-major cartesian product',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenLeftIsEmpty(): void
+    {
+        self::assertSame(
+            [],
+            self::strings(
+                (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+                    ->op([], self::settings([
+                        'php.tests' => new ListValue([]),
+                        'phpunit.testsuites.unit' => new ListValue([new StringValue('Unit')]),
+                    ])),
+            ),
+            'JoinedLists must return an empty list when the left key resolves to no values',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenRightIsEmpty(): void
+    {
+        self::assertSame(
+            [],
+            self::strings(
+                (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+                    ->op([], self::settings([
+                        'php.tests' => new ListValue([new StringValue('tests')]),
+                        'phpunit.testsuites.unit' => new ListValue([]),
+                    ])),
+            ),
+            'JoinedLists must return an empty list when the right key resolves to no values',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenArgumentCountWrong(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('two settings keys and a separator, got 2');
+
+        (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit']))
+            ->op([], self::settings([]));
+    }
+
+    #[Test]
+    public function throwsWhenLeftKeyAbsent(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('cannot find settings key "php.tests"');
+
+        (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+            ->op([], self::settings([
+                'phpunit.testsuites.unit' => new ListValue([new StringValue('Unit')]),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenRightKeyAbsent(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('cannot find settings key "phpunit.testsuites.unit"');
+
+        (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+            ->op([], self::settings([
+                'php.tests' => new ListValue([new StringValue('tests')]),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenLeftKeyIsNotList(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('"php.tests" to be a list');
+
+        (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+            ->op([], self::settings([
+                'php.tests' => new BoolValue(true),
+                'phpunit.testsuites.unit' => new ListValue([new StringValue('Unit')]),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenLeftElementIsNotString(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('"php.tests" to contain strings');
+
+        (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+            ->op([], self::settings([
+                'php.tests' => new ListValue([new IntValue(42)]),
+                'phpunit.testsuites.unit' => new ListValue([new StringValue('Unit')]),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenRightKeyIsNotList(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('"phpunit.testsuites.unit" to be a list');
+
+        (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+            ->op([], self::settings([
+                'php.tests' => new ListValue([new StringValue('tests')]),
+                'phpunit.testsuites.unit' => new BoolValue(true),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenRightElementIsNotString(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('"phpunit.testsuites.unit" to contain strings');
+
+        (new JoinedListsFormula(['php.tests', 'phpunit.testsuites.unit', '/']))
+            ->op([], self::settings([
+                'php.tests' => new ListValue([new StringValue('tests')]),
+                'phpunit.testsuites.unit' => new ListValue([new IntValue(42)]),
+            ]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function strings(Op $op): array
+    {
+        if (!$op instanceof Listed) {
+            throw new SheriffException('JoinedLists must produce a Listed pipeline source');
+        }
+
+        return array_map(
+            static fn(Op $part): string => $part->rendered(),
+            $op->parts(),
+        );
+    }
+
+    /**
+     * @param array<string, Value> $values
+     */
+    private static function settings(array $values): Settings
+    {
+        return new readonly class ($values) implements Settings {
+            /**
+             * @param array<string, Value> $values
+             */
+            public function __construct(private array $values) {}
+
+            #[Override]
+            public function has(string $name): bool
+            {
+                return array_key_exists($name, $this->values);
+            }
+
+            #[Override]
+            public function value(string $name): Value
+            {
+                return $this->values[$name];
+            }
+
+            #[Override]
+            public function keys(): array
+            {
+                return array_keys($this->values);
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Added JoinedLists DSL source op that emits the left-major cartesian product of two list settings joined by a separator
- Updated DEV.md with the new op entry and a usage example

Closes #768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `JoinedLists` operation to combine two configuration lists using a custom separator, generating a left-major product with empty results when either input is empty.

* **Documentation**
  * Added DSL documentation and usage examples for the new list-joining operation.

* **Tests**
  * Added comprehensive test coverage validating joins, cartesian products, edge cases, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->