### PR TITLE
Accurate Exclude-Key Tool Mapping In README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ vendor/bin/sheriff check
 
 Customization is optional. If needed, create `.sheriff.yaml` in the project root.
 
-Three settings cascade across every tool that consumes them:
+Four settings cascade across every tool that consumes them:
 
 - `php.src` — paths analysed by PHPStan, Psalm, PHPUnit, PHPMD, PHP_CodeSniffer, PHP Metrics, Infection, SonarCloud
-- `infra.exclude` — paths skipped by PHP_CodeSniffer, PHP-CS-Fixer, PHP Metrics, markdownlint, jsonlint, yamllint, typos, hadolint, shellcheck
+- `php.exclude` — paths skipped by PHP_CodeSniffer and PHP-CS-Fixer
+- `infra.exclude` — paths skipped by PHP Metrics, markdownlint, jsonlint, yamllint, typos, hadolint, shellcheck
 - `php.versions` — versions used in the CI matrix and consumed by PHPStan, PHP-CS-Fixer, PHPMD, Infection
 
 Change one key, every consuming tool follows.


### PR DESCRIPTION
- Documented `php.exclude` as the key honoured by PHP_CodeSniffer and PHP-CS-Fixer
- Removed those two tools from the `infra.exclude` description

Closes #815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how configuration settings cascade across different tools and linters, specifying which paths are excluded by PHP_CodeSniffer, PHP-CS-Fixer, PHP Metrics, and other analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->