### PR TITLE
Php Tests Configuration Key

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -11,6 +11,7 @@
 
 defaults:
   php.src: ["src"]
+  php.tests: ["tests"]
   infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
   envs: {}

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -11,6 +11,7 @@
 
 defaults:
   php.src: ["src"]
+  php.tests: ["tests"]
   infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
   envs: {}


### PR DESCRIPTION
- Added php.tests default key holding test code paths separate from production source paths

Closes #770