### PR TITLE
Codecov CLI From PyPI

### DIFF
--- a/.github/workflows/sheriff.yml
+++ b/.github/workflows/sheriff.yml
@@ -118,6 +118,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .sheriff/codecov/coverage.xml
           fail_ci_if_error: true
+          use_pypi: true
 
       # ------------------------------------------------------------
       # Infection (if config exists)

--- a/templates/always/.github/workflows/sheriff.yml
+++ b/templates/always/.github/workflows/sheriff.yml
@@ -110,6 +110,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .sheriff/codecov/coverage.xml
           fail_ci_if_error: true
+          use_pypi: true
 
       # ------------------------------------------------------------
       # Infection (if config exists)


### PR DESCRIPTION
- Added `use_pypi: true` to the Codecov step so the CLI installs from PyPI instead of the broken signature endpoint

Closes #801