### PR TITLE
Valid Renovate Preset List

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  "extends": ["config:recommended", ":disablePreReleases"],
+  "extends": ["config:recommended"],
 
   "schedule": ["* 1-4 * * *"],
   "timezone": "UTC",


### PR DESCRIPTION
- Removed the nonexistent `:disablePreReleases` preset that broke Renovate config validation

Closes #780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to allow pre-release versions in dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->