### PR TITLE
Renovate Skips Pre Release Versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disablePreReleases"],
 
   "schedule": ["* 1-4 * * *"],
   "timezone": "UTC",


### PR DESCRIPTION
- Added disablePreReleases preset to renovate.json so dependency PRs only propose stable versions

Closes #778