### PR TITLE
Phpunit Suites Composed From Php Tests

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -115,8 +115,9 @@ defaults:
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
-  phpunit.testsuites.unit: ["../../tests/Unit"]
-  phpunit.testsuites.integration: ["../../tests/Integration"]
+  # phpunit.testsuites.* values are subdirectories of php.tests, not full paths
+  phpunit.testsuites.unit: ["Unit"]
+  phpunit.testsuites.integration: ["Integration"]
 
   psalm.cli: true
   psalm.error_level: 1

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -115,8 +115,9 @@ defaults:
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
-  phpunit.testsuites.unit: ["../../tests/Unit"]
-  phpunit.testsuites.integration: ["../../tests/Integration"]
+  # phpunit.testsuites.* values are subdirectories of php.tests, not full paths
+  phpunit.testsuites.unit: ["Unit"]
+  phpunit.testsuites.integration: ["Integration"]
 
   psalm.cli: true
   psalm.error_level: 1

--- a/templates/always/.sheriff/phpunit/phpunit.xml
+++ b/templates/always/.sheriff/phpunit/phpunit.xml
@@ -11,11 +11,11 @@
 >
     <testsuites>
         <testsuite name="unit">
-{% ListText(phpunit.testsuites.unit)|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
+{% JoinedLists(php.tests, phpunit.testsuites.unit, "/")|EachFormatted("../../%s")|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
         </testsuite>
 
         <testsuite name="integration">
-{% ListText(phpunit.testsuites.integration)|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
+{% JoinedLists(php.tests, phpunit.testsuites.integration, "/")|EachFormatted("../../%s")|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
- Refactored PHPUnit suite paths to derive from php.tests joined with subdirectory names
- Updated phpunit.testsuites defaults to hold subdirectory names instead of absolute paths

Closes #772

**Breaking changes:**
- phpunit.testsuites.unit and phpunit.testsuites.integration overrides now hold subdirectories of php.tests, not full paths. Projects overriding these keys with full paths must shorten them to subdirectory names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified PHPUnit test suite path configuration across default and template configurations, switching from full relative paths to relative subdirectory names.
  * Updated test suite discovery template generation for unit and integration test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->