### PR TITLE
PHPCS Sees Test Code Through Shared Variables

### DIFF
--- a/.sheriff/phpcs/phpcs.xml
+++ b/.sheriff/phpcs/phpcs.xml
@@ -3,11 +3,10 @@
     <description>Structural and semantic PHP rules</description>
 
     <file>../../src</file>
+    <file>../../tests</file>
 
     <exclude-pattern>vendor/*</exclude-pattern>
-    <exclude-pattern>tests/*</exclude-pattern>
     <exclude-pattern>.git/*</exclude-pattern>
-    <exclude-pattern>templates/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>

--- a/.sheriff/phpcs/slevomat-style.xml
+++ b/.sheriff/phpcs/slevomat-style.xml
@@ -31,6 +31,7 @@
         <properties>
             <property name="rootNamespaces" type="array">
                 <element key="src" value="Haspadar\Sheriff"/>
+                <element key="tests" value="Haspadar\Sheriff\Tests"/>
             </property>
         </properties>
     </rule>

--- a/src/Settings/ComposerSettings.php
+++ b/src/Settings/ComposerSettings.php
@@ -11,9 +11,10 @@ use Override;
 /**
  * Settings decorator that exposes derived keys read from `composer.json`.
  *
- * Currently provides `phpcs.root_namespace` — the first PSR-4 root namespace
- * declared by the project. Other composer-derived keys can be added here
- * without touching the rest of the Settings stack.
+ * Provides `phpcs.root_namespace` — the first PSR-4 root namespace declared
+ * under `autoload` — and `phpcs.tests_root_namespace` — the first PSR-4 root
+ * namespace declared under `autoload-dev`. Other composer-derived keys can be
+ * added here without touching the rest of the Settings stack.
  *
  * Example:
  *
@@ -22,6 +23,8 @@ use Override;
 final readonly class ComposerSettings implements Settings
 {
     private const string ROOT_NAMESPACE_KEY = 'phpcs.root_namespace';
+
+    private const string TESTS_ROOT_NAMESPACE_KEY = 'phpcs.tests_root_namespace';
 
     /**
      * Initializes with the underlying settings and the composer.json path.
@@ -34,7 +37,9 @@ final readonly class ComposerSettings implements Settings
     #[Override]
     public function has(string $name): bool
     {
-        return $name === self::ROOT_NAMESPACE_KEY || $this->base->has($name);
+        return $name === self::ROOT_NAMESPACE_KEY
+            || $name === self::TESTS_ROOT_NAMESPACE_KEY
+            || $this->base->has($name);
     }
 
     #[Override]
@@ -46,16 +51,28 @@ final readonly class ComposerSettings implements Settings
             );
         }
 
+        if ($name === self::TESTS_ROOT_NAMESPACE_KEY && !$this->base->has($name)) {
+            return new StringValue(
+                (new ComposerTestsRootNamespace($this->composer))->toString(),
+            );
+        }
+
         return $this->base->value($name);
     }
 
     #[Override]
     public function keys(): array
     {
-        $baseKeys = $this->base->keys();
+        $keys = $this->base->keys();
 
-        return in_array(self::ROOT_NAMESPACE_KEY, $baseKeys, true)
-            ? $baseKeys
-            : [...$baseKeys, self::ROOT_NAMESPACE_KEY];
+        if (!in_array(self::ROOT_NAMESPACE_KEY, $keys, true)) {
+            $keys = [...$keys, self::ROOT_NAMESPACE_KEY];
+        }
+
+        if (!in_array(self::TESTS_ROOT_NAMESPACE_KEY, $keys, true)) {
+            $keys = [...$keys, self::TESTS_ROOT_NAMESPACE_KEY];
+        }
+
+        return $keys;
     }
 }

--- a/src/Settings/ComposerTestsRootNamespace.php
+++ b/src/Settings/ComposerTestsRootNamespace.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Settings;
+
+/**
+ * Root namespace from the PSR-4 autoload-dev section of composer.json.
+ */
+final readonly class ComposerTestsRootNamespace
+{
+    /**
+     * Initializes with the composer.json file path.
+     *
+     * @param string $path Absolute path to the composer.json file
+     */
+    public function __construct(private string $path) {}
+
+    /** Returns the first PSR-4 root namespace declared under autoload-dev. */
+    public function toString(): string
+    {
+        if (!is_file($this->path)) {
+            return '';
+        }
+
+        $contents = file_get_contents($this->path);
+        /** @var array{autoload-dev?: array{psr-4?: array<string, string>}} $data */
+        $data = json_decode(is_string($contents) ? $contents : '{}', true) ?? [];
+        $namespaces = $data['autoload-dev']['psr-4'] ?? [];
+
+        return $namespaces !== []
+            ? rtrim(array_key_first($namespaces), '\\')
+            : '';
+    }
+}

