### PR TITLE
PHPUnit Testsuites DSL Source Operator

### DIFF
--- a/src/Chain/Parse/FormulaTarget.php
+++ b/src/Chain/Parse/FormulaTarget.php
@@ -31,12 +31,8 @@ final readonly class FormulaTarget
      */
     public function formula(): Formula
     {
-        if ($this->name === 'EnabledTools') {
-            return new EnabledToolsFormula($this->args);
-        }
-
-        if ($this->name === 'JoinedLists') {
-            return new JoinedListsFormula($this->args);
+        if (in_array($this->name, ['EnabledTools', 'JoinedLists', 'PhpunitTestsuites'], true)) {
+            return $this->customFormula();
         }
 
         foreach ($this->candidates() as $candidate) {
@@ -55,6 +51,21 @@ final readonly class FormulaTarget
         }
 
         throw new InvalidArgumentException(sprintf('Unknown pipeline formula "%s"', $this->name));
+    }
+
+    /**
+     * Returns the dedicated formula for one of the special-cased names.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function customFormula(): Formula
+    {
+        return match ($this->name) {
+            'EnabledTools' => new EnabledToolsFormula($this->args),
+            'JoinedLists' => new JoinedListsFormula($this->args),
+            'PhpunitTestsuites' => new PhpunitTestsuitesFormula($this->args),
+            default => throw new InvalidArgumentException(sprintf('Unknown custom formula "%s"', $this->name)),
+        };
     }
 
     /**

--- a/src/Chain/Parse/FormulaTarget.php
+++ b/src/Chain/Parse/FormulaTarget.php
@@ -16,6 +16,8 @@ use InvalidArgumentException;
  */
 final readonly class FormulaTarget
 {
+    private const array CUSTOM_NAMES = ['EnabledTools', 'JoinedLists', 'PhpunitTestsuites'];
+
     /**
      * Initializes with a PascalCase formula name and its raw arguments.
      *
@@ -31,7 +33,7 @@ final readonly class FormulaTarget
      */
     public function formula(): Formula
     {
-        if (in_array($this->name, ['EnabledTools', 'JoinedLists', 'PhpunitTestsuites'], true)) {
+        if (in_array($this->name, self::CUSTOM_NAMES, true)) {
             return $this->customFormula();
         }
 
@@ -54,7 +56,7 @@ final readonly class FormulaTarget
     }
 
     /**
-     * Returns the dedicated formula for one of the special-cased names.
+     * Returns the dedicated formula for one of the CUSTOM_NAMES entries.
      *
      * @throws InvalidArgumentException
      */

--- a/src/Chain/Parse/PhpunitTestsuitesFormula.php
+++ b/src/Chain/Parse/PhpunitTestsuitesFormula.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Op;
+use Haspadar\Sheriff\Chain\Render\Xml\PhpunitTestsuites;
+use Haspadar\Sheriff\Settings\Settings;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+
+/**
+ * Builds the PhpunitTestsuites source op from two settings keys.
+ *
+ * Accepts the testsuites tree key first and the base directories list key
+ * second. Both keys are resolved against settings and the resolved Values
+ * are passed to the source op as-is.
+ *
+ * Example:
+ *
+ *     (new PhpunitTestsuitesFormula(['phpunit.testsuites', 'php.tests']))
+ *         ->op([], $settings);
+ */
+final readonly class PhpunitTestsuitesFormula implements Formula
+{
+    private const int EXPECTED_ARGS = 2;
+
+    /**
+     * Initializes with the raw template arguments — two settings keys.
+     *
+     * @param list<string> $args Raw template arguments; expects the testsuites tree key and the base directories list key
+     */
+    public function __construct(private array $args) {}
+
+    #[Override]
+    public function op(array $previous, Settings $settings): Op
+    {
+        if (count($this->args) !== self::EXPECTED_ARGS) {
+            throw new SheriffException(
+                sprintf(
+                    'PhpunitTestsuites expects the testsuites key and the base directories key, got %d arguments',
+                    count($this->args),
+                ),
+            );
+        }
+
+        $suites = $this->valueAt(0, $settings);
+        $baseDirs = $this->valueAt(1, $settings);
+
+        return new PhpunitTestsuites($suites, $baseDirs);
+    }
+
+    /**
+     * Reads the value bound to the argument at the given index.
+     *
+     * @throws SheriffException
+     */
+    private function valueAt(int $index, Settings $settings): Value
+    {
+        $key = $this->args[$index];
+
+        if (!$settings->has($key)) {
+            throw new SheriffException(
+                sprintf('PhpunitTestsuites cannot find settings key "%s"', $key),
+            );
+        }
+
+        return $settings->value($key);
+    }
+}

--- a/src/Chain/Render/Xml/PhpunitSuiteBlock.php
+++ b/src/Chain/Render/Xml/PhpunitSuiteBlock.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Xml;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Override;
+
+/**
+ * Renders one PHPUnit `<testsuite>` block with its directory entries.
+ *
+ * Example:
+ *
+ *     (new PhpunitSuiteBlock('unit', ['tests/Unit']))->rendered();
+ */
+final readonly class PhpunitSuiteBlock implements Rendered
+{
+    private const string INDENT = '        ';
+
+    private const string DIR_INDENT = '            ';
+
+    /**
+     * Initializes with the suite name and the directory paths it covers.
+     *
+     * @param string $name Value of the testsuite name attribute
+     * @param list<string> $paths Directory paths relative to the project root
+     */
+    public function __construct(private string $name, private array $paths) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        $lines = [sprintf('%s<testsuite name="%s">', self::INDENT, $this->name)];
+
+        foreach ($this->paths as $path) {
+            $lines[] = sprintf(
+                '%s<directory suffix="Test.php">../../%s</directory>',
+                self::DIR_INDENT,
+                $path,
+            );
+        }
+
+        $lines[] = sprintf('%s</testsuite>', self::INDENT);
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Chain/Render/Xml/PhpunitTestsuites.php
+++ b/src/Chain/Render/Xml/PhpunitTestsuites.php
@@ -41,6 +41,11 @@ final readonly class PhpunitTestsuites implements Rendered
     public function rendered(): string
     {
         $bases = $this->stringList($this->roots, 'base directories');
+
+        if ($bases === []) {
+            throw new SheriffException('PhpunitTestsuites requires at least one base directory');
+        }
+
         $entries = $this->entries();
 
         if ($entries === []) {

--- a/src/Chain/Render/Xml/PhpunitTestsuites.php
+++ b/src/Chain/Render/Xml/PhpunitTestsuites.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Chain\Render\Xml;
+
+use Haspadar\Sheriff\Chain\Rendered;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\Settings\Value\Value;
+use Haspadar\Sheriff\SheriffException;
+use Override;
+
+/**
+ * Renders PHPUnit testsuite blocks from a names-to-subdirs tree and base dirs.
+ *
+ * Each entry of the tree becomes one `<testsuite>` block whose name is the
+ * entry key. The directory list is the cartesian product of the base
+ * directories from `php.tests` and the subdirectories under that suite.
+ * An empty tree yields a single `default` suite covering every base directory.
+ *
+ * Example:
+ *
+ *     (new PhpunitTestsuites(
+ *         new TreeValue(['unit' => new ListValue([new StringValue('Unit')])]),
+ *         new ListValue([new StringValue('tests')]),
+ *     ))->rendered();
+ */
+final readonly class PhpunitTestsuites implements Rendered
+{
+    /**
+     * Initializes with the testsuites tree and the base directories list.
+     *
+     * @param Value $suites TreeValue of suite name to subdir list; empty ListValue accepted for YAML `{}`
+     * @param Value $roots ListValue of base directories (typically php.tests)
+     */
+    public function __construct(private Value $suites, private Value $roots) {}
+
+    #[Override]
+    public function rendered(): string
+    {
+        $bases = $this->stringList($this->roots, 'base directories');
+        $entries = $this->entries();
+
+        if ($entries === []) {
+            return (new PhpunitSuiteBlock('default', $bases))->rendered();
+        }
+
+        $blocks = [];
+
+        foreach ($entries as $name => $subdirs) {
+            $subs = $this->stringList($subdirs, sprintf('suite "%s"', $name));
+            $blocks[] = (new PhpunitSuiteBlock($name, $this->pairs($bases, $subs)))->rendered();
+        }
+
+        return implode("\n", $blocks);
+    }
+
+    /**
+     * Builds the cartesian product of base/subdir pairs.
+     *
+     * @param list<string> $bases
+     * @param list<string> $subs
+     * @return list<string>
+     */
+    private function pairs(array $bases, array $subs): array
+    {
+        $paths = [];
+
+        foreach ($bases as $base) {
+            $paths = array_merge(
+                $paths,
+                array_map(static fn(string $sub): string => sprintf('%s/%s', $base, $sub), $subs),
+            );
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Resolves the testsuites payload to its name-to-subdirs entries.
+     *
+     * @throws SheriffException
+     * @return array<string, Value>
+     */
+    private function entries(): array
+    {
+        if ($this->suites instanceof TreeValue) {
+            return $this->suites->entries;
+        }
+
+        if ($this->suites instanceof ListValue && $this->suites->children === []) {
+            return [];
+        }
+
+        throw new SheriffException(
+            sprintf('PhpunitTestsuites requires a TreeValue payload, got %s', get_debug_type($this->suites)),
+        );
+    }
+
+    /**
+     * Returns the list of strings under a ListValue payload.
+     *
+     * @throws SheriffException
+     * @return list<string>
+     */
+    private function stringList(Value $value, string $label): array
+    {
+        if (!$value instanceof ListValue) {
+            throw new SheriffException(
+                sprintf('PhpunitTestsuites expects %s to be a list, got %s', $label, $value::class),
+            );
+        }
+
+        $result = [];
+
+        foreach ($value->children as $child) {
+            if (!$child instanceof StringValue) {
+                throw new SheriffException(
+                    sprintf('PhpunitTestsuites expects %s to contain strings, got %s', $label, $child::class),
+                );
+            }
+
+            $result[] = $child->raw;
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Chain/Parse/PhpunitTestsuitesFormulaTest.php
+++ b/tests/Unit/Chain/Parse/PhpunitTestsuitesFormulaTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
 
 use Haspadar\Sheriff\Chain\Parse\PhpunitTestsuitesFormula;
-use Haspadar\Sheriff\Chain\Render\Xml\PhpunitTestsuites;
 use Haspadar\Sheriff\Settings\Value\ListValue;
 use Haspadar\Sheriff\Settings\Value\StringValue;
 use Haspadar\Sheriff\Settings\Value\TreeValue;
@@ -16,22 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 final class PhpunitTestsuitesFormulaTest extends TestCase
 {
-    #[Test]
-    public function buildsPhpunitTestsuitesOpFromTwoSettingsKeys(): void
-    {
-        self::assertInstanceOf(
-            PhpunitTestsuites::class,
-            (new PhpunitTestsuitesFormula(['phpunit.testsuites', 'php.tests']))
-                ->op([], new FakeSettings([
-                    'phpunit.testsuites' => new TreeValue([
-                        'unit' => new ListValue([new StringValue('Unit')]),
-                    ]),
-                    'php.tests' => new ListValue([new StringValue('tests')]),
-                ])),
-            'PhpunitTestsuitesFormula must produce a PhpunitTestsuites op from two resolved keys',
-        );
-    }
-
     #[Test]
     public function rendersConfiguredSuitesWhenBothKeysResolveToData(): void
     {

--- a/tests/Unit/Chain/Parse/PhpunitTestsuitesFormulaTest.php
+++ b/tests/Unit/Chain/Parse/PhpunitTestsuitesFormulaTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Parse;
+
+use Haspadar\Sheriff\Chain\Parse\PhpunitTestsuitesFormula;
+use Haspadar\Sheriff\Chain\Render\Xml\PhpunitTestsuites;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
+use Haspadar\Sheriff\Tests\Fake\Settings\FakeSettings;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PhpunitTestsuitesFormulaTest extends TestCase
+{
+    #[Test]
+    public function buildsPhpunitTestsuitesOpFromTwoSettingsKeys(): void
+    {
+        self::assertInstanceOf(
+            PhpunitTestsuites::class,
+            (new PhpunitTestsuitesFormula(['phpunit.testsuites', 'php.tests']))
+                ->op([], new FakeSettings([
+                    'phpunit.testsuites' => new TreeValue([
+                        'unit' => new ListValue([new StringValue('Unit')]),
+                    ]),
+                    'php.tests' => new ListValue([new StringValue('tests')]),
+                ])),
+            'PhpunitTestsuitesFormula must produce a PhpunitTestsuites op from two resolved keys',
+        );
+    }
+
+    #[Test]
+    public function rendersConfiguredSuitesWhenBothKeysResolveToData(): void
+    {
+        self::assertSame(
+            implode("\n", [
+                '        <testsuite name="unit">',
+                '            <directory suffix="Test.php">../../tests/Unit</directory>',
+                '        </testsuite>',
+            ]),
+            (new PhpunitTestsuitesFormula(['phpunit.testsuites', 'php.tests']))
+                ->op([], new FakeSettings([
+                    'phpunit.testsuites' => new TreeValue([
+                        'unit' => new ListValue([new StringValue('Unit')]),
+                    ]),
+                    'php.tests' => new ListValue([new StringValue('tests')]),
+                ]))
+                ->rendered(),
+            'PhpunitTestsuitesFormula must wire the resolved tree and base dirs into PhpunitTestsuites',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenArgumentCountWrong(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('got 1 arguments');
+
+        (new PhpunitTestsuitesFormula(['phpunit.testsuites']))
+            ->op([], new FakeSettings([]));
+    }
+
+    #[Test]
+    public function throwsWhenTestsuitesKeyAbsent(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('cannot find settings key "phpunit.testsuites"');
+
+        (new PhpunitTestsuitesFormula(['phpunit.testsuites', 'php.tests']))
+            ->op([], new FakeSettings([
+                'php.tests' => new ListValue([new StringValue('tests')]),
+            ]));
+    }
+
+    #[Test]
+    public function throwsWhenBaseDirsKeyAbsent(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('cannot find settings key "php.tests"');
+
+        (new PhpunitTestsuitesFormula(['phpunit.testsuites', 'php.tests']))
+            ->op([], new FakeSettings([
+                'phpunit.testsuites' => new TreeValue([]),
+            ]));
+    }
+}

--- a/tests/Unit/Chain/Render/Xml/PhpunitTestsuitesTest.php
+++ b/tests/Unit/Chain/Render/Xml/PhpunitTestsuitesTest.php
@@ -132,6 +132,18 @@ final class PhpunitTestsuitesTest extends TestCase
     }
 
     #[Test]
+    public function throwsWhenBaseDirectoryListIsEmpty(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('requires at least one base directory');
+
+        (new PhpunitTestsuites(
+            new TreeValue(['unit' => new ListValue([new StringValue('Unit')])]),
+            new ListValue([]),
+        ))->rendered();
+    }
+
+    #[Test]
     public function throwsWhenSuitesPayloadIsNeitherTreeNorEmptyList(): void
     {
         $this->expectException(SheriffException::class);

--- a/tests/Unit/Chain/Render/Xml/PhpunitTestsuitesTest.php
+++ b/tests/Unit/Chain/Render/Xml/PhpunitTestsuitesTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\Sheriff\Tests\Unit\Chain\Render\Xml;
+
+use Haspadar\Sheriff\Chain\Render\Xml\PhpunitTestsuites;
+use Haspadar\Sheriff\Settings\Value\IntValue;
+use Haspadar\Sheriff\Settings\Value\ListValue;
+use Haspadar\Sheriff\Settings\Value\StringValue;
+use Haspadar\Sheriff\Settings\Value\TreeValue;
+use Haspadar\Sheriff\SheriffException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PhpunitTestsuitesTest extends TestCase
+{
+    #[Test]
+    public function rendersOneSuitePerEntryWithSubdirsAppended(): void
+    {
+        self::assertSame(
+            implode("\n", [
+                '        <testsuite name="unit">',
+                '            <directory suffix="Test.php">../../tests/Unit</directory>',
+                '        </testsuite>',
+                '        <testsuite name="integration">',
+                '            <directory suffix="Test.php">../../tests/Integration</directory>',
+                '        </testsuite>',
+            ]),
+            (new PhpunitTestsuites(
+                new TreeValue([
+                    'unit' => new ListValue([new StringValue('Unit')]),
+                    'integration' => new ListValue([new StringValue('Integration')]),
+                ]),
+                new ListValue([new StringValue('tests')]),
+            ))->rendered(),
+            'PhpunitTestsuites must render one suite per tree entry with directories under php.tests',
+        );
+    }
+
+    #[Test]
+    public function expandsSubdirsAcrossMultipleBaseDirectories(): void
+    {
+        self::assertSame(
+            implode("\n", [
+                '        <testsuite name="unit">',
+                '            <directory suffix="Test.php">../../tests/Unit</directory>',
+                '            <directory suffix="Test.php">../../spec/Unit</directory>',
+                '        </testsuite>',
+            ]),
+            (new PhpunitTestsuites(
+                new TreeValue(['unit' => new ListValue([new StringValue('Unit')])]),
+                new ListValue([new StringValue('tests'), new StringValue('spec')]),
+            ))->rendered(),
+            'PhpunitTestsuites must emit one directory per base/subdir pair',
+        );
+    }
+
+    #[Test]
+    public function emitsMultipleDirectoriesWhenSubdirsListHasManyEntries(): void
+    {
+        self::assertSame(
+            implode("\n", [
+                '        <testsuite name="feature">',
+                '            <directory suffix="Test.php">../../tests/Feature</directory>',
+                '            <directory suffix="Test.php">../../tests/Acceptance</directory>',
+                '        </testsuite>',
+            ]),
+            (new PhpunitTestsuites(
+                new TreeValue([
+                    'feature' => new ListValue([
+                        new StringValue('Feature'),
+                        new StringValue('Acceptance'),
+                    ]),
+                ]),
+                new ListValue([new StringValue('tests')]),
+            ))->rendered(),
+            'PhpunitTestsuites must list every subdir under the same suite block',
+        );
+    }
+
+    #[Test]
+    public function fallsBackToSingleDefaultSuiteWhenTreeIsEmpty(): void
+    {
+        self::assertSame(
+            implode("\n", [
+                '        <testsuite name="default">',
+                '            <directory suffix="Test.php">../../tests</directory>',
+                '        </testsuite>',
+            ]),
+            (new PhpunitTestsuites(
+                new TreeValue([]),
+                new ListValue([new StringValue('tests')]),
+            ))->rendered(),
+            'PhpunitTestsuites must render a single default suite over the base directories when the tree is empty',
+        );
+    }
+
+    #[Test]
+    public function acceptsEmptyListBaseAsEmptyTree(): void
+    {
+        self::assertSame(
+            implode("\n", [
+                '        <testsuite name="default">',
+                '            <directory suffix="Test.php">../../tests</directory>',
+                '        </testsuite>',
+            ]),
+            (new PhpunitTestsuites(
+                new ListValue([]),
+                new ListValue([new StringValue('tests')]),
+            ))->rendered(),
+            'PhpunitTestsuites must treat an empty ListValue as an empty tree because YAML `{}` parses as `[]`',
+        );
+    }
+
+    #[Test]
+    public function fallsBackToDefaultSuiteAcrossEveryBaseDirectory(): void
+    {
+        self::assertSame(
+            implode("\n", [
+                '        <testsuite name="default">',
+                '            <directory suffix="Test.php">../../tests</directory>',
+                '            <directory suffix="Test.php">../../spec</directory>',
+                '        </testsuite>',
+            ]),
+            (new PhpunitTestsuites(
+                new TreeValue([]),
+                new ListValue([new StringValue('tests'), new StringValue('spec')]),
+            ))->rendered(),
+            'PhpunitTestsuites must include every base directory in the default suite',
+        );
+    }
+
+    #[Test]
+    public function throwsWhenSuitesPayloadIsNeitherTreeNorEmptyList(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('requires a TreeValue payload');
+
+        (new PhpunitTestsuites(
+            new StringValue('oops'),
+            new ListValue([new StringValue('tests')]),
+        ))->rendered();
+    }
+
+    #[Test]
+    public function throwsWhenBaseDirectoriesAreNotAList(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('expects base directories to be a list');
+
+        (new PhpunitTestsuites(
+            new TreeValue([]),
+            new StringValue('tests'),
+        ))->rendered();
+    }
+
+    #[Test]
+    public function throwsWhenBaseDirectoryEntryIsNotAString(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('base directories to contain strings');
+
+        (new PhpunitTestsuites(
+            new TreeValue(['unit' => new ListValue([new StringValue('Unit')])]),
+            new ListValue([new IntValue(42)]),
+        ))->rendered();
+    }
+
+    #[Test]
+    public function throwsWhenSuiteSubdirsAreNotAList(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('suite "unit" to be a list');
+
+        (new PhpunitTestsuites(
+            new TreeValue(['unit' => new StringValue('Unit')]),
+            new ListValue([new StringValue('tests')]),
+        ))->rendered();
+    }
+
+    #[Test]
+    public function throwsWhenSuiteSubdirEntryIsNotAString(): void
+    {
+        $this->expectException(SheriffException::class);
+        $this->expectExceptionMessage('suite "unit" to contain strings');
+
+        (new PhpunitTestsuites(
+            new TreeValue(['unit' => new ListValue([new IntValue(42)])]),
+            new ListValue([new StringValue('tests')]),
+        ))->rendered();
+    }
+}


### PR DESCRIPTION
- Added PhpunitTestsuites op rendering one testsuite block per tree entry
- Added PhpunitSuiteBlock helper rendering one testsuite block
- Added PhpunitTestsuitesFormula resolving two settings keys at template parse
- Refactored FormulaTarget to keep custom formula names in a single constant

Part of #794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PHPUnit test suite configuration and automated XML rendering with support for customizable suite names and organized directory structures.
  * Enhanced configuration routing to support expanded template patterns.

* **Tests**
  * Comprehensive test coverage added for test suite configuration and XML rendering functionality, including input validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->