### PR TITLE
Sonar Tests Sourced From Php Tests

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -142,7 +142,6 @@ defaults:
   sonar.cli: false
   sonar.organization: ""
   sonar.projectKey: ""
-  sonar.tests: ["tests"]
   sonar.exclusions: []
   sonar.php.coverage.reportPaths: [".sheriff/codecov/coverage.xml"]
 

--- a/DEV.md
+++ b/DEV.md
@@ -601,7 +601,6 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `sonar.cli` | `false` | Enable local sonar-scanner |
 | `sonar.organization` | `""` | SonarCloud organization |
 | `sonar.projectKey` | `""` | SonarCloud project key |
-| `sonar.tests` | `["tests"]` | Test directories |
 | `sonar.exclusions` | `[]` | Excluded paths |
 | `sonar.php.coverage.reportPaths` | `[".sheriff/codecov/coverage.xml"]` | Coverage report path |
 

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -142,7 +142,6 @@ defaults:
   sonar.cli: false
   sonar.organization: ""
   sonar.projectKey: ""
-  sonar.tests: ["tests"]
   sonar.exclusions: []
   sonar.php.coverage.reportPaths: [".sheriff/codecov/coverage.xml"]
 

--- a/templates/always/.sheriff/sonar/sonar-project.properties
+++ b/templates/always/.sheriff/sonar/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization={% StringText(sonar.organization) %}
 sonar.projectKey={% StringText(sonar.projectKey) %}
 sonar.sources={% ListText(php.src)|Joined(",") %}
-sonar.tests={% ListText(sonar.tests)|Joined(",") %}
+sonar.tests={% ListText(php.tests)|Joined(",") %}
 sonar.exclusions={% ListText(sonar.exclusions)|Joined(",") %}
 sonar.php.coverage.reportPaths={% ListText(sonar.php.coverage.reportPaths)|Joined(",") %}


### PR DESCRIPTION
- Refactored SonarCloud properties to read sonar.tests from php.tests
- Removed dedicated sonar.tests defaults entry that duplicated php.tests
- Updated DEV.md to drop the removed key from the documented defaults

Closes #776

**Breaking changes:**
- sonar.tests is no longer a configuration key. Projects overriding sonar.tests must move the value to php.tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarQube/SonarCloud configuration settings, adjusting test detection and exclusion parameters for improved code quality scanning.

* **Documentation**
  * Updated configuration reference guide to reflect changes in code analysis default settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->