### PR TITLE
Drive PHPUnit Testsuites From the Testsuites Config Map

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -17,6 +17,9 @@ override:
     - "../../bin/sheriff-fix"
     - "../../bin/sheriff-sync"
     - "../../bin/sheriff-tokens-check"
+  phpunit.testsuites:
+    unit: ["Unit"]
+    integration: ["Integration"]
 
 append:
   infra.exclude:

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -116,9 +116,8 @@ defaults:
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
-  # phpunit.testsuites.* values are subdirectories of php.tests, not full paths
-  phpunit.testsuites.unit: ["Unit"]
-  phpunit.testsuites.integration: ["Integration"]
+  # phpunit.testsuites maps suite name to subdirs under php.tests; empty renders a single default suite
+  phpunit.testsuites: {}
 
   psalm.cli: true
   psalm.error_level: 1

--- a/.sheriff/phpunit/phpunit.xml
+++ b/.sheriff/phpunit/phpunit.xml
@@ -13,7 +13,6 @@
         <testsuite name="unit">
             <directory suffix="Test.php">../../tests/Unit</directory>
         </testsuite>
-
         <testsuite name="integration">
             <directory suffix="Test.php">../../tests/Integration</directory>
         </testsuite>

--- a/DEV.md
+++ b/DEV.md
@@ -147,11 +147,11 @@ Example:
 
 List formatting:
 
-`{% ListText(phpunit.testsuites.unit)|EachFormatted("            <directory>%s</directory>")|Joined("\n") %}`
+`{% ListText(php.tests)|EachFormatted("            <directory>%s</directory>")|Joined("\n") %}`
 
 Path joining across configuration keys:
 
-`{% JoinedLists(php.tests, phpunit.testsuites.unit, "/")|EachFormatted("            <directory>%s</directory>")|Joined("\n") %}`
+`{% JoinedLists(php.src, php.tests, "/")|EachFormatted("            <directory>%s</directory>")|Joined("\n") %}`
 
 Per-item rewriting before formatting:
 
@@ -555,8 +555,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `phpunit.cli` | `true` | Enable PHPUnit |
 | `phpunit.php_options` | `"-d memory_limit=1G"` | PHP CLI options |
 | `phpunit.source.include` | `["../../src"]` | Source directories for coverage |
-| `phpunit.testsuites.unit` | `["../../tests/Unit"]` | Unit test directories |
-| `phpunit.testsuites.integration` | `["../../tests/Integration"]` | Integration test directories |
+| `phpunit.testsuites` | `{}` | Map from suite name to subdirs under `php.tests`; empty renders a single `default` suite |
 
 ### psalm
 

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -116,9 +116,8 @@ defaults:
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
-  # phpunit.testsuites.* values are subdirectories of php.tests, not full paths
-  phpunit.testsuites.unit: ["Unit"]
-  phpunit.testsuites.integration: ["Integration"]
+  # phpunit.testsuites maps suite name to subdirs under php.tests; empty renders a single default suite
+  phpunit.testsuites: {}
 
   psalm.cli: true
   psalm.error_level: 1

--- a/templates/always/.sheriff/phpunit/phpunit.xml
+++ b/templates/always/.sheriff/phpunit/phpunit.xml
@@ -10,13 +10,7 @@
         beStrictAboutCoverageMetadata="false"
 >
     <testsuites>
-        <testsuite name="unit">
-{% JoinedLists(php.tests, phpunit.testsuites.unit, "/")|EachFormatted("../../%s")|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
-        </testsuite>
-
-        <testsuite name="integration">
-{% JoinedLists(php.tests, phpunit.testsuites.integration, "/")|EachFormatted("../../%s")|EachFormatted('            <directory suffix="Test.php">%s</directory>')|Joined("\n") %}
-        </testsuite>
+{% PhpunitTestsuites(phpunit.testsuites, php.tests) %}
     </testsuites>
 
     <source>


### PR DESCRIPTION
- Updated phpunit.xml template to read suites through PhpunitTestsuites
- Removed flat phpunit.testsuites.unit and .integration defaults
- Added an empty phpunit.testsuites tree as the new default
- Updated DEV.md to describe the new key shape

Closes #794

**Breaking changes:**

The flat keys \`phpunit.testsuites.unit\` and \`phpunit.testsuites.integration\` are gone. Consumer projects that override them via \`.sheriff.yaml\` need to switch to the nested form:

\`\`\`yaml
# before
override:
  phpunit.testsuites.unit: ["Unit"]
  phpunit.testsuites.integration: ["Integration"]
# after
override:
  phpunit.testsuites:
    unit: ["Unit"]
    integration: ["Integration"]
\`\`\`

Projects that did not override these keys now get a single \`default\` suite covering every directory listed in \`php.tests\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHPUnit test suite configuration structure from predefined unit and integration suites to a dynamic configuration approach.

* **Documentation**
  * Updated documentation examples to reflect the new test suite configuration format and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/sheriff/pull/797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->