### PR TITLE
Project Word Whitelist For Typos

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -148,6 +148,7 @@ defaults:
 
   typos.cli: true
   typos.exclude: ["vendor/", "tests/", ".git/"]
+  typos.extend_words: []
 
   yamllint.cli: true
   yamllint.ignore: ["vendor/**", "tests/**", ".git/**", ".sheriff/**/html/**", ".sheriff/**/coverage-report/**"]

--- a/.sheriff/typos/_typos.toml
+++ b/.sheriff/typos/_typos.toml
@@ -4,6 +4,7 @@
 [default]
 binary = false
 
+
 [files]
 extend-exclude = [
     "vendor/",

--- a/DEV.md
+++ b/DEV.md
@@ -608,6 +608,7 @@ All keys below are declared in `templates/always/.sheriff/config.yaml` with thei
 |-----|---------|-------------|
 | `typos.cli` | `true` | Enable typo checking |
 | `typos.exclude` | `["vendor/", "tests/", ".git/"]` | Excluded directories |
+| `typos.extend_words` | `[]` | Words treated as correct (e.g. `["galya"]`) |
 
 ### yamllint
 

--- a/templates/always/.sheriff/config.yaml
+++ b/templates/always/.sheriff/config.yaml
@@ -148,6 +148,7 @@ defaults:
 
   typos.cli: true
   typos.exclude: ["vendor/", "tests/", ".git/"]
+  typos.extend_words: []
 
   yamllint.cli: true
   yamllint.ignore: ["vendor/**", "tests/**", ".git/**", ".sheriff/**/html/**", ".sheriff/**/coverage-report/**"]

--- a/templates/always/.sheriff/typos/_typos.toml
+++ b/templates/always/.sheriff/typos/_typos.toml
@@ -3,6 +3,7 @@
 
 [default]
 binary = false
+{% ListText(typos.extend_words)|EachFormatted('%1$s = "%1$s"')|Joined("\n")|WhenNotEmpty("\n[default.extend-words]\n%s") %}
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
- Added the `typos.extend_words` config key that renders a `[default.extend-words]` section so listed words pass the typos check
- Updated DEV.md config reference

Closes #813