### PR TITLE
Tests Paths Filter Default For Haspadar Rules

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -107,6 +107,8 @@ defaults:
       checkedExceptionClasses:
         - '\Throwable'
     haspadar:
+      testsPaths:
+        - '*/tests/*'
       afferentCoupling:
         ignoreInterfaces: true
         excludedClasses: []

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -20,6 +20,8 @@ parameters:
         checkedExceptionClasses:
             - \Throwable
     haspadar:
+        testsPaths:
+            - "*/tests/*"
         afferentCoupling:
             ignoreInterfaces: true
             excludedClasses:

--- a/DEV.md
+++ b/DEV.md
@@ -543,6 +543,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `phpstan.parameters.checkClassCaseSensitivity` | `true` | Enforce case-sensitive class references |
 | `phpstan.parameters.checkDynamicProperties` | `true` | Report writes to undeclared dynamic properties |
 | `phpstan.parameters.exceptions.checkedExceptionClasses` | `['\Throwable']` | Checked exception classes for the strict-rules `throws` analysis |
+| `phpstan.parameters.haspadar.testsPaths` | `['*/tests/*']` | fnmatch patterns against absolute file paths; matched files are exempt from haspadar production rules |
 | `phpstan.parameters.haspadar.afferentCoupling.ignoreInterfaces` | `true` | Skip interfaces when counting afferent coupling (haspadar rule) |
 | `phpstan.parameters.haspadar.afferentCoupling.excludedClasses` | `[]` | FQCNs excluded from the haspadar afferent coupling rule |
 | `phpstan.parameters.haspadar.prohibitStaticMethods.allowNamedConstructors` | `true` | Allow named constructors (e.g. `public static function fromX(...): self { return new self(...); }` or `public static function fromX(...): static { return new static(...); }`) as the only sanctioned static methods |

--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.52.1",
+            "version": "v0.53.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "13391b5fabc81559010935c02ee01f8ede91a288"
+                "reference": "39ad4490ff4faae93b6fc941f7c5b2e800105faa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/13391b5fabc81559010935c02ee01f8ede91a288",
-                "reference": "13391b5fabc81559010935c02ee01f8ede91a288",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/39ad4490ff4faae93b6fc941f7c5b2e800105faa",
+                "reference": "39ad4490ff4faae93b6fc941f7c5b2e800105faa",
                 "shasum": ""
             },
             "require": {
@@ -1831,7 +1831,7 @@
                 "phpstan/phpstan": "^2.0"
             },
             "require-dev": {
-                "haspadar/sheriff": "^0.29",
+                "haspadar/sheriff": "^0.33",
                 "kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
                 "slevomat/coding-standard": "^8.28"
             },
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.52.1"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.53.0"
             },
-            "time": "2026-05-19T14:06:31+00:00"
+            "time": "2026-05-23T07:31:36+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -107,6 +107,8 @@ defaults:
       checkedExceptionClasses:
         - '\Throwable'
     haspadar:
+      testsPaths:
+        - '*/tests/*'
       afferentCoupling:
         ignoreInterfaces: true
         excludedClasses: []

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -111,6 +111,8 @@ final class TemplateFileTest extends TestCase
                 . "        checkedExceptionClasses:\n"
                 . "            - \\Throwable\n"
                 . "    haspadar:\n"
+                . "        testsPaths:\n"
+                . "            - \"*/tests/*\"\n"
                 . "        afferentCoupling:\n"
                 . "            ignoreInterfaces: true\n"
                 . "            excludedClasses: []\n"


### PR DESCRIPTION
- Added haspadar.testsPaths default so production rules can skip test files
- Updated phpstan-rules to v0.53.0 which introduces the testsPaths filter
- Updated DEV.md to document the new haspadar.testsPaths default

Part of #763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `testsPaths` configuration option for PHPStan haspadar rules, enabling test directories to be exempted from production rules.

* **Documentation**
  * Documented the new `testsPaths` configuration parameter in developer guide.

* **Tests**
  * Updated test assertions for PHPStan configuration rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->