### PR TITLE
Drop AfferentCoupling Excludes For Value Objects

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -24,14 +24,6 @@ append:
   phpstan.parameters:
     haspadar:
       afferentCoupling:
-        # Value-object classes excluded until afferentCoupling becomes path-aware
-        # so it ignores incoming references from tests/.
-        # Tracked in haspadar/phpstan-rules#230.
+        # Central exception type used across all layers by design.
         excludedClasses:
           - '\Haspadar\Sheriff\SheriffException'
-          - '\Haspadar\Sheriff\File\TextFile'
-          - '\Haspadar\Sheriff\Settings\Value\BoolValue'
-          - '\Haspadar\Sheriff\Settings\Value\IntValue'
-          - '\Haspadar\Sheriff\Settings\Value\ListValue'
-          - '\Haspadar\Sheriff\Settings\Value\StringValue'
-          - '\Haspadar\Sheriff\Settings\Value\TreeValue'

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -27,11 +27,5 @@ parameters:
             ignoreInterfaces: true
             excludedClasses:
                 - \Haspadar\Sheriff\SheriffException
-                - \Haspadar\Sheriff\File\TextFile
-                - \Haspadar\Sheriff\Settings\Value\BoolValue
-                - \Haspadar\Sheriff\Settings\Value\IntValue
-                - \Haspadar\Sheriff\Settings\Value\ListValue
-                - \Haspadar\Sheriff\Settings\Value\StringValue
-                - \Haspadar\Sheriff\Settings\Value\TreeValue
         prohibitStaticMethods:
             allowNamedConstructors: true

--- a/composer.lock
+++ b/composer.lock
@@ -1814,16 +1814,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.53.0",
+            "version": "v0.53.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "39ad4490ff4faae93b6fc941f7c5b2e800105faa"
+                "reference": "5d2447be9091dfe4a0a4c8a6ff8617cb7cbb4e19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/39ad4490ff4faae93b6fc941f7c5b2e800105faa",
-                "reference": "39ad4490ff4faae93b6fc941f7c5b2e800105faa",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/5d2447be9091dfe4a0a4c8a6ff8617cb7cbb4e19",
+                "reference": "5d2447be9091dfe4a0a4c8a6ff8617cb7cbb4e19",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.53.0"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.53.1"
             },
-            "time": "2026-05-23T07:31:36+00:00"
+            "time": "2026-05-24T22:08:58+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
- Updated haspadar/phpstan-rules to v0.53.1 with path-aware AfferentCoupling
- Removed value-object classes from afferentCoupling excludedClasses
- Kept SheriffException as the only intentional exclusion

Closes #792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined code analysis configuration by consolidating excluded class lists to essential items only, removing previously excluded value-object and file-related classes from analysis parameters. Simplified related configuration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->