### PR TITLE
Opt-In Psalm UnusedClass Suppression

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -17,6 +17,8 @@ override:
     - "../../bin/sheriff-fix"
     - "../../bin/sheriff-sync"
     - "../../bin/sheriff-tokens-check"
+  psalm.suppress.unused_class:
+    - "../../src"
   phpunit.testsuites:
     unit: ["Unit"]
     integration: ["Integration"]

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -124,6 +124,7 @@ defaults:
   psalm.project.files: []
   psalm.project.ignore: []
   psalm.suppress.possibly_unused: []
+  psalm.suppress.unused_class: []
 
   infection.cli: true
   infection.min_msi: 50.0

--- a/DEV.md
+++ b/DEV.md
@@ -567,6 +567,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 | `psalm.project.files` | `[]` | Individual files to analyze |
 | `psalm.project.ignore` | `["../../vendor", "../../tests", "../../.git"]` | Ignored directories |
 | `psalm.suppress.possibly_unused` | `[]` | Directories to suppress PossiblyUnusedMethod (e.g. `["../../src"]` for DI-constructed classes) |
+| `psalm.suppress.unused_class` | `[]` | Directories to suppress UnusedClass (e.g. `["../../src"]` for public API classes) |
 
 ### infection
 

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -124,6 +124,7 @@ defaults:
   psalm.project.files: []
   psalm.project.ignore: []
   psalm.suppress.possibly_unused: []
+  psalm.suppress.unused_class: []
 
   infection.cli: true
   infection.min_msi: 50.0

--- a/templates/always/.sheriff/psalm/psalm.xml
+++ b/templates/always/.sheriff/psalm/psalm.xml
@@ -19,11 +19,7 @@
     </plugins>
     <issueHandlers>
         <InvalidAttribute errorLevel="suppress" />
-        <UnusedClass errorLevel="suppress">
-            <errorLevel type="suppress">
-{% ListText(php.src)|EachFormatted("../../%s")|EachFormatted('                <directory name="%s" />')|Joined("\n") %}
-            </errorLevel>
-        </UnusedClass>
+{% ListText(psalm.suppress.unused_class)|EachFormatted('                <directory name="%s" />')|Joined("\n")|WhenNotEmpty("        <UnusedClass errorLevel=\"suppress\">\n            <errorLevel type=\"suppress\">\n%s\n            </errorLevel>\n        </UnusedClass>") %}
 {% ListText(psalm.suppress.possibly_unused)|EachFormatted('                <directory name="%s" />')|Joined("\n")|WhenNotEmpty("        <PossiblyUnusedMethod errorLevel=\"suppress\">\n            <errorLevel type=\"suppress\">\n%s\n            </errorLevel>\n        </PossiblyUnusedMethod>") %}
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
- Refactored the Psalm template to render `UnusedClass` suppression only when configured
- Added the `psalm.suppress.unused_class` config key defaulting to empty
- Added this repository's own suppression override for its source directory
- Updated DEV.md config reference

Closes #803

**Breaking changes:**
- `UnusedClass` is no longer suppressed for source directories by default; after `sheriff sync`, libraries with public classes may see new `UnusedClass` errors
- To restore prior behaviour, set `psalm.suppress.unused_class: ["../../src"]` in `.sheriff.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Psalm suppression configuration for unused class checks across configuration files and templates.
  * Updated default configuration settings to include new Psalm suppression option.

* **Documentation**
  * Added documentation for the new Psalm configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->