### PR TITLE
PHP CS Fixer Reads php.src, php.tests and php.exclude

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -60,7 +60,6 @@ defaults:
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
   php_cs_fixer.extend: ""
-  php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
   phpcs.extend: ""

--- a/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -115,10 +115,11 @@ return (new PhpCsFixer\Config())
         'php_unit_mock_short_will_return' => true,
         'php_unit_method_casing' => true,
         'php_unit_data_provider_static' => true,
-        'php_unit_data_provider_name' => true,
         'php_unit_data_provider_return_type' => true,
         'php_unit_attributes' => true,
-        'php_unit_strict' => true,
+        // Temporarily disabled: tests still compare Value objects via assertEquals.
+        // See haspadar/sheriff#790.
+        'php_unit_strict' => false,
         'php_unit_set_up_tear_down_visibility' => true,
 
     ]))

--- a/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -117,8 +117,8 @@ return (new PhpCsFixer\Config())
         'php_unit_data_provider_static' => true,
         'php_unit_data_provider_return_type' => true,
         'php_unit_attributes' => true,
-        // Temporarily disabled: tests still compare Value objects via assertEquals.
-        // See haspadar/sheriff#790.
+        // Disabled until Value-object equality assertions migrate off assertEquals.
+        // Tracked in haspadar/sheriff#790.
         'php_unit_strict' => false,
         'php_unit_set_up_tear_down_visibility' => true,
 

--- a/.sheriff/php-cs-fixer/php-cs-fixer.project.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.project.php
@@ -9,8 +9,11 @@ $rules = require __DIR__ . '/php-cs-fixer.php';
 
 $rules->setFinder(
     Finder::create()
-        ->in([__DIR__ . '/../..'])
-        ->exclude(['vendor','tests','.git','templates']),
+        ->in([
+            __DIR__ . '/../../src',
+            __DIR__ . '/../../tests',
+        ])
+        ->exclude(['vendor','.git']),
 )->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
 
 return $rules;

--- a/DEV.md
+++ b/DEV.md
@@ -477,9 +477,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 |-----|---------|-------------|
 | `php-cs-fixer.cli` | `true` | Enable PHP CS Fixer |
 | `php_cs_fixer.allow_unsupported` | `["true"]` | Allow unsupported PHP versions |
-| `php_cs_fixer.exclude` | `["vendor", "tests", ".git"]` | Excluded directories |
 | `php_cs_fixer.extend` | `""` | Raw PHP fragment inserted at the end of the `setRules()` array (overrides preset and built-in entries) |
-| `php_cs_fixer.paths` | `["../.."]` | Paths to fix |
 
 ### phpcs
 

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -60,7 +60,6 @@ defaults:
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
   php_cs_fixer.extend: ""
-  php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
   phpcs.extend: ""

--- a/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -115,8 +115,8 @@ return (new PhpCsFixer\Config())
         'php_unit_data_provider_static' => true,
         'php_unit_data_provider_return_type' => true,
         'php_unit_attributes' => true,
-        // Temporarily disabled: tests still compare Value objects via assertEquals.
-        // See haspadar/sheriff#790.
+        // Disabled until Value-object equality assertions migrate off assertEquals.
+        // Tracked in haspadar/sheriff#790.
         'php_unit_strict' => false,
         'php_unit_set_up_tear_down_visibility' => true,
 {% StringText(php_cs_fixer.extend) %}

--- a/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -113,10 +113,11 @@ return (new PhpCsFixer\Config())
         'php_unit_mock_short_will_return' => true,
         'php_unit_method_casing' => true,
         'php_unit_data_provider_static' => true,
-        'php_unit_data_provider_name' => true,
         'php_unit_data_provider_return_type' => true,
         'php_unit_attributes' => true,
-        'php_unit_strict' => true,
+        // Temporarily disabled: tests still compare Value objects via assertEquals.
+        // See haspadar/sheriff#790.
+        'php_unit_strict' => false,
         'php_unit_set_up_tear_down_visibility' => true,
 {% StringText(php_cs_fixer.extend) %}
     ]))

--- a/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.project.php
+++ b/templates/always/.sheriff/php-cs-fixer/php-cs-fixer.project.php
@@ -9,8 +9,11 @@ $rules = require __DIR__ . '/php-cs-fixer.php';
 
 $rules->setFinder(
     Finder::create()
-        ->in([{% ListText(php_cs_fixer.paths)|EachFormatted("__DIR__ . '/%s'")|Joined(",\n") %}])
-        ->exclude([{% ListText(infra.exclude)|EachFormatted("'%s'")|Joined(",") %}]),
+        ->in([
+{% ListText(php.src)|EachFormatted("            __DIR__ . '/../../%s'")|Joined(",\n") %},
+{% ListText(php.tests)|EachFormatted("            __DIR__ . '/../../%s'")|Joined(",\n") %},
+        ])
+        ->exclude([{% ListText(php.exclude)|EachFormatted("'%s'")|Joined(",") %}]),
 )->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
 
 return $rules;