--- a/templates/always/.sheriff/phpcs/phpcs.xml
+++ b/templates/always/.sheriff/phpcs/phpcs.xml
@@ -3,8 +3,9 @@
     <description>Structural and semantic PHP rules</description>
 
 {% ListText(php.src)|EachFormatted("../../%s")|EachFormatted("    <file>%s</file>")|Joined("\n") %}
+{% ListText(php.tests)|EachFormatted("../../%s")|EachFormatted("    <file>%s</file>")|Joined("\n") %}
 
-{% ListText(infra.exclude)|EachFormatted("%s/*")|EachFormatted("    <exclude-pattern>%s</exclude-pattern>")|Joined("\n") %}
+{% ListText(php.exclude)|EachFormatted("%s/*")|EachFormatted("    <exclude-pattern>%s</exclude-pattern>")|Joined("\n") %}
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>

--- a/templates/always/.sheriff/phpcs/slevomat-style.xml
+++ b/templates/always/.sheriff/phpcs/slevomat-style.xml
@@ -31,6 +31,7 @@
         <properties>
             <property name="rootNamespaces" type="array">
                 <element key="src" value="{% StringText(phpcs.root_namespace) %}"/>
+                <element key="tests" value="{% StringText(phpcs.tests_root_namespace) %}"/>
             </property>
         </properties>
     </rule>

--- a/tests/Constraint/Files/HasFileContents.php
+++ b/tests/Constraint/Files/HasFileContents.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Constraint\Files;
 
 use Haspadar\Sheriff\File\File;
