### PR TITLE
Configurable Codecov Upload Failure Handling

### DIFF
--- a/.github/workflows/sheriff.yml
+++ b/.github/workflows/sheriff.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .sheriff/codecov/coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       # ------------------------------------------------------------
       # Infection (if config exists)

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -32,6 +32,7 @@ defaults:
 
   codecov.cloud: true
   codecov.cli: false
+  codecov.fail_ci_if_error: false
 
   coderabbit.cloud: true
   coderabbit.cli: false

--- a/DEV.md
+++ b/DEV.md
@@ -422,6 +422,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 |-----|---------|-------------|
 | `codecov.cloud` | `true` | Upload coverage to Codecov in CI |
 | `codecov.cli` | `false` | Enable codecov-cli locally |
+| `codecov.fail_ci_if_error` | `false` | Fail the CI job when the Codecov upload step errors |
 
 ### coderabbit
 

--- a/templates/always/.github/workflows/sheriff.yml
+++ b/templates/always/.github/workflows/sheriff.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .sheriff/codecov/coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: {% BoolText(codecov.fail_ci_if_error) %}
 
       # ------------------------------------------------------------
       # Infection (if config exists)

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -32,6 +32,7 @@ defaults:
 
   codecov.cloud: true
   codecov.cli: false
+  codecov.fail_ci_if_error: false
 
   coderabbit.cloud: true
   coderabbit.cli: false


### PR DESCRIPTION
- Added `codecov.fail_ci_if_error` config key defaulting to non-fatal Codecov uploads
- Updated the CI workflow template to drive the Codecov step from the new key
- Updated DEV.md config reference

Closes #801