### PR TITLE
Trait Use Spacing Aligned With php-cs-fixer

### DIFF
--- a/.sheriff/phpcs/slevomat-classes.xml
+++ b/.sheriff/phpcs/slevomat-classes.xml
@@ -52,7 +52,12 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseOrder"/>
-    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
+        <properties>
+            <property name="linesCountBeforeFirstUseWhenFirstInClass" value="0"/>
+            <property name="linesCountAfterLastUseWhenLastInClass" value="0"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
 
     <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>

--- a/templates/always/.sheriff/phpcs/slevomat-classes.xml
+++ b/templates/always/.sheriff/phpcs/slevomat-classes.xml
@@ -52,7 +52,12 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseOrder"/>
-    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
+        <properties>
+            <property name="linesCountBeforeFirstUseWhenFirstInClass" value="0"/>
+            <property name="linesCountAfterLastUseWhenLastInClass" value="0"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
 
     <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>


### PR DESCRIPTION
- Updated the phpcs trait-use spacing rule to allow zero blank lines around a class's only trait use

Closes #811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP CodeSniffer configuration to enforce explicit spacing rules for trait declarations in classes. The ruleset now requires zero blank lines before the first trait use and zero blank lines after the last trait use within class definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->