+use Override;
 use PHPUnit\Framework\Constraint\Constraint;
 
 final class HasFileContents extends Constraint
 {
-    public function __construct(
-        private readonly string $expected,
-    ) {}
+    public function __construct(private readonly string $expected,) {}
 
-    #[\Override]
+    #[Override]
     protected function matches(mixed $other): bool
     {
         return $other instanceof File
@@ -25,7 +24,7 @@ final class HasFileContents extends Constraint
         return 'has contents ' . var_export($this->expected, true);
     }
 
-    #[\Override]
+    #[Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof File) {

--- a/tests/Constraint/Files/HasFiles.php
+++ b/tests/Constraint/Files/HasFiles.php
@@ -5,23 +5,20 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Constraint\Files;
 
 use Haspadar\Sheriff\Files\Files;
+use Override;
 use PHPUnit\Framework\Constraint\Constraint;
 
 final class HasFiles extends Constraint
 {
-    /**
-     * @param array<string, string> $expected path => contents
-     */
-    public function __construct(
-        private readonly array $expected,
-    ) {}
+    /** @param array<string, string> $expected path => contents */
+    public function __construct(private readonly array $expected,) {}
 
     public function toString(): string
     {
         return 'has files ' . $this->export($this->expected);
     }
 
-    #[\Override]
+    #[Override]
     protected function matches(mixed $other): bool
     {
         if (!$other instanceof Files) {
@@ -41,13 +38,13 @@ final class HasFiles extends Constraint
         return $actual === $expected;
     }
 
-    #[\Override]
+    #[Override]
     protected function failureDescription(mixed $other): string
     {
         return 'files ' . $this->toString();
     }
 
-    #[\Override]
+    #[Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof Files) {
@@ -57,9 +54,11 @@ final class HasFiles extends Constraint
         }
 
         $actual = [];
+
         foreach ($other->all() as $file) {
             $actual[$file->name()] = $file->contents();
         }
+
         ksort($actual);
 
         return "\nExpected: {$this->export($this->expected)}"

--- a/tests/Constraint/HasFormulaFailure.php
+++ b/tests/Constraint/HasFormulaFailure.php
@@ -6,9 +6,10 @@ namespace Haspadar\Sheriff\Tests\Constraint;
 
 use Haspadar\Sheriff\File\File;
 use Haspadar\Sheriff\SheriffException;
+use Override;
 use PHPUnit\Framework\Constraint\Constraint;
 
-final class HasFormulaError extends Constraint
+final class HasFormulaFailure extends Constraint
 {
     public function __construct(
         private readonly string $fileName,
@@ -16,7 +17,7 @@ final class HasFormulaError extends Constraint
         private readonly string $reasonPart,
     ) {}
 
-    #[\Override]
+    #[Override]
     protected function matches(mixed $other): bool
     {
         if (!$other instanceof File) {
@@ -38,6 +39,6 @@ final class HasFormulaError extends Constraint
 
     public function toString(): string
     {
-        return 'has formula error with file context';
+        return 'has formula failure with file context';
     }
 }

--- a/tests/Constraint/Storage/HasEntries.php
+++ b/tests/Constraint/Storage/HasEntries.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Constraint\Storage;
 
 use Haspadar\Sheriff\Storage\Storage;
+use Override;
 use PHPUnit\Framework\Constraint\Constraint;
 
 final class HasEntries extends Constraint
 {
-    /**
-     * @param list<string> $expected
-     */
+    /** @param list<string> $expected */
     public function __construct(
         private readonly string $location,
         private readonly array $expected,
@@ -22,7 +21,7 @@ final class HasEntries extends Constraint
         return "has entries {$this->export($this->expected)} under {$this->export($this->location)}";
     }
 
-    #[\Override]
+    #[Override]
     protected function matches(mixed $other): bool
     {
         if (!$other instanceof Storage) {
@@ -40,13 +39,13 @@ final class HasEntries extends Constraint
         return $actual === $expected;
     }
 
-    #[\Override]
+    #[Override]
     protected function failureDescription(mixed $other): string
     {
         return 'storage ' . $this->toString();
     }
 
-    #[\Override]
+    #[Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof Storage) {

--- a/tests/Constraint/Storage/HasEntry.php
+++ b/tests/Constraint/Storage/HasEntry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Constraint\Storage;
 
 use Haspadar\Sheriff\Storage\Storage;
+use Override;
 use PHPUnit\Framework\Constraint\Constraint;
 
 final class HasEntry extends Constraint
@@ -22,7 +23,7 @@ final class HasEntry extends Constraint
             . "and mode {$this->export($this->mode)}";
     }
 
-    #[\Override]
+    #[Override]
     protected function matches(mixed $other): bool
     {
         return $other instanceof Storage
@@ -31,13 +32,13 @@ final class HasEntry extends Constraint
             && $other->mode($this->location) === $this->mode;
     }
 
-    #[\Override]
+    #[Override]
     protected function failureDescription(mixed $other): string
     {
         return 'storage ' . $this->toString();
     }
 
-    #[\Override]
+    #[Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof Storage) {

--- a/tests/Constraint/Storage/ReactionWasSilent.php
+++ b/tests/Constraint/Storage/ReactionWasSilent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Constraint\Storage;
 
 use Haspadar\Sheriff\Tests\Fake\Storage\Reaction\FakeStorageReaction;
+use Override;
 use PHPUnit\Framework\Constraint\Constraint;
 
 final class ReactionWasSilent extends Constraint
@@ -14,7 +15,7 @@ final class ReactionWasSilent extends Constraint
         return 'recorded no created or updated paths';
     }
 
-    #[\Override]
+    #[Override]
     protected function matches(mixed $other): bool
     {
         return $other instanceof FakeStorageReaction
@@ -22,13 +23,13 @@ final class ReactionWasSilent extends Constraint
             && $other->updatedPaths() === [];
     }
 
-    #[\Override]
+    #[Override]
     protected function failureDescription(mixed $other): string
     {
         return 'reaction ' . $this->toString();
     }
 
-    #[\Override]
+    #[Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         if (!$other instanceof FakeStorageReaction) {

--- a/tests/Fake/Settings/FakeSettings.php
+++ b/tests/Fake/Settings/FakeSettings.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Fake\Settings;
 
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
 
 final readonly class FakeSettings implements Settings
 {
-    /**
-     * @param array<string, Value> $values
-     */
+    /** @param array<string, Value> $values */
     public function __construct(private array $values) {}
 
     public function has(string $name): bool
@@ -29,6 +27,7 @@ final readonly class FakeSettings implements Settings
         return $this->values[$name];
     }
 
+    /** @return list<string> */
     public function keys(): array
     {
         return array_keys($this->values);

--- a/tests/Fixture/ConsoleProcess.php
+++ b/tests/Fixture/ConsoleProcess.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Fixture;
 
+use InvalidArgumentException;
+use RuntimeException;
+
 final readonly class ConsoleProcess
 {
     private const array ALLOWED = ['info', 'success', 'error', 'muted'];
@@ -15,7 +18,7 @@ final readonly class ConsoleProcess
     public function __construct(string $method, string $text)
     {
         if (!in_array($method, self::ALLOWED, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('Method %s is not allowed', var_export($method, true)),
             );
         }
@@ -34,7 +37,7 @@ final readonly class ConsoleProcess
         );
 
         if (!is_resource($proc)) {
-            throw new \RuntimeException('Failed to start subprocess');
+            throw new RuntimeException('Failed to start subprocess');
         }
 
         fclose($pipes[0]);
@@ -45,7 +48,7 @@ final readonly class ConsoleProcess
         $exitCode = proc_close($proc);
 
         if ($exitCode !== 0) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 sprintf('Subprocess exited with code %d: %s', $exitCode, $this->stderr),
             );
         }

--- a/tests/Fixture/TempFolder.php
+++ b/tests/Fixture/TempFolder.php
@@ -71,6 +71,7 @@ final readonly class TempFolder
         }
 
         $items = scandir($dir);
+
         if ($items === false) {
             throw new SheriffException(
                 sprintf('Failed to scan directory: "%s"', $dir),
@@ -83,7 +84,9 @@ final readonly class TempFolder
             }
 
             $path = $dir . '/' . $item;
-            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+            is_dir($path)
+                ? $this->removeDirectory($path)
+                : unlink($path);
         }
 
         rmdir($dir);

--- a/tests/Integration/Cli/SheriffEntrypointTest.php
+++ b/tests/Integration/Cli/SheriffEntrypointTest.php
@@ -70,9 +70,7 @@ final class SheriffEntrypointTest extends TestCase
         }
     }
 
-    /**
-     * @param list<string> $command
-     */
+    /** @param list<string> $command */
     private function stdout(array $command, ?string $cwd = null): string
     {
         $proc = proc_open(
@@ -96,15 +94,15 @@ final class SheriffEntrypointTest extends TestCase
         return $stdout;
     }
 
-    /**
-     * @return list<string>
-     */
+    /** @return list<string> */
     private function composerBin(): array
     {
         $json = json_decode((string) file_get_contents(__DIR__ . '/../../../composer.json'), true);
 
         /** @var list<string> $bin */
-        $bin = is_array($json) && isset($json['bin']) && is_array($json['bin']) ? $json['bin'] : [];
+        $bin = is_array($json) && isset($json['bin']) && is_array($json['bin'])
+            ? $json['bin']
+            : [];
 
         return $bin;
     }

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -67,7 +67,10 @@ final class TemplateFileTest extends TestCase
     {
         self::assertThat(
             new TemplateFile(
-                new TextFile('docker.yml', 'image: {% ListText(php.versions)|EachFormatted("%s-alpine")|Joined(" ") %}'),
+                new TextFile(
+                    'docker.yml',
+                    'image: {% ListText(php.versions)|EachFormatted("%s-alpine")|Joined(" ") %}',
+                ),
                 new PatchedSettings(
                     new DefaultSettings(),
                     new OverrideList('php.versions', new ListValue([

--- a/tests/Integration/Settings/YamlBoolAliasTest.php
+++ b/tests/Integration/Settings/YamlBoolAliasTest.php
@@ -31,8 +31,8 @@ final class YamlBoolAliasTest extends TestCase
         yield 'false' => ['false', 'false'];
     }
 
-    #[Test]
     #[DataProvider('aliases')]
+    #[Test]
     public function rendersYamlBooleanAsCanonicalLiteral(string $alias, string $expected): void
     {
         $folder = (new TempFolder())->withFile(

--- a/tests/Unit/Chain/Map/EachFormattedTest.php
+++ b/tests/Unit/Chain/Map/EachFormattedTest.php
@@ -7,9 +7,9 @@ namespace Haspadar\Sheriff\Tests\Unit\Chain\Map;
 use Haspadar\Sheriff\Chain\Map\EachFormatted;
 use Haspadar\Sheriff\Chain\Map\Formatted;
 use Haspadar\Sheriff\Chain\Plain\ListText;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +37,7 @@ final class EachFormattedTest extends TestCase
         self::assertSame(
             ['- src', '- tests', '- docs'],
             array_map(
-                fn (object $part): string => $part->rendered(),
+                static fn(object $part): string => $part->rendered(),
                 (new EachFormatted(
                     new ListText(new ListValue([
                         new StringValue('src'),

--- a/tests/Unit/Chain/Map/EachReplacedTest.php
+++ b/tests/Unit/Chain/Map/EachReplacedTest.php
@@ -7,9 +7,9 @@ namespace Haspadar\Sheriff\Tests\Unit\Chain\Map;
 use Haspadar\Sheriff\Chain\Map\EachReplaced;
 use Haspadar\Sheriff\Chain\Map\Replaced;
 use Haspadar\Sheriff\Chain\Plain\ListText;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
+++ b/tests/Unit/Chain/Parse/EnabledToolsFormulaTest.php
@@ -162,9 +162,7 @@ final class EnabledToolsFormulaTest extends TestCase
             ]));
     }
 
-    /**
-     * @return list<string>
-     */
+    /** @return list<string> */
     private static function names(Op $op): array
     {
         if (!$op instanceof Listed) {
@@ -177,15 +175,11 @@ final class EnabledToolsFormulaTest extends TestCase
         );
     }
 
-    /**
-     * @param array<string, Value> $values
-     */
+    /** @param array<string, Value> $values */
     private static function settings(array $values): Settings
     {
         return new readonly class ($values) implements Settings {
-            /**
-             * @param array<string, Value> $values
-             */
+            /** @param array<string, Value> $values */
             public function __construct(private array $values) {}
 
             #[Override]

--- a/tests/Unit/Chain/Parse/JoinedListsFormulaTest.php
+++ b/tests/Unit/Chain/Parse/JoinedListsFormulaTest.php
@@ -176,9 +176,7 @@ final class JoinedListsFormulaTest extends TestCase
             ]));
     }
 
-    /**
-     * @return list<string>
-     */
+    /** @return list<string> */
     private static function strings(Op $op): array
     {
         if (!$op instanceof Listed) {
@@ -191,15 +189,11 @@ final class JoinedListsFormulaTest extends TestCase
         );
     }
 
-    /**
-     * @param array<string, Value> $values
-     */
+    /** @param array<string, Value> $values */
     private static function settings(array $values): Settings
     {
         return new readonly class ($values) implements Settings {
-            /**
-             * @param array<string, Value> $values
-             */
+            /** @param array<string, Value> $values */
             public function __construct(private array $values) {}
 
             #[Override]

--- a/tests/Unit/Chain/Parse/MapFormulaTest.php
+++ b/tests/Unit/Chain/Parse/MapFormulaTest.php
@@ -9,12 +9,13 @@ use Haspadar\Sheriff\Chain\Map\Formatted;
 use Haspadar\Sheriff\Chain\Parse\MapFormula;
 use Haspadar\Sheriff\Chain\Plain\IntText;
 use Haspadar\Sheriff\Chain\Plain\ListText;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\Settings\Value\IntValue;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use LogicException;
 use Override;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -93,7 +94,7 @@ final class MapFormulaTest extends TestCase
             #[Override]
             public function value(string $name): Value
             {
-                throw new \LogicException('not used');
+                throw new LogicException('not used');
             }
 
             #[Override]

--- a/tests/Unit/Chain/Parse/PipelineFormulasTest.php
+++ b/tests/Unit/Chain/Parse/PipelineFormulasTest.php
@@ -6,12 +6,12 @@ namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
 
 use Haspadar\Sheriff\Chain\Parse\PipelineFormulas;
 use Haspadar\Sheriff\Chain\Parse\PipelineOp;
-use InvalidArgumentException;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\Settings\Value\IntValue;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\Value;
+use InvalidArgumentException;
 use Override;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -125,15 +125,11 @@ final class PipelineFormulasTest extends TestCase
         (new PipelineFormulas('StringText(app.name) junk'))->formulas();
     }
 
-    /**
-     * @param array<string, Value> $values
-     */
+    /** @param array<string, Value> $values */
     private static function settings(array $values): Settings
     {
         return new readonly class ($values) implements Settings {
-            /**
-             * @param array<string, Value> $values
-             */
+            /** @param array<string, Value> $values */
             public function __construct(private array $values) {}
 
             #[Override]

--- a/tests/Unit/Chain/Parse/PipelineOpTest.php
+++ b/tests/Unit/Chain/Parse/PipelineOpTest.php
@@ -12,12 +12,12 @@ use Haspadar\Sheriff\Chain\Parse\SourceFormula;
 use Haspadar\Sheriff\Chain\Plain\IntText;
 use Haspadar\Sheriff\Chain\Plain\ListText;
 use Haspadar\Sheriff\Chain\Reduce\Joined;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\Settings\Value\IntValue;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
 use Override;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -88,15 +88,11 @@ final class PipelineOpTest extends TestCase
         (new PipelineOp([], self::settings([])))->rendered();
     }
 
-    /**
-     * @param array<string, Value> $values
-     */
+    /** @param array<string, Value> $values */
     private static function settings(array $values): Settings
     {
         return new readonly class ($values) implements Settings {
-            /**
-             * @param array<string, Value> $values
-             */
+            /** @param array<string, Value> $values */
             public function __construct(private array $values) {}
 
             #[Override]

--- a/tests/Unit/Chain/Parse/ReduceFormulaTest.php
+++ b/tests/Unit/Chain/Parse/ReduceFormulaTest.php
@@ -9,12 +9,13 @@ use Haspadar\Sheriff\Chain\Parse\ReduceFormula;
 use Haspadar\Sheriff\Chain\Plain\IntText;
 use Haspadar\Sheriff\Chain\Plain\ListText;
 use Haspadar\Sheriff\Chain\Reduce\Joined;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\Settings\Value\IntValue;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use LogicException;
 use Override;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -111,7 +112,7 @@ final class ReduceFormulaTest extends TestCase
             #[Override]
             public function value(string $name): Value
             {
-                throw new \LogicException('not used');
+                throw new LogicException('not used');
             }
 
             #[Override]

--- a/tests/Unit/Chain/Parse/SourceFormulaTest.php
+++ b/tests/Unit/Chain/Parse/SourceFormulaTest.php
@@ -9,7 +9,6 @@ use Haspadar\Sheriff\Chain\Plain\BoolText;
 use Haspadar\Sheriff\Chain\Plain\IntText;
 use Haspadar\Sheriff\Chain\Plain\ListText;
 use Haspadar\Sheriff\Chain\Render\Neon\NeonTree;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Settings;
 use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\Settings\Value\IntValue;
@@ -17,6 +16,7 @@ use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
 use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
 use Override;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -114,15 +114,11 @@ final class SourceFormulaTest extends TestCase
             ->op([], self::settings(['phpstan.cli' => new BoolValue(true)]));
     }
 
-    /**
-     * @param array<string, Value> $values
-     */
+    /** @param array<string, Value> $values */
     private static function settings(array $values): Settings
     {
         return new readonly class ($values) implements Settings {
-            /**
-             * @param array<string, Value> $values
-             */
+            /** @param array<string, Value> $values */
             public function __construct(private array $values) {}
 
             #[Override]

--- a/tests/Unit/Chain/Plain/FloatTextTest.php
+++ b/tests/Unit/Chain/Plain/FloatTextTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Unit\Chain\Plain;
 
 use Haspadar\Sheriff\Chain\Plain\FloatText;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Value\FloatValue;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Chain/Plain/ListTextTest.php
+++ b/tests/Unit/Chain/Plain/ListTextTest.php
@@ -9,13 +9,13 @@ use Haspadar\Sheriff\Chain\Plain\FloatText;
 use Haspadar\Sheriff\Chain\Plain\IntText;
 use Haspadar\Sheriff\Chain\Plain\ListText;
 use Haspadar\Sheriff\Chain\Plain\StringText;
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\Settings\Value\FloatValue;
 use Haspadar\Sheriff\Settings\Value\IntValue;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -40,7 +40,7 @@ final class ListTextTest extends TestCase
         self::assertSame(
             ['src', 'tests', 'docs'],
             array_map(
-                fn (object $part): string => $part->rendered(),
+                static fn(object $part): string => $part->rendered(),
                 (new ListText(new ListValue([
                     new StringValue('src'),
                     new StringValue('tests'),

--- a/tests/Unit/Chain/Render/Json/JsonOfTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonOfTest.php
@@ -37,8 +37,8 @@ final class JsonOfTest extends TestCase
     }
 
     /** @param class-string $expected */
-    #[Test]
     #[DataProvider('valueRendererPairs')]
+    #[Test]
     public function dispatchesEachValueSubtypeToTheMatchingRenderer(
         Value $value,
         string $expected,

--- a/tests/Unit/Chain/Render/Neon/NeonBareStringTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonBareStringTest.php
@@ -21,8 +21,8 @@ final class NeonBareStringTest extends TestCase
         yield 'dotted path' => ['1G.alpha', '1G.alpha'];
     }
 
-    #[Test]
     #[DataProvider('safeStrings')]
+    #[Test]
     public function rendersSafePayloadWithoutQuotes(string $raw, string $expected): void
     {
         self::assertSame(
@@ -44,8 +44,8 @@ final class NeonBareStringTest extends TestCase
         yield 'empty' => ['', '""'];
     }
 
-    #[Test]
     #[DataProvider('unsafeStrings')]
+    #[Test]
     public function fallsBackToQuotedFormForUnsafePayload(string $raw, string $expected): void
     {
         self::assertSame(

--- a/tests/Unit/File/TemplateFileTest.php
+++ b/tests/Unit/File/TemplateFileTest.php
@@ -9,7 +9,7 @@ use Haspadar\Sheriff\File\TextFile;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Tests\Constraint\Files\HasFileContents;
-use Haspadar\Sheriff\Tests\Constraint\HasFormulaError;
+use Haspadar\Sheriff\Tests\Constraint\HasFormulaFailure;
 use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -71,7 +71,7 @@ final class TemplateFileTest extends TestCase
                 new TextFile('broken.neon', '{% MissingFormula(phpstan.paths) %}'),
                 new FakeSettings([]),
             ),
-            new HasFormulaError(
+            new HasFormulaFailure(
                 'broken.neon',
                 'MissingFormula(phpstan.paths)',
                 'Unknown pipeline formula',
@@ -87,7 +87,7 @@ final class TemplateFileTest extends TestCase
                 new TextFile('missing.neon', '{% StringText(app.name) %}'),
                 new FakeSettings([]),
             ),
-            new HasFormulaError(
+            new HasFormulaFailure(
                 'missing.neon',
                 'StringText(app.name)',
                 'cannot find settings key',
@@ -107,7 +107,7 @@ final class TemplateFileTest extends TestCase
                     ]),
                 ]),
             ),
-            new HasFormulaError(
+            new HasFormulaFailure(
                 'typed.neon',
                 'StringText(phpstan.paths)',
                 'StringValue',

--- a/tests/Unit/Files/EachFileTest.php
+++ b/tests/Unit/Files/EachFileTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Unit\Files;
 
+use ArrayObject;
 use Haspadar\Sheriff\File\File;
 use Haspadar\Sheriff\Files\EachFile;
 use Haspadar\Sheriff\Files\TextFiles;
@@ -15,21 +16,22 @@ final class EachFileTest extends TestCase
     #[Test]
     public function executesActionForEachFile(): void
     {
-        $called = [];
+        /** @var ArrayObject<int, string> $called */
+        $called = new ArrayObject();
 
         (new EachFile(
             new TextFiles([
                 'a.txt' => 'A',
                 'b.txt' => 'B',
             ]),
-            function (File $file) use (&$called): void {
-                $called[] = $file->name();
+            static function (File $file) use ($called): void {
+                $called->append($file->name());
             },
         ))->run();
 
         self::assertSame(
             ['a.txt', 'b.txt'],
-            $called,
+            $called->getArrayCopy(),
             'Action must be executed for each file',
         );
     }

--- a/tests/Unit/Files/FilteredFilesTest.php
+++ b/tests/Unit/Files/FilteredFilesTest.php
@@ -23,7 +23,7 @@ final class FilteredFilesTest extends TestCase
                     'pre-push-sheriff' => 'exit 2',
                     'commit-msg' => 'exit 3',
                 ]),
-                fn(File $file): bool => !str_ends_with($file->name(), 'pre-push'),
+                static fn(File $file): bool => !str_ends_with($file->name(), 'pre-push'),
             ),
             new HasFiles([
                 'pre-push-sheriff' => 'exit 2',
@@ -41,7 +41,7 @@ final class FilteredFilesTest extends TestCase
                 new TextFiles([
                     'pre-push' => 'exit 0',
                 ]),
-                fn(File $file): bool => str_starts_with($file->name(), 'commit'),
+                static fn(File $file): bool => str_starts_with($file->name(), 'commit'),
             ),
             new HasFiles([]),
             'FilteredFiles must return empty list when no files satisfy the predicate',
@@ -57,7 +57,7 @@ final class FilteredFilesTest extends TestCase
                     'pre-push' => 'run push checks',
                     'pre-commit' => 'run commit checks',
                 ]),
-                fn(File $file): bool => str_starts_with($file->name(), 'pre-'),
+                static fn(File $file): bool => str_starts_with($file->name(), 'pre-'),
             ),
             new HasFiles([
                 'pre-push' => 'run push checks',

--- a/tests/Unit/Files/MappedFilesTest.php
+++ b/tests/Unit/Files/MappedFilesTest.php
@@ -23,7 +23,7 @@ final class MappedFilesTest extends TestCase
                     'README.md' => 'Hello, {{name}}',
                     'config/app.ini' => 'name={{name}}',
                 ]),
-                fn(File $file) => new ReplacedFile(
+                static fn(File $file) => new ReplacedFile(
                     $file,
                     '{{name}}',
                     'Sheriff',

--- a/tests/Unit/Settings/ComposerSettingsTest.php
+++ b/tests/Unit/Settings/ComposerSettingsTest.php
@@ -62,6 +62,72 @@ final class ComposerSettingsTest extends TestCase
     }
 
     #[Test]
+    public function exposesTestsRootNamespaceKeyDerivedFromComposerJson(): void
+    {
+        $folder = (new TempFolder())->withFile(
+            'composer.json',
+            json_encode(
+                [
+                    'autoload' => ['psr-4' => ['App\\' => 'src/']],
+                    'autoload-dev' => ['psr-4' => ['App\\Tests\\' => 'tests/']],
+                ],
+                JSON_THROW_ON_ERROR,
+            ),
+        );
+
+        $value = (new ComposerSettings(
+            new FakeSettings([]),
+            $folder->path() . '/composer.json',
+        ))->value('phpcs.tests_root_namespace');
+
+        $folder->close();
+
+        self::assertEquals(
+            new StringValue('App\\Tests'),
+            $value,
+            'ComposerSettings must read the first PSR-4 namespace from autoload-dev in composer.json',
+        );
+    }
+
+    #[Test]
+    public function rendersEmptyTestsRootNamespaceWhenComposerJsonIsAbsent(): void
+    {
+        self::assertEquals(
+            new StringValue(''),
+            (new ComposerSettings(
+                new FakeSettings([]),
+                '/nonexistent/path/composer.json',
+            ))->value('phpcs.tests_root_namespace'),
+            'ComposerSettings must return an empty StringValue for tests root namespace when composer.json is missing',
+        );
+    }
+
+    #[Test]
+    public function reportsTestsRootNamespaceKeyAsAvailableEvenWithoutBase(): void
+    {
+        self::assertTrue(
+            (new ComposerSettings(
+                new FakeSettings([]),
+                '/anywhere/composer.json',
+            ))->has('phpcs.tests_root_namespace'),
+            'ComposerSettings must report phpcs.tests_root_namespace as available regardless of the base settings',
+        );
+    }
+
+    #[Test]
+    public function letsBaseSettingsOverrideTheDerivedTestsNamespace(): void
+    {
+        self::assertEquals(
+            new StringValue('Custom\\Tests'),
+            (new ComposerSettings(
+                new FakeSettings(['phpcs.tests_root_namespace' => new StringValue('Custom\\Tests')]),
+                '/anywhere/composer.json',
+            ))->value('phpcs.tests_root_namespace'),
+            'User-provided phpcs.tests_root_namespace must win over the composer.json derivation',
+        );
+    }
+
+    #[Test]
     public function delegatesUnknownKeysToBaseSettings(): void
     {
         self::assertEquals(
@@ -96,6 +162,19 @@ final class ComposerSettingsTest extends TestCase
                 '/anywhere/composer.json',
             ))->has('phpstan.level'),
             'ComposerSettings must delegate has() to the base settings for non-namespace keys',
+        );
+    }
+
+    #[Test]
+    public function exposesBothDerivedNamespaceKeysOnTopOfBaseKeys(): void
+    {
+        self::assertSame(
+            ['phpstan.level', 'phpcs.root_namespace', 'phpcs.tests_root_namespace'],
+            (new ComposerSettings(
+                new FakeSettings(['phpstan.level' => new IntValue(9)]),
+                '/anywhere/composer.json',
+            ))->keys(),
+            'ComposerSettings must append both derived namespace keys to the base keys',
         );
     }
 }

--- a/tests/Unit/Settings/DefaultSettingsTest.php
+++ b/tests/Unit/Settings/DefaultSettingsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Unit\Settings;
 
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\DefaultSettings;
 use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\Settings\Value\FloatValue;
@@ -12,6 +11,7 @@ use Haspadar\Sheriff\Settings\Value\IntValue;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Tests\Fixture\TempFolder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Settings/Patch/AppendPatchesTest.php
+++ b/tests/Unit/Settings/Patch/AppendPatchesTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Unit\Settings\Patch;
 
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Patch\AppendList;
 use Haspadar\Sheriff\Settings\Patch\AppendPatches;
 use Haspadar\Sheriff\Settings\Patch\AppendTree;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Settings/Patch/OverridePatchesTest.php
+++ b/tests/Unit/Settings/Patch/OverridePatchesTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Unit\Settings\Patch;
 
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Patch\OverrideList;
 use Haspadar\Sheriff\Settings\Patch\OverridePatches;
 use Haspadar\Sheriff\Settings\Patch\OverrideScalar;
 use Haspadar\Sheriff\Settings\Patch\OverrideTree;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Settings/Patch/RemovePatchesTest.php
+++ b/tests/Unit/Settings/Patch/RemovePatchesTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Unit\Settings\Patch;
 
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Patch\RemoveList;
 use Haspadar\Sheriff\Settings\Patch\RemovePatches;
 use Haspadar\Sheriff\Settings\Patch\RemoveTree;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Settings/Value/RawValueTest.php
+++ b/tests/Unit/Settings/Value/RawValueTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Unit\Settings\Value;
 
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\Value\BoolValue;
 use Haspadar\Sheriff\Settings\Value\FloatValue;
 use Haspadar\Sheriff\Settings\Value\IntValue;
@@ -12,6 +11,7 @@ use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\RawValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;

--- a/tests/Unit/Settings/YamlDocumentTest.php
+++ b/tests/Unit/Settings/YamlDocumentTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Haspadar\Sheriff\Tests\Unit\Settings;
 
-use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Settings\YamlDocument;
+use Haspadar\Sheriff\SheriffException;
 use Haspadar\Sheriff\Tests\Fixture\TempFolder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
- Added test directories to PHPCS file set so style violations in tests fail the check
- Refactored PHPCS template to read php.exclude instead of infra.exclude
- Added phpcs.tests_root_namespace derived from composer autoload-dev so TypeNameMatchesFileName accepts tests
- Renamed HasFormulaError to HasFormulaFailure to satisfy the no-Error-suffix rule
- Fixed bulk style violations across test files exposed by the wider scan

Closes #781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PHPCS now includes test files alongside source files for consistent code linting.
  * Added automatic test namespace detection from project configuration.

* **Tests**
  * Comprehensive test coverage added for test namespace resolution functionality.
  * Test constraints refactored and renamed for better clarity.

* **Chores**
  * Import statement reordering and code formatting standardization.
  * Static closure refactoring and test suite organization improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->