### PR TITLE
Php Exclude Defaults Separate From Infra Excludes

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -12,6 +12,7 @@
 defaults:
   php.src: ["src"]
   php.tests: ["tests"]
+  php.exclude: ["vendor", ".git"]
   infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
   envs: {}

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -12,6 +12,7 @@
 defaults:
   php.src: ["src"]
   php.tests: ["tests"]
+  php.exclude: ["vendor", ".git"]
   infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
   envs: {}


### PR DESCRIPTION
- Added php.exclude default with vendor and .git so PHP analysers can have an independent excludes list

Part of #782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration to exclude vendor and system directories from PHP-related checks, reducing unnecessary analysis of third-party dependencies and version control files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->