--- a/tests/Constraint/Files/HasFileContents.php
+++ b/tests/Constraint/Files/HasFileContents.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 final class HasFileContents extends Constraint
 {
-    public function __construct(private readonly string $expected,) {}
+    public function __construct(private readonly string $expected) {}
 
     #[Override]
     protected function matches(mixed $other): bool

--- a/tests/Constraint/Files/HasFiles.php
+++ b/tests/Constraint/Files/HasFiles.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 final class HasFiles extends Constraint
 {
     /** @param array<string, string> $expected path => contents */
-    public function __construct(private readonly array $expected,) {}
+    public function __construct(private readonly array $expected) {}
 
     public function toString(): string
     {

--- a/tests/Fixture/ConsoleProcess.php
+++ b/tests/Fixture/ConsoleProcess.php
@@ -25,7 +25,7 @@ final readonly class ConsoleProcess
 
         $script = sprintf(
             'require %s; (new \Haspadar\Sheriff\Output\Console())->%s(%s);',
-            var_export(dirname(__DIR__, 2) . '/vendor/autoload.php', true),
+            var_export(__DIR__ . '/../../vendor/autoload.php', true),
             $method,
             var_export($text, true),
         );

--- a/tests/Integration/AgentRules/AgentRulesInstallTest.php
+++ b/tests/Integration/AgentRules/AgentRulesInstallTest.php
@@ -25,8 +25,8 @@ final class AgentRulesInstallTest extends TestCase
         try {
             $this->runScript($folder->path());
 
-            self::assertFalse(
-                file_exists($folder->path() . '/CLAUDE.md'),
+            self::assertFileDoesNotExist(
+                $folder->path() . '/CLAUDE.md',
                 'CLAUDE.md must not be created when the user has no agent file',
             );
         } finally {

--- a/tests/Integration/Cli/SheriffEntrypointTest.php
+++ b/tests/Integration/Cli/SheriffEntrypointTest.php
@@ -100,7 +100,7 @@ final class SheriffEntrypointTest extends TestCase
         $json = json_decode((string) file_get_contents(__DIR__ . '/../../../composer.json'), true);
 
         /** @var list<string> $bin */
-        $bin = is_array($json) && isset($json['bin']) && is_array($json['bin'])
+        $bin = is_array($json) && array_key_exists('bin', $json) && is_array($json['bin'])
             ? $json['bin']
             : [];
 

--- a/tests/Integration/File/TemplateFileTest.php
+++ b/tests/Integration/File/TemplateFileTest.php
@@ -123,7 +123,7 @@ final class TemplateFileTest extends TestCase
                 . "            ignoreInterfaces: true\n"
                 . "            excludedClasses: []\n"
                 . "        prohibitStaticMethods:\n"
-                . "            allowNamedConstructors: true",
+                . '            allowNamedConstructors: true',
             ),
             'TemplateFile must render the phpstan.parameters TreeValue as a nested neon block, including bare strings and block-style lists',
         );

--- a/tests/Unit/Chain/Parse/MapFormulaTest.php
+++ b/tests/Unit/Chain/Parse/MapFormulaTest.php
@@ -84,7 +84,7 @@ final class MapFormulaTest extends TestCase
 
     private static function settings(): Settings
     {
-        return new readonly class () implements Settings {
+        return new readonly class implements Settings {
             #[Override]
             public function has(string $name): bool
             {

--- a/tests/Unit/Chain/Parse/ReduceFormulaTest.php
+++ b/tests/Unit/Chain/Parse/ReduceFormulaTest.php
@@ -102,7 +102,7 @@ final class ReduceFormulaTest extends TestCase
 
     private static function settings(): Settings
     {
-        return new readonly class () implements Settings {
+        return new readonly class implements Settings {
             #[Override]
             public function has(string $name): bool
             {

--- a/tests/Unit/Chain/Plain/EnvsTextTest.php
+++ b/tests/Unit/Chain/Plain/EnvsTextTest.php
@@ -114,7 +114,7 @@ final class EnvsTextTest extends TestCase
             "      - name: Set environment variables\n"
             . "        run: |\n"
             . "          git fetch --tags --unshallow 2>/dev/null || git fetch --tags\n"
-            . '          echo "FOO=$(echo a)" >> "$GITHUB_ENV"' . "\n"
+            . "          echo \"FOO=\$(echo a)\" >> \"\$GITHUB_ENV\"\n"
             . '          echo "BAR=$(echo b)" >> "$GITHUB_ENV"',
             (new EnvsText(
                 new TreeValue([

--- a/tests/Unit/Chain/Render/Json/JsonOfTest.php
+++ b/tests/Unit/Chain/Render/Json/JsonOfTest.php
@@ -55,8 +55,7 @@ final class JsonOfTest extends TestCase
     {
         $this->expectException(TypeError::class);
 
-        $unknown = new class () implements Value {
-        };
+        $unknown = new class implements Value {};
 
         (new JsonOf($unknown))->renderer();
     }

--- a/tests/Unit/Chain/Render/Neon/NeonOfTest.php
+++ b/tests/Unit/Chain/Render/Neon/NeonOfTest.php
@@ -89,8 +89,7 @@ final class NeonOfTest extends TestCase
     {
         $this->expectException(TypeError::class);
 
-        $unknown = new class () implements Value {
-        };
+        $unknown = new class implements Value {};
 
         (new NeonOf($unknown))->renderer();
     }


### PR DESCRIPTION
- Updated php-cs-fixer Finder to scan php.src and php.tests
- Updated php-cs-fixer Finder to exclude php.exclude
- Removed php_cs_fixer.paths from Sheriff defaults
- Removed php_unit_data_provider_name rule to avoid forcing long provideXCases method names
- Disabled php_unit_strict pending tests rewrite tracked in #790

Closes #789

**Breaking changes:**
- \`php_cs_fixer.paths\` removed from defaults — use \`php.src\`, \`php.tests\` and \`php.exclude\` instead
- \`infra.exclude\` no longer affects php-cs-fixer scans; override \`php.exclude\` for PHP analysers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration reference for php-cs-fixer options.

* **Tests**
  * Improved assertion clarity in integration and unit tests.

* **Style**
  * Removed trailing commas in constructor declarations.
  * Updated code formatting for consistency.

* **Chores**
  * Updated php-cs-fixer configuration and rules.
  * Adjusted file inclusion paths for php-cs-fixer scanning.
  * Temporarily disabled a PHPUnit rule pending future migration updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->