### PR TITLE
Remove PR Size Check From CI

### DIFF
--- a/.github/workflows/sheriff.yml
+++ b/.github/workflows/sheriff.yml
@@ -9,27 +9,6 @@ on:
 jobs:
 
   # ============================================================
-  # PR SIZE CHECK
-  # ============================================================
-  pr_size:
-    name: PR Size
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-        with:
-          fetch-depth: 0
-
-      - uses: maidsafe/pr_size_checker@948bfb3e96d93fbeeef4e207375163e8dae5665e
-        with:
-          max_lines_changed: 5000
-
-
-  # ============================================================
   # INFRA CHECKS
   # ============================================================
   infra:

--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -2,7 +2,6 @@ override:
   phpmetrics.coupling.max_afferent: 35
   phpmetrics.coupling.max_efferent: 25
   php.versions: ["8.3", "8.4", "8.5"]
-  ci.pr.max_lines_changed: 5000
   ci.sheriff_bin: bin/sheriff
   sonar.organization: haspadar-org
   sonar.projectKey: haspadar_sheriff

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -21,7 +21,6 @@ defaults:
   check.slow: ["infection", "sonar"]
 
   ci.sheriff_bin: "vendor/bin/sheriff"
-  ci.pr.max_lines_changed: 250
   ci.infra_checks: ["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]
   ci.php_checks: ["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]
 

--- a/DEV.md
+++ b/DEV.md
@@ -404,7 +404,6 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ci.sheriff_bin` | `"vendor/bin/sheriff"` | Path to Sheriff binary in CI |
-| `ci.pr.max_lines_changed` | `250` | Maximum lines changed per PR |
 | `ci.infra_checks` | `["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]` | Tools placed into the infra CI matrix; filtered by each tool's `<name>.cli` flag. Override or `append` in `.sheriff.yaml` to extend the matrix |
 | `ci.php_checks` | `["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]` | Tools placed into the PHP-static CI matrix; filtered by each tool's `<name>.cli` flag. Override or `append` in `.sheriff.yaml` to extend the matrix |
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ override:
     phpstan.parameters:
         level: 8
     php.versions: ["8.3", "8.4", "8.5"]
-    ci.pr.max_lines_changed: 400
 ```
 
 Use `php_cs_fixer.extend` and `phpcs.extend` to inject native-syntax fragments at the end of the generated config. Useful when a built-in rule clashes with project code — for example, narrowing `phpdoc_types` instead of disabling it entirely:

--- a/templates/always/.github/workflows/sheriff.yml
+++ b/templates/always/.github/workflows/sheriff.yml
@@ -9,27 +9,6 @@ on:
 jobs:
 
   # ============================================================
-  # PR SIZE CHECK
-  # ============================================================
-  pr_size:
-    name: PR Size
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-        with:
-          fetch-depth: 0
-
-      - uses: maidsafe/pr_size_checker@948bfb3e96d93fbeeef4e207375163e8dae5665e
-        with:
-          max_lines_changed: {% IntText(ci.pr.max_lines_changed) %}
-
-
-  # ============================================================
   # INFRA CHECKS
   # ============================================================
   infra:

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -21,7 +21,6 @@ defaults:
   check.slow: ["infection", "sonar"]
 
   ci.sheriff_bin: "vendor/bin/sheriff"
-  ci.pr.max_lines_changed: 250
   ci.infra_checks: ["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]
   ci.php_checks: ["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]
 


### PR DESCRIPTION
- Removed pr_size job from the Sheriff workflow template and generated workflow
- Removed ci.pr.max_lines_changed key from default config, repository override, README and DEV docs

Closes